### PR TITLE
.NET: Align WorkflowOutputEvent streaming deserialization with SourceId to ExecutorId rename

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI.DurableTask/CHANGELOG.md
+++ b/dotnet/src/Microsoft.Agents.AI.DurableTask/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Fixed `WorkflowOutputEvent` streaming deserialization to read `executorId` instead of the renamed `sourceId` property, with fallback for backward compatibility.
 - Fix issue with resuming checkpoint after package version upgrade ([#6670](https://github.com/microsoft/agent-framework/pull/6670))
 - Bind MCP threadId to the current agent and guard cross-agent session dispatch ([#6531](https://github.com/microsoft/agent-framework/pull/6531))
 - Added support for durable workflows ([#4436](https://github.com/microsoft/agent-framework/pull/4436))

--- a/dotnet/src/Microsoft.Agents.AI.DurableTask/CHANGELOG.md
+++ b/dotnet/src/Microsoft.Agents.AI.DurableTask/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-- Fixed `WorkflowOutputEvent` streaming deserialization to read `executorId` instead of the renamed `sourceId` property, with fallback for backward compatibility.
+- Fixed `WorkflowOutputEvent` streaming deserialization to read `executorId` instead of the renamed `sourceId` property, with fallback for backward compatibility ([#6896](https://github.com/microsoft/agent-framework/pull/6896))
 - Fix issue with resuming checkpoint after package version upgrade ([#6670](https://github.com/microsoft/agent-framework/pull/6670))
 - Bind MCP threadId to the current agent and guard cross-agent session dispatch ([#6531](https://github.com/microsoft/agent-framework/pull/6531))
 - Added support for durable workflows ([#4436](https://github.com/microsoft/agent-framework/pull/4436))

--- a/dotnet/src/Microsoft.Agents.AI.DurableTask/Workflows/DurableStreamingWorkflowRun.cs
+++ b/dotnet/src/Microsoft.Agents.AI.DurableTask/Workflows/DurableStreamingWorkflowRun.cs
@@ -429,7 +429,7 @@ internal sealed class DurableStreamingWorkflowRun : IStreamingWorkflowRun
                 ? execIdElem.GetString() ?? string.Empty
                 : root.TryGetProperty("sourceId", out JsonElement srcIdElem)
                     ? srcIdElem.GetString() ?? string.Empty
-                    : string.Empty;
+                    : throw new JsonException("WorkflowOutputEvent is missing required 'executorId' (or legacy 'sourceId') property.");
             object? outputData = GetDataProperty(root);
             return new WorkflowOutputEvent(outputData!, outputExecutorId);
         }

--- a/dotnet/src/Microsoft.Agents.AI.DurableTask/Workflows/DurableStreamingWorkflowRun.cs
+++ b/dotnet/src/Microsoft.Agents.AI.DurableTask/Workflows/DurableStreamingWorkflowRun.cs
@@ -425,9 +425,9 @@ internal sealed class DurableStreamingWorkflowRun : IStreamingWorkflowRun
             }
 
             // WorkflowOutputEvent
-            string sourceId = root.GetProperty("sourceId").GetString() ?? string.Empty;
+            string outputExecutorId = root.GetProperty("executorId").GetString() ?? string.Empty;
             object? outputData = GetDataProperty(root);
-            return new WorkflowOutputEvent(outputData!, sourceId);
+            return new WorkflowOutputEvent(outputData!, outputExecutorId);
         }
 
         return JsonSerializer.Deserialize(json, eventType, DurableSerialization.Options) as WorkflowEvent;

--- a/dotnet/src/Microsoft.Agents.AI.DurableTask/Workflows/DurableStreamingWorkflowRun.cs
+++ b/dotnet/src/Microsoft.Agents.AI.DurableTask/Workflows/DurableStreamingWorkflowRun.cs
@@ -425,7 +425,11 @@ internal sealed class DurableStreamingWorkflowRun : IStreamingWorkflowRun
             }
 
             // WorkflowOutputEvent
-            string outputExecutorId = root.GetProperty("executorId").GetString() ?? string.Empty;
+            string outputExecutorId = root.TryGetProperty("executorId", out JsonElement execIdElem)
+                ? execIdElem.GetString() ?? string.Empty
+                : root.TryGetProperty("sourceId", out JsonElement srcIdElem)
+                    ? srcIdElem.GetString() ?? string.Empty
+                    : string.Empty;
             object? outputData = GetDataProperty(root);
             return new WorkflowOutputEvent(outputData!, outputExecutorId);
         }

--- a/dotnet/tests/Microsoft.Agents.AI.DurableTask.UnitTests/Workflows/DurableStreamingWorkflowRunTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.DurableTask.UnitTests/Workflows/DurableStreamingWorkflowRunTests.cs
@@ -263,6 +263,37 @@ public sealed class DurableStreamingWorkflowRunTests
     }
 
     [Fact]
+    public async Task WatchStreamAsync_WorkflowOutputEvent_LegacySourceId_RoundTripsCorrectlyAsync()
+    {
+        // Arrange — simulate a legacy payload that uses "sourceId" instead of "executorId"
+        const string legacyEventJson = """{"sourceId":"legacy-executor","data":"legacy-data"}""";
+        string typeName = typeof(WorkflowOutputEvent).AssemblyQualifiedName!;
+        string serializedEvent = JsonSerializer.Serialize(
+            new { typeName, data = legacyEventJson },
+            DurableSerialization.Options);
+        string serializedOutput = SerializeWorkflowResult("done", [serializedEvent]);
+
+        Mock<DurableTaskClient> mockClient = new("test");
+        mockClient.Setup(c => c.GetInstanceAsync(InstanceId, true, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CreateMetadata(OrchestrationRuntimeStatus.Completed, serializedOutput: serializedOutput));
+
+        DurableStreamingWorkflowRun run = new(mockClient.Object, InstanceId, CreateTestWorkflow());
+
+        // Act
+        List<WorkflowEvent> events = [];
+        await foreach (WorkflowEvent evt in run.WatchStreamAsync())
+        {
+            events.Add(evt);
+        }
+
+        // Assert
+        Assert.Equal(2, events.Count);
+        WorkflowOutputEvent result = Assert.IsType<WorkflowOutputEvent>(events[0]);
+        Assert.Equal("legacy-executor", result.ExecutorId);
+        Assert.Equal("legacy-data", result.Data?.ToString());
+    }
+
+    [Fact]
     public async Task WatchStreamAsync_CompletedWithoutWrapper_YieldsFailedEventAsync()
     {
         // Arrange — output not wrapped in DurableWorkflowResult (indicates a bug)

--- a/dotnet/tests/Microsoft.Agents.AI.DurableTask.UnitTests/Workflows/DurableStreamingWorkflowRunTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.DurableTask.UnitTests/Workflows/DurableStreamingWorkflowRunTests.cs
@@ -266,10 +266,10 @@ public sealed class DurableStreamingWorkflowRunTests
     public async Task WatchStreamAsync_WorkflowOutputEvent_LegacySourceId_RoundTripsCorrectlyAsync()
     {
         // Arrange — simulate a legacy payload that uses "sourceId" instead of "executorId"
-        const string legacyEventJson = """{"sourceId":"legacy-executor","data":"legacy-data"}""";
+        const string LegacyEventJson = """{"sourceId":"legacy-executor","data":"legacy-data"}""";
         string typeName = typeof(WorkflowOutputEvent).AssemblyQualifiedName!;
         string serializedEvent = JsonSerializer.Serialize(
-            new { typeName, data = legacyEventJson },
+            new { typeName, data = LegacyEventJson },
             DurableSerialization.Options);
         string serializedOutput = SerializeWorkflowResult("done", [serializedEvent]);
 

--- a/dotnet/tests/Microsoft.Agents.AI.DurableTask.UnitTests/Workflows/DurableStreamingWorkflowRunTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.DurableTask.UnitTests/Workflows/DurableStreamingWorkflowRunTests.cs
@@ -234,6 +234,35 @@ public sealed class DurableStreamingWorkflowRunTests
     }
 
     [Fact]
+    public async Task WatchStreamAsync_WorkflowOutputEvent_RoundTripsCorrectlyAsync()
+    {
+        // Arrange
+        WorkflowOutputEvent outputEvent = new("test-data", "executor-1");
+        string serializedEvent = SerializeEvent(outputEvent);
+        string serializedOutput = SerializeWorkflowResult("done", [serializedEvent]);
+
+        Mock<DurableTaskClient> mockClient = new("test");
+        mockClient.Setup(c => c.GetInstanceAsync(InstanceId, true, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CreateMetadata(OrchestrationRuntimeStatus.Completed, serializedOutput: serializedOutput));
+
+        DurableStreamingWorkflowRun run = new(mockClient.Object, InstanceId, CreateTestWorkflow());
+
+        // Act
+        List<WorkflowEvent> events = [];
+        await foreach (WorkflowEvent evt in run.WatchStreamAsync())
+        {
+            events.Add(evt);
+        }
+
+        // Assert
+        Assert.Equal(2, events.Count);
+        WorkflowOutputEvent result = Assert.IsType<WorkflowOutputEvent>(events[0]);
+        Assert.Equal("executor-1", result.ExecutorId);
+        Assert.Equal("test-data", result.Data?.ToString());
+        Assert.Empty(result.Tags);
+    }
+
+    [Fact]
     public async Task WatchStreamAsync_CompletedWithoutWrapper_YieldsFailedEventAsync()
     {
         // Arrange — output not wrapped in DurableWorkflowResult (indicates a bug)


### PR DESCRIPTION
### Motivation & Context

Cherry-picked commits from [microsoft/agent-framework#6896](https://github.com/microsoft/agent-framework/pull/6896) into this new standalone durable extension repo, since the PR was opened before the code was moved here.

> **Note:** This cherry-pick was performed by GitHub Copilot (GHCP).

PR #3441 in the original repo renamed `WorkflowOutputEvent.SourceId` to `ExecutorId` (keeping `SourceId` as an `[Obsolete]` + `[JsonIgnore]` alias), but the manual streaming deserialization in `DeserializeEventByType` was not updated. It still called `root.GetProperty("sourceId")`, which throws a `KeyNotFoundException` at runtime because the serialized JSON contains `"executorId"`.

This causes `WatchStreamAsync` to crash with an unhandled exception whenever the stream includes a `WorkflowOutputEvent` (e.g., when an executor calls `YieldOutputAsync`).

### Cherry-picked commits

1. **Fix WorkflowOutputEvent streaming deserialization** — read `"executorId"` instead of `"sourceId"` from the JSON payload
2. **Add WorkflowOutputEvent streaming round-trip test** — covers the serialize-deserialize path through `DeserializeEventByType`
3. **TryGetProperty fallback** — use `TryGetProperty` with `sourceId` fallback for backward compatibility with older persisted streams
4. **Legacy sourceId test** — test covering the fallback path for legacy `sourceId` payloads
5. **PascalCase const naming** — fix `legacyEventJson` → `LegacyEventJson` for IDE1006
6. **Throw JsonException when neither key is present** — consistent with caller's existing catch handler for malformed payloads

### Build Verification

✅ Solution builds with 0 errors, 0 warnings.