### PR TITLE
Add artifacts for E2E testing and publishing

### DIFF
--- a/.github/workflows/dotnet-build-and-test.yml
+++ b/.github/workflows/dotnet-build-and-test.yml
@@ -36,11 +36,11 @@ jobs:
 
       - name: Run DurableTask unit tests
         working-directory: dotnet
-        run: dotnet test --project tests/Microsoft.Agents.AI.DurableTask.UnitTests/Microsoft.Agents.AI.DurableTask.UnitTests.csproj --configuration Release --no-build --report-xunit-trx --results-directory ../artifacts/test-results
+        run: dotnet test tests/Microsoft.Agents.AI.DurableTask.UnitTests/Microsoft.Agents.AI.DurableTask.UnitTests.csproj --configuration Release --no-build --report-xunit-trx --results-directory ../artifacts/test-results
 
       - name: Run Azure Functions unit tests
         working-directory: dotnet
-        run: dotnet test --project tests/Microsoft.Agents.AI.Hosting.AzureFunctions.UnitTests/Microsoft.Agents.AI.Hosting.AzureFunctions.UnitTests.csproj --configuration Release --no-build --report-xunit-trx --results-directory ../artifacts/test-results
+        run: dotnet test tests/Microsoft.Agents.AI.Hosting.AzureFunctions.UnitTests/Microsoft.Agents.AI.Hosting.AzureFunctions.UnitTests.csproj --configuration Release --no-build --report-xunit-trx --results-directory ../artifacts/test-results
 
       - name: Pack DurableTask
         working-directory: dotnet

--- a/.github/workflows/dotnet-integration-tests.yml
+++ b/.github/workflows/dotnet-integration-tests.yml
@@ -42,11 +42,11 @@ jobs:
 
       - name: Run DurableTask integration tests
         working-directory: dotnet
-        run: dotnet test --project tests/Microsoft.Agents.AI.DurableTask.IntegrationTests/Microsoft.Agents.AI.DurableTask.IntegrationTests.csproj --configuration Release --no-build --report-xunit-trx --results-directory ../artifacts/test-results
+        run: dotnet test tests/Microsoft.Agents.AI.DurableTask.IntegrationTests/Microsoft.Agents.AI.DurableTask.IntegrationTests.csproj --configuration Release --no-build --report-xunit-trx --results-directory ../artifacts/test-results
 
       - name: Run Azure Functions integration tests
         working-directory: dotnet
-        run: dotnet test --project tests/Microsoft.Agents.AI.Hosting.AzureFunctions.IntegrationTests/Microsoft.Agents.AI.Hosting.AzureFunctions.IntegrationTests.csproj --configuration Release --no-build --report-xunit-trx --results-directory ../artifacts/test-results
+        run: dotnet test tests/Microsoft.Agents.AI.Hosting.AzureFunctions.IntegrationTests/Microsoft.Agents.AI.Hosting.AzureFunctions.IntegrationTests.csproj --configuration Release --no-build --report-xunit-trx --results-directory ../artifacts/test-results
 
       - name: Upload test results
         if: always()

--- a/eng/README.md
+++ b/eng/README.md
@@ -1,0 +1,53 @@
+# Engineering pipelines
+
+This directory contains pipeline definitions and shared templates for work that runs outside the normal GitHub pull request flow.
+
+GitHub remains the source of truth for code review and day-to-day development. Pull requests are opened and reviewed in GitHub, and the GitHub Actions workflows provide the public build and unit-test signal for ordinary changes.
+
+Azure DevOps is used for jobs that need a more controlled execution environment, especially jobs that require protected credentials or service connections. The Azure DevOps pipelines are defined in this repo so changes can be reviewed with the code, while the pipeline resources, approvals, and secret stores are managed outside the public repository.
+
+## Pipeline layout
+
+| Path | Purpose |
+| --- | --- |
+| `eng/ci/code-mirror.yml` | Mirrors the GitHub repository into Azure Repos so Azure DevOps can run trusted pipelines from a controlled copy of the source. |
+| `eng/ci/e2e-tests.yml` | Runs end-to-end tests that require protected model credentials or service connections. |
+| `eng/ci/package-release.yml` | Builds package artifacts and, when explicitly enabled, publishes .NET and Python packages. |
+| `eng/templates/jobs/` | Reusable jobs for shared test infrastructure and language-specific E2E test runs. |
+| `eng/templates/official/jobs/` | Reusable jobs for package build and release stages. |
+
+## Test approach
+
+Pull requests should continue to rely on GitHub Actions for fast validation:
+
+- .NET restore, build, unit tests, and package creation
+- Python linting, type checking, unit tests, and package creation
+
+End-to-end tests run in Azure DevOps because they can require protected resources. The E2E pipeline starts local dependencies on the build agent:
+
+- Durable Task Scheduler emulator
+- Azurite
+- Redis
+- Azure Functions Core Tools
+
+Model endpoints, deployment names, API keys, and service connections are supplied by protected Azure DevOps variables or service connections. They should not be stored in this repository.
+
+## Release approach
+
+Package release also runs in Azure DevOps. The release pipeline builds the .NET and Python artifacts first, then requires an explicit publish decision.
+
+Publishing is disabled by default. Maintainers should first run the release pipeline as a dry run, inspect the generated artifacts, confirm the package versions, and only then rerun with the appropriate publish option enabled.
+
+The release pipeline is structured to publish:
+
+- .NET NuGet packages and symbol packages
+- Python source distribution and wheel packages
+
+The exact publishing credentials or service connections are managed in Azure DevOps. If the release process changes, update the pipeline templates in this directory rather than putting credentials or internal setup notes in the repository.
+
+## Maintainer notes
+
+- Keep public pipeline documentation in this file high level and safe to share.
+- Keep organization-specific setup steps, links, permissions, and secret names in the internal team docs.
+- Review pipeline changes the same way as product code changes.
+- Prefer dry-run package builds before enabling publish steps.

--- a/eng/ci/e2e-tests.yml
+++ b/eng/ci/e2e-tests.yml
@@ -1,0 +1,45 @@
+trigger: none
+pr: none
+
+schedules:
+  - cron: '0 8 * * *'
+    displayName: 'Daily E2E tests'
+    branches:
+      include:
+        - main
+    always: true
+
+resources:
+  repositories:
+    - repository: 1es
+      type: git
+      name: 1ESPipelineTemplates/1ESPipelineTemplates
+      ref: refs/tags/release
+    - repository: eng
+      type: git
+      name: engineering
+      ref: refs/tags/release
+
+variables:
+  - template: ci/variables/build.yml@eng
+  - template: ci/variables/cfs.yml@eng
+  - group: agent-framework-durable-extension-e2e
+
+extends:
+  template: v1/1ES.Official.PipelineTemplate.yml@1es
+  parameters:
+    pool:
+      name: 1es-pool-azfunc
+      image: 1es-ubuntu-22.04
+      os: linux
+
+    stages:
+      - stage: DotNetE2E
+        displayName: '.NET E2E tests'
+        jobs:
+          - template: /eng/templates/jobs/dotnet-e2e-tests.yml@self
+
+      - stage: PythonE2E
+        displayName: 'Python E2E tests'
+        jobs:
+          - template: /eng/templates/jobs/python-e2e-tests.yml@self

--- a/eng/ci/package-release.yml
+++ b/eng/ci/package-release.yml
@@ -1,0 +1,58 @@
+trigger: none
+pr: none
+
+parameters:
+  - name: publishDotNet
+    type: boolean
+    default: false
+    displayName: 'Publish .NET packages'
+  - name: publishPython
+    type: boolean
+    default: false
+    displayName: 'Publish Python package'
+  - name: artifactName
+    type: string
+    default: 'agent-framework-durable-extension-packages'
+    displayName: 'Pipeline artifact name'
+
+resources:
+  repositories:
+    - repository: 1es
+      type: git
+      name: 1ESPipelineTemplates/1ESPipelineTemplates
+      ref: refs/tags/release
+    - repository: eng
+      type: git
+      name: engineering
+      ref: refs/tags/release
+
+variables:
+  - template: ci/variables/build.yml@eng
+  - template: ci/variables/cfs.yml@eng
+  - group: agent-framework-durable-extension-release
+
+extends:
+  template: v1/1ES.Official.PipelineTemplate.yml@1es
+  parameters:
+    pool:
+      name: 1es-pool-azfunc
+      image: 1es-ubuntu-22.04
+      os: linux
+
+    stages:
+      - stage: BuildPackages
+        displayName: 'Build packages'
+        jobs:
+          - template: /eng/templates/official/jobs/build-packages.yml@self
+            parameters:
+              artifactName: ${{ parameters.artifactName }}
+
+      - stage: PublishPackages
+        displayName: 'Publish packages'
+        dependsOn: BuildPackages
+        jobs:
+          - template: /eng/templates/official/jobs/publish-packages.yml@self
+            parameters:
+              artifactName: ${{ parameters.artifactName }}
+              publishDotNet: ${{ parameters.publishDotNet }}
+              publishPython: ${{ parameters.publishPython }}

--- a/eng/templates/jobs/dotnet-e2e-tests.yml
+++ b/eng/templates/jobs/dotnet-e2e-tests.yml
@@ -1,0 +1,62 @@
+jobs:
+  - job: DotNetE2E
+    displayName: '.NET E2E tests'
+    timeoutInMinutes: 90
+    pool:
+      name: 1es-pool-azfunc
+      image: 1es-ubuntu-22.04
+      os: linux
+    variables:
+      DURABLE_TASK_SCHEDULER_CONNECTION_STRING: 'Endpoint=http://localhost:8080;TaskHub=default;Authentication=None'
+      AzureWebJobsStorage: 'UseDevelopmentStorage=true'
+      REDIS_CONNECTION_STRING: 'localhost:6379'
+      NUGET_CERT_REVOCATION_MODE: offline
+    steps:
+      - checkout: self
+
+      - task: UseDotNet@2
+        displayName: 'Use .NET SDK from global.json'
+        inputs:
+          packageType: sdk
+          useGlobalJson: true
+          workingDirectory: dotnet
+
+      - template: setup-integration-infra.yml
+
+      - bash: dotnet restore agent-framework-durable-extension.slnx
+        workingDirectory: dotnet
+        displayName: 'Restore .NET solution'
+
+      - bash: dotnet build agent-framework-durable-extension.slnx --configuration Release --no-restore
+        workingDirectory: dotnet
+        displayName: 'Build .NET solution'
+
+      - bash: |
+          mkdir -p ../artifacts/test-results
+          dotnet test tests/Microsoft.Agents.AI.DurableTask.IntegrationTests/Microsoft.Agents.AI.DurableTask.IntegrationTests.csproj --configuration Release --no-build --report-xunit-trx --results-directory ../artifacts/test-results
+        workingDirectory: dotnet
+        displayName: 'Run DurableTask integration tests'
+        env:
+          AZURE_OPENAI_ENDPOINT: $(AZURE_OPENAI_ENDPOINT)
+          AZURE_OPENAI_DEPLOYMENT_NAME: $(AZURE_OPENAI_DEPLOYMENT_NAME)
+          AZURE_OPENAI_CHAT_DEPLOYMENT_NAME: $(AZURE_OPENAI_DEPLOYMENT_NAME)
+          AZURE_OPENAI_API_KEY: $(AZURE_OPENAI_API_KEY)
+
+      - bash: |
+          mkdir -p ../artifacts/test-results
+          dotnet test tests/Microsoft.Agents.AI.Hosting.AzureFunctions.IntegrationTests/Microsoft.Agents.AI.Hosting.AzureFunctions.IntegrationTests.csproj --configuration Release --no-build --report-xunit-trx --results-directory ../artifacts/test-results
+        workingDirectory: dotnet
+        displayName: 'Run Azure Functions integration tests'
+        env:
+          AZURE_OPENAI_ENDPOINT: $(AZURE_OPENAI_ENDPOINT)
+          AZURE_OPENAI_DEPLOYMENT_NAME: $(AZURE_OPENAI_DEPLOYMENT_NAME)
+          AZURE_OPENAI_CHAT_DEPLOYMENT_NAME: $(AZURE_OPENAI_DEPLOYMENT_NAME)
+          AZURE_OPENAI_API_KEY: $(AZURE_OPENAI_API_KEY)
+
+      - task: PublishTestResults@2
+        condition: always()
+        inputs:
+          testResultsFormat: VSTest
+          testResultsFiles: 'artifacts/test-results/**/*.trx'
+          failTaskOnFailedTests: true
+        displayName: 'Publish .NET test results'

--- a/eng/templates/jobs/python-e2e-tests.yml
+++ b/eng/templates/jobs/python-e2e-tests.yml
@@ -1,0 +1,49 @@
+jobs:
+  - job: PythonE2E
+    displayName: 'Python E2E tests'
+    timeoutInMinutes: 90
+    pool:
+      name: 1es-pool-azfunc
+      image: 1es-ubuntu-22.04
+      os: linux
+    variables:
+      DURABLE_TASK_SCHEDULER_CONNECTION_STRING: 'Endpoint=http://localhost:8080;TaskHub=default;Authentication=None'
+      REDIS_CONNECTION_STRING: 'redis://localhost:6379'
+    steps:
+      - checkout: self
+
+      - task: UsePythonVersion@0
+        displayName: 'Use Python 3.13'
+        inputs:
+          versionSpec: '3.13'
+
+      - bash: |
+          curl -LsSf https://astral.sh/uv/install.sh | sh
+          echo "##vso[task.prependpath]$HOME/.local/bin"
+        displayName: 'Install uv'
+
+      - template: setup-integration-infra.yml
+
+      - bash: uv sync --all-packages --group dev --group test
+        workingDirectory: python
+        displayName: 'Sync Python workspace'
+
+      - bash: |
+          mkdir -p ../artifacts/test-results
+          uv run pytest packages/durabletask/tests/integration_tests -m integration -n logical --dist worksteal --timeout 480 --junitxml ../artifacts/test-results/python-integration.xml
+        workingDirectory: python
+        displayName: 'Run Python integration tests'
+        env:
+          FOUNDRY_PROJECT_ENDPOINT: $(FOUNDRY_PROJECT_ENDPOINT)
+          FOUNDRY_MODEL: $(FOUNDRY_MODEL)
+          AZURE_OPENAI_ENDPOINT: $(AZURE_OPENAI_ENDPOINT)
+          AZURE_OPENAI_MODEL: $(AZURE_OPENAI_MODEL)
+          AZURE_OPENAI_API_KEY: $(AZURE_OPENAI_API_KEY)
+
+      - task: PublishTestResults@2
+        condition: always()
+        inputs:
+          testResultsFormat: JUnit
+          testResultsFiles: 'artifacts/test-results/python-integration.xml'
+          failTaskOnFailedTests: true
+        displayName: 'Publish Python test results'

--- a/eng/templates/jobs/setup-integration-infra.yml
+++ b/eng/templates/jobs/setup-integration-infra.yml
@@ -1,0 +1,40 @@
+steps:
+  - bash: |
+      set -euo pipefail
+
+      if [ "$(docker ps -aq -f name=dts-emulator)" ]; then
+        docker rm -f dts-emulator
+      fi
+
+      docker run -d --name dts-emulator -p 8080:8080 -p 8082:8082 -e DTS_USE_DYNAMIC_TASK_HUBS=true mcr.microsoft.com/dts/dts-emulator:latest
+      timeout 60 bash -c 'until curl --silent --show-error http://localhost:8082 >/dev/null; do sleep 2; done'
+    displayName: 'Start Durable Task Scheduler emulator'
+
+  - bash: |
+      set -euo pipefail
+
+      if [ "$(docker ps -aq -f name=azurite)" ]; then
+        docker rm -f azurite
+      fi
+
+      docker run -d --name azurite -p 10000:10000 -p 10001:10001 -p 10002:10002 mcr.microsoft.com/azure-storage/azurite
+      timeout 60 bash -c 'until curl --silent --show-error http://localhost:10000/devstoreaccount1 >/dev/null; do sleep 2; done'
+    displayName: 'Start Azurite'
+
+  - bash: |
+      set -euo pipefail
+
+      if [ "$(docker ps -aq -f name=redis)" ]; then
+        docker rm -f redis
+      fi
+
+      docker run -d --name redis -p 6379:6379 redis:latest
+      timeout 60 bash -c 'until docker exec redis redis-cli ping | grep -q PONG; do sleep 2; done'
+    displayName: 'Start Redis'
+
+  - bash: |
+      set -euo pipefail
+
+      npm install -g azure-functions-core-tools@4 --unsafe-perm true
+      func --version
+    displayName: 'Install Azure Functions Core Tools'

--- a/eng/templates/official/jobs/build-packages.yml
+++ b/eng/templates/official/jobs/build-packages.yml
@@ -1,0 +1,84 @@
+parameters:
+  - name: artifactName
+    type: string
+    default: 'agent-framework-durable-extension-packages'
+
+jobs:
+  - job: BuildPackages
+    displayName: 'Build package artifacts'
+    pool:
+      name: 1es-pool-azfunc
+      image: 1es-ubuntu-22.04
+      os: linux
+    templateContext:
+      outputParentDirectory: $(Build.ArtifactStagingDirectory)
+      outputs:
+        - output: pipelineArtifact
+          targetPath: $(Build.ArtifactStagingDirectory)/packages
+          artifactName: ${{ parameters.artifactName }}
+    steps:
+      - checkout: self
+
+      - task: UseDotNet@2
+        displayName: 'Use .NET SDK from global.json'
+        inputs:
+          packageType: sdk
+          useGlobalJson: true
+          workingDirectory: dotnet
+
+      - task: UsePythonVersion@0
+        displayName: 'Use Python 3.13'
+        inputs:
+          versionSpec: '3.13'
+
+      - bash: |
+          curl -LsSf https://astral.sh/uv/install.sh | sh
+          echo "##vso[task.prependpath]$HOME/.local/bin"
+        displayName: 'Install uv'
+
+      - bash: dotnet restore agent-framework-durable-extension.slnx
+        workingDirectory: dotnet
+        displayName: 'Restore .NET solution'
+
+      - bash: dotnet build agent-framework-durable-extension.slnx --configuration Release --no-restore
+        workingDirectory: dotnet
+        displayName: 'Build .NET solution'
+
+      - bash: |
+          mkdir -p ../artifacts/test-results
+          dotnet test tests/Microsoft.Agents.AI.DurableTask.UnitTests/Microsoft.Agents.AI.DurableTask.UnitTests.csproj --configuration Release --no-build --report-xunit-trx --results-directory ../artifacts/test-results
+          dotnet test tests/Microsoft.Agents.AI.Hosting.AzureFunctions.UnitTests/Microsoft.Agents.AI.Hosting.AzureFunctions.UnitTests.csproj --configuration Release --no-build --report-xunit-trx --results-directory ../artifacts/test-results
+        workingDirectory: dotnet
+        displayName: 'Run .NET unit tests'
+
+      - bash: |
+          mkdir -p "$(Build.ArtifactStagingDirectory)/packages/dotnet"
+          dotnet pack src/Microsoft.Agents.AI.DurableTask/Microsoft.Agents.AI.DurableTask.csproj --configuration Release --no-build --output "$(Build.ArtifactStagingDirectory)/packages/dotnet"
+          dotnet pack src/Microsoft.Agents.AI.Hosting.AzureFunctions/Microsoft.Agents.AI.Hosting.AzureFunctions.csproj --configuration Release --no-build --output "$(Build.ArtifactStagingDirectory)/packages/dotnet"
+        workingDirectory: dotnet
+        displayName: 'Pack .NET packages'
+
+      - bash: uv sync --all-packages --group dev --group test
+        workingDirectory: python
+        displayName: 'Sync Python workspace'
+
+      - bash: uv run ruff check packages/durabletask
+        workingDirectory: python
+        displayName: 'Run Python lint'
+
+      - bash: uv run mypy --config-file packages/durabletask/pyproject.toml packages/durabletask/agent_framework_durabletask
+        workingDirectory: python
+        displayName: 'Run Python type check'
+
+      - bash: uv run pytest -m "not integration" packages/durabletask/tests
+        workingDirectory: python
+        displayName: 'Run Python unit tests'
+
+      - bash: |
+          mkdir -p "$(Build.ArtifactStagingDirectory)/packages/python"
+          uv build packages/durabletask --out-dir "$(Build.ArtifactStagingDirectory)/packages/python"
+        workingDirectory: python
+        displayName: 'Build Python package'
+
+      - bash: find "$(Build.ArtifactStagingDirectory)/packages" -type f | sort
+        displayName: 'List package artifacts'

--- a/eng/templates/official/jobs/publish-packages.yml
+++ b/eng/templates/official/jobs/publish-packages.yml
@@ -1,0 +1,95 @@
+parameters:
+  - name: artifactName
+    type: string
+    default: 'agent-framework-durable-extension-packages'
+  - name: publishDotNet
+    type: boolean
+    default: false
+  - name: publishPython
+    type: boolean
+    default: false
+
+jobs:
+  - job: ValidateRelease
+    displayName: '(Manual) Validate package release'
+    condition: or(${{ eq(parameters.publishDotNet, true) }}, ${{ eq(parameters.publishPython, true) }})
+    pool: server
+    steps:
+      - task: ManualValidation@1
+        displayName: 'Approve package publish'
+        inputs:
+          notifyUsers: ''
+          instructions: |
+            Review package artifacts from the BuildPackages stage.
+            Confirm package versions are correct and have not already been published.
+            Resume only when ready to publish selected package types.
+
+  - job: PublishDotNet
+    dependsOn: ValidateRelease
+    condition: and(succeeded(), ${{ eq(parameters.publishDotNet, true) }})
+    displayName: 'Publish .NET packages'
+    pool:
+      name: 1es-pool-azfunc
+      image: 1es-ubuntu-22.04
+      os: linux
+    steps:
+      - checkout: none
+
+      - task: UseDotNet@2
+        displayName: 'Use .NET SDK 10.0.x'
+        inputs:
+          packageType: sdk
+          version: 10.0.x
+
+      - download: current
+        artifact: ${{ parameters.artifactName }}
+
+      - bash: |
+          set -euo pipefail
+          shopt -s nullglob
+
+          packages=("$(Pipeline.Workspace)/${{ parameters.artifactName }}/dotnet"/*.nupkg)
+          if [ ${#packages[@]} -eq 0 ]; then
+            echo "No .nupkg files found"
+            exit 1
+          fi
+
+          for package in "${packages[@]}"; do
+            dotnet nuget push "$package" --source https://api.nuget.org/v3/index.json --api-key "$NUGET_API_KEY" --skip-duplicate
+          done
+
+          symbols=("$(Pipeline.Workspace)/${{ parameters.artifactName }}/dotnet"/*.snupkg)
+          for symbols_package in "${symbols[@]}"; do
+            dotnet nuget push "$symbols_package" --source https://api.nuget.org/v3/index.json --api-key "$NUGET_API_KEY" --skip-duplicate
+          done
+        displayName: 'Push .NET packages to NuGet'
+        env:
+          NUGET_API_KEY: $(NUGET_API_KEY)
+
+  - job: PublishPython
+    dependsOn: ValidateRelease
+    condition: and(succeeded(), ${{ eq(parameters.publishPython, true) }})
+    displayName: 'Publish Python package'
+    pool:
+      name: 1es-pool-azfunc
+      image: 1es-ubuntu-22.04
+      os: linux
+    steps:
+      - checkout: none
+
+      - download: current
+        artifact: ${{ parameters.artifactName }}
+
+      - task: UsePythonVersion@0
+        displayName: 'Use Python 3.13'
+        inputs:
+          versionSpec: '3.13'
+
+      - bash: |
+          set -euo pipefail
+          python -m pip install --upgrade pip twine
+          python -m twine upload --non-interactive "$(Pipeline.Workspace)/${{ parameters.artifactName }}/python"/*
+        displayName: 'Upload Python package to PyPI'
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: $(PYPI_TOKEN)


### PR DESCRIPTION
Adds the necessary artifacts for running E2E tests and publishing packages in ADO. The approach was largely lifted from the [Serverless Agent Framework repo](https://github.com/Azure/azure-functions-agent-runtime).