### PR TITLE
Add es-metadata.yml for 1ES ADO pipeline support

### DIFF
--- a/es-metadata.yml
+++ b/es-metadata.yml
@@ -1,0 +1,12 @@
+schemaVersion: 1.0.0
+providers:
+- provider: InventoryAsCode
+  version: 1.0.0
+  metadata:
+    isProduction: true
+    accountableOwners:
+      service: e8fdf03b-44f7-48d3-8653-a744c922a342
+    routing:
+      defaultAreaPath:
+        org: azfunc
+        path: internal\Azure Functions\Core


### PR DESCRIPTION
This file is required for integration with the 1ES ADO Pipelines infrastructure. I'm using the same content as https://github.com/Azure/azure-functions-host/blob/dev/es-metadata.yml.

Once this is merged, we should be unblocked for creating the ADO-managed E2E test pipelines.