### PR TITLE
Add code mirroring

### DIFF
--- a/eng/ci/code-mirror.yml
+++ b/eng/ci/code-mirror.yml
@@ -1,0 +1,22 @@
+trigger:
+  branches:
+    include:
+    # Keep this set limited as appropriate (don't mirror individual user branches).
+    - main
+    - release/*
+  tags:
+    include:
+    - "*"
+
+resources:
+  repositories:
+  - repository: eng
+    type: git
+    name: engineering
+    ref: refs/tags/release
+
+variables:
+- template: ci/variables/cfs.yml@eng
+
+extends:
+  template: ci/code-mirror.yml@eng


### PR DESCRIPTION
Add Azure DevOps pipeline configuration for code mirroring.

This mirrors branches (`main`, `release/*`) and tags to the internal Azure DevOps repository using the shared engineering template.

Reference: https://github.com/Azure/durable-agent-framework/pull/14