### PR TITLE
Enable E2E validation in internally managed Azure Pipelines

### DIFF
--- a/eng/README.md
+++ b/eng/README.md
@@ -2,7 +2,7 @@
 
 This directory contains pipeline definitions and shared templates for work that runs outside the normal GitHub pull request flow.
 
-GitHub remains the source of truth for code review and day-to-day development. Pull requests are opened and reviewed in GitHub, and the GitHub Actions workflows provide the public build and unit-test signal for ordinary changes.
+GitHub remains the source of truth for code review and day-to-day development. Pull requests are opened and reviewed in GitHub, and GitHub Actions provide the public build and unit-test signal. End-to-end tests and package publishing run in Azure DevOps, which offers a more controlled environment for identity-based access and credentials.
 
 Azure DevOps is used for jobs that need a more controlled execution environment, especially jobs that require protected credentials or service connections. The Azure DevOps pipelines are defined in this repo so changes can be reviewed with the code, while the pipeline resources, approvals, and secret stores are managed outside the public repository.
 
@@ -11,7 +11,7 @@ Azure DevOps is used for jobs that need a more controlled execution environment,
 | Path | Purpose |
 | --- | --- |
 | `eng/ci/code-mirror.yml` | Mirrors the GitHub repository into Azure Repos so Azure DevOps can run trusted pipelines from a controlled copy of the source. |
-| `eng/ci/e2e-tests.yml` | Runs end-to-end tests that require protected model credentials or service connections. |
+| `eng/ci/e2e-tests.yml` | Runs scheduled and manual end-to-end tests that reach Azure models through a service connection identity. |
 | `eng/ci/package-release.yml` | Builds package artifacts and, when explicitly enabled, publishes .NET and Python packages. |
 | `eng/templates/jobs/` | Reusable jobs for shared test infrastructure and language-specific E2E test runs. |
 | `eng/templates/official/jobs/` | Reusable jobs for package build and release stages. |
@@ -23,14 +23,16 @@ Pull requests should continue to rely on GitHub Actions for fast validation:
 - .NET restore, build, unit tests, and package creation
 - Python linting, type checking, unit tests, and package creation
 
-End-to-end tests run in Azure DevOps because they can require protected resources. The E2E pipeline starts local dependencies on the build agent:
+End-to-end tests run in Azure DevOps because they can require access to protected resources. The E2E pipeline uses a Governed 1ES Linux agent and starts local dependencies on the build agent:
 
 - Durable Task Scheduler emulator
 - Azurite
 - Redis
 - Azure Functions Core Tools
 
-Model endpoints, deployment names, API keys, and service connections are supplied by protected Azure DevOps variables or service connections. They should not be stored in this repository.
+The pipeline runs on a daily schedule and can be started manually against any branch. It is not triggered by commits or pull requests, so it runs from the Azure Repos mirror and does not need a GitHub connection.
+
+Access to Azure OpenAI and Foundry models uses the identity of an Azure service connection (no API keys). Model endpoints and deployment or model names are provided as non-secret pipeline variables. As a result, the E2E pipeline does not rely on any secret variables.
 
 ## Release approach
 
@@ -43,7 +45,7 @@ The release pipeline is structured to publish:
 - .NET NuGet packages and symbol packages
 - Python source distribution and wheel packages
 
-The exact publishing credentials or service connections are managed in Azure DevOps. If the release process changes, update the pipeline templates in this directory rather than putting credentials or internal setup notes in the repository.
+The publishing credentials are held inside Azure DevOps service connections for NuGet.org and PyPI. The pipeline never reads these credentials directly, so there are no publishing secrets in this repository or in pipeline variables. If the release process changes, update the pipeline templates in this directory rather than putting credentials or internal setup notes in the repository.
 
 ## Maintainer notes
 

--- a/eng/ci/e2e-tests.yml
+++ b/eng/ci/e2e-tests.yml
@@ -7,8 +7,12 @@ pr: none
 parameters:
   - name: linuxImage
     type: string
-    default: '1es-azurelinux-3'
+    default: '1es-ubuntu-22.04'
     displayName: '1ES Hosted Pools Linux image'
+  - name: windowsImage
+    type: string
+    default: '1es-windows-2022'
+    displayName: '1ES Hosted Pools Windows image (for SDL source analysis)'
   - name: azureServiceConnection
     type: string
     default: 'agent-framework-durable-extension-e2e'
@@ -42,10 +46,19 @@ extends:
   parameters:
     pool:
       name: 1es-pool-azfunc
-      # This image must be added to the hosted pool before enabling this pipeline.
-      # CoreAI's preferred base image is 1ES PT - Starter Azure Linux 3 Gen2.
+      # 1es-ubuntu-22.04 is a 1ES-compliant image already in the pool and provides
+      # Docker and Azure CLI, which the tests need. CoreAI recommends migrating to
+      # an Azure Linux 3 image later for better vulnerability servicing.
       image: ${{ parameters.linuxImage }}
       os: linux
+
+    # The SDL source-analysis stage only runs on Windows. Because the build pool
+    # is Linux, 1ES requires a Windows image in the same pool for that stage.
+    sdl:
+      sourceAnalysisPool:
+        name: 1es-pool-azfunc
+        image: ${{ parameters.windowsImage }}
+        os: windows
 
     stages:
       - stage: E2E

--- a/eng/ci/e2e-tests.yml
+++ b/eng/ci/e2e-tests.yml
@@ -1,5 +1,18 @@
+# This pipeline runs on a schedule and on manual runs only. It is not triggered by
+# commits or pull requests, so it can run from the Azure Repos mirror without a
+# GitHub connection. Trigger a manual run and pick a branch to test changes.
 trigger: none
 pr: none
+
+parameters:
+  - name: linuxImage
+    type: string
+    default: '1es-azurelinux-3'
+    displayName: '1ES Hosted Pools Linux image'
+  - name: azureServiceConnection
+    type: string
+    default: 'agent-framework-durable-extension-e2e'
+    displayName: 'Azure Resource Manager service connection'
 
 schedules:
   - cron: '0 8 * * *'
@@ -21,25 +34,26 @@ resources:
       ref: refs/tags/release
 
 variables:
-  - template: ci/variables/build.yml@eng
-  - template: ci/variables/cfs.yml@eng
+  - template: /ci/variables/cfs.yml@eng
   - group: agent-framework-durable-extension-e2e
 
 extends:
-  template: v1/1ES.Official.PipelineTemplate.yml@1es
+  template: v1/1ES.Unofficial.PipelineTemplate.yml@1es
   parameters:
     pool:
       name: 1es-pool-azfunc
-      image: 1es-ubuntu-22.04
+      # This image must be added to the hosted pool before enabling this pipeline.
+      # CoreAI's preferred base image is 1ES PT - Starter Azure Linux 3 Gen2.
+      image: ${{ parameters.linuxImage }}
       os: linux
 
     stages:
-      - stage: DotNetE2E
-        displayName: '.NET E2E tests'
+      - stage: E2E
+        displayName: 'End-to-end tests'
         jobs:
           - template: /eng/templates/jobs/dotnet-e2e-tests.yml@self
-
-      - stage: PythonE2E
-        displayName: 'Python E2E tests'
-        jobs:
+            parameters:
+              azureServiceConnection: ${{ parameters.azureServiceConnection }}
           - template: /eng/templates/jobs/python-e2e-tests.yml@self
+            parameters:
+              azureServiceConnection: ${{ parameters.azureServiceConnection }}

--- a/eng/ci/e2e-tests.yml
+++ b/eng/ci/e2e-tests.yml
@@ -42,7 +42,7 @@ variables:
   - group: agent-framework-durable-extension-e2e
 
 extends:
-  template: v1/1ES.Unofficial.PipelineTemplate.yml@1es
+  template: v1/1ES.Official.PipelineTemplate.yml@1es
   parameters:
     pool:
       name: 1es-pool-azfunc

--- a/eng/ci/e2e-tests.yml
+++ b/eng/ci/e2e-tests.yml
@@ -8,7 +8,10 @@ parameters:
   - name: linuxImage
     type: string
     default: '1es-ubuntu-22.04'
-    displayName: '1ES Hosted Pools Linux image'
+    # Must be an Ubuntu/Debian-based image: the integration infrastructure setup
+    # uses apt-get, dpkg, and the Ubuntu packages.microsoft.com feed. A non-Ubuntu
+    # image (e.g. Azure Linux 3) would require reworking that setup step.
+    displayName: '1ES Hosted Pools Linux image (Ubuntu-based)'
   - name: windowsImage
     type: string
     default: '1es-windows-2022'

--- a/eng/ci/package-release.yml
+++ b/eng/ci/package-release.yml
@@ -14,6 +14,14 @@ parameters:
     type: string
     default: 'agent-framework-durable-extension-packages'
     displayName: 'Pipeline artifact name'
+  - name: nugetServiceConnection
+    type: string
+    default: 'agent-framework-durable-extension-nuget-org'
+    displayName: 'NuGet.org service connection'
+  - name: pypiServiceConnection
+    type: string
+    default: 'agent-framework-durable-extension-pypi'
+    displayName: 'PyPI service connection'
 
 resources:
   repositories:
@@ -27,17 +35,15 @@ resources:
       ref: refs/tags/release
 
 variables:
-  - template: ci/variables/build.yml@eng
-  - template: ci/variables/cfs.yml@eng
-  - group: agent-framework-durable-extension-release
+  - template: /ci/variables/cfs.yml@eng
 
 extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1es
   parameters:
     pool:
       name: 1es-pool-azfunc
-      image: 1es-ubuntu-22.04
-      os: linux
+      image: 1es-windows-2022
+      os: windows
 
     stages:
       - stage: BuildPackages
@@ -56,3 +62,5 @@ extends:
               artifactName: ${{ parameters.artifactName }}
               publishDotNet: ${{ parameters.publishDotNet }}
               publishPython: ${{ parameters.publishPython }}
+              nugetServiceConnection: ${{ parameters.nugetServiceConnection }}
+              pypiServiceConnection: ${{ parameters.pypiServiceConnection }}

--- a/eng/nuget.ci.config
+++ b/eng/nuget.ci.config
@@ -12,10 +12,10 @@
 <configuration>
   <packageSources>
     <clear />
-    <add key="PythonSDK_Internal_PublicPackages" value="https://pkgs.dev.azure.com/azfunc/internal/_packaging/PythonSDK_Internal_PublicPackages/nuget/v3/index.json" />
+    <add key="upstream" value="https://pkgs.dev.azure.com/azfunc/internal/_packaging/upstream/nuget/v3/index.json" />
   </packageSources>
   <packageSourceMapping>
-    <packageSource key="PythonSDK_Internal_PublicPackages">
+    <packageSource key="upstream">
       <package pattern="*" />
     </packageSource>
   </packageSourceMapping>

--- a/eng/nuget.ci.config
+++ b/eng/nuget.ci.config
@@ -4,9 +4,10 @@
 
   The governed 1ES pool cannot reach api.nuget.org directly. This config restores
   from the internal Azure Artifacts feed, which serves nuget.org packages through
-  its upstream source. It is referenced explicitly with the restore configfile
-  option and is intentionally NOT auto-discovered, so local development and GitHub
-  Actions continue to use the repo's default dotnet/nuget.config (nuget.org).
+  its upstream source. The governed pipelines copy this file over dotnet/nuget.config
+  before restoring, so MSBuild SDK resolution, the solution restore, and the runtime
+  sample builds all use the internal feed. The committed dotnet/nuget.config keeps
+  pointing at nuget.org so local development and GitHub Actions are unaffected.
 -->
 <configuration>
   <packageSources>

--- a/eng/nuget.ci.config
+++ b/eng/nuget.ci.config
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  CI-only NuGet configuration for Azure DevOps governed pipelines.
+
+  The governed 1ES pool cannot reach api.nuget.org directly. This config restores
+  from the internal Azure Artifacts feed, which serves nuget.org packages through
+  its upstream source. It is referenced explicitly with the restore configfile
+  option and is intentionally NOT auto-discovered, so local development and GitHub
+  Actions continue to use the repo's default dotnet/nuget.config (nuget.org).
+-->
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="PythonSDK_Internal_PublicPackages" value="https://pkgs.dev.azure.com/azfunc/internal/_packaging/PythonSDK_Internal_PublicPackages/nuget/v3/index.json" />
+  </packageSources>
+  <packageSourceMapping>
+    <packageSource key="PythonSDK_Internal_PublicPackages">
+      <package pattern="*" />
+    </packageSource>
+  </packageSourceMapping>
+</configuration>

--- a/eng/templates/jobs/dotnet-e2e-tests.yml
+++ b/eng/templates/jobs/dotnet-e2e-tests.yml
@@ -10,6 +10,11 @@ jobs:
       DURABLE_TASK_SCHEDULER_CONNECTION_STRING: 'Endpoint=http://localhost:8080;TaskHub=default;Authentication=None'
       AzureWebJobsStorage: 'UseDevelopmentStorage=true'
       REDIS_CONNECTION_STRING: 'localhost:6379'
+      # The agent OS disk (/) is nearly full from the base image, Docker images, and
+      # Azure Functions Core Tools. Keep the NuGet package cache and temp files on the
+      # roomier work volume so the .NET restore/build does not exhaust /.
+      NUGET_PACKAGES: $(Agent.TempDirectory)/.nuget/packages
+      TMPDIR: $(Agent.TempDirectory)
     steps:
       - checkout: self
 
@@ -28,13 +33,23 @@ jobs:
       - task: NuGetAuthenticate@1
         displayName: 'Authenticate to Azure Artifacts feed'
 
-      - bash: dotnet restore agent-framework-durable-extension.slnx
-        workingDirectory: dotnet
-        displayName: 'Restore .NET solution'
+      - bash: df -h
+        displayName: 'Disk space (baseline)'
 
-      - bash: dotnet build agent-framework-durable-extension.slnx --configuration Release --no-restore
+      # Build only the integration test projects. The tests build the specific
+      # samples they exercise at runtime, so building the full solution (32 sample
+      # projects, many of them Azure Functions apps with large bin output) upfront
+      # is unnecessary and exhausts the agent's disk.
+      - bash: |
+          set -euo pipefail
+          dotnet build tests/Microsoft.Agents.AI.DurableTask.IntegrationTests/Microsoft.Agents.AI.DurableTask.IntegrationTests.csproj --configuration Release
+          dotnet build tests/Microsoft.Agents.AI.Hosting.AzureFunctions.IntegrationTests/Microsoft.Agents.AI.Hosting.AzureFunctions.IntegrationTests.csproj --configuration Release
         workingDirectory: dotnet
-        displayName: 'Build .NET solution'
+        displayName: 'Build integration test projects'
+
+      - bash: df -h
+        condition: always()
+        displayName: 'Disk space (after build)'
 
       - task: AzureCLI@2
         displayName: 'Run DurableTask integration tests'
@@ -55,6 +70,10 @@ jobs:
           AZURE_OPENAI_ENDPOINT: $(AZURE_OPENAI_ENDPOINT)
           AZURE_OPENAI_DEPLOYMENT_NAME: $(AZURE_OPENAI_DEPLOYMENT_NAME)
           AZURE_OPENAI_CHAT_DEPLOYMENT_NAME: $(AZURE_OPENAI_DEPLOYMENT_NAME)
+
+      - bash: df -h
+        condition: always()
+        displayName: 'Disk space (after DurableTask tests)'
 
       - task: AzureCLI@2
         displayName: 'Run Azure Functions integration tests'

--- a/eng/templates/jobs/dotnet-e2e-tests.yml
+++ b/eng/templates/jobs/dotnet-e2e-tests.yml
@@ -13,6 +13,11 @@ jobs:
     steps:
       - checkout: self
 
+      # Disk usage baseline, before we add anything (Docker images, func, packages). This
+      # shows how much the pool image itself leaves free on the single OS disk.
+      - bash: df -h
+        displayName: 'Disk space (image baseline)'
+
       - task: UseDotNet@2
         displayName: 'Use .NET SDK from global.json'
         inputs:
@@ -29,7 +34,7 @@ jobs:
         displayName: 'Authenticate to Azure Artifacts feed'
 
       - bash: df -h
-        displayName: 'Disk space (baseline)'
+        displayName: 'Disk space (after infra setup)'
 
       # Build only the integration test projects. The tests build the specific
       # samples they exercise at runtime, so building the full solution (32 sample
@@ -41,6 +46,14 @@ jobs:
           dotnet build tests/Microsoft.Agents.AI.Hosting.AzureFunctions.IntegrationTests/Microsoft.Agents.AI.Hosting.AzureFunctions.IntegrationTests.csproj --configuration Release
         workingDirectory: dotnet
         displayName: 'Build integration test projects'
+
+      # Reclaim disk: the NuGet http-cache holds compressed downloads that are no
+      # longer needed once packages are extracted into the global packages folder.
+      # The global packages folder itself is kept for the runtime sample builds.
+      - bash: |
+          dotnet nuget locals http-cache --clear
+          dotnet nuget locals temp --clear
+        displayName: 'Clear NuGet download caches'
 
       - bash: df -h
         condition: always()

--- a/eng/templates/jobs/dotnet-e2e-tests.yml
+++ b/eng/templates/jobs/dotnet-e2e-tests.yml
@@ -1,16 +1,15 @@
+parameters:
+  - name: azureServiceConnection
+    type: string
+
 jobs:
   - job: DotNetE2E
     displayName: '.NET E2E tests'
     timeoutInMinutes: 90
-    pool:
-      name: 1es-pool-azfunc
-      image: 1es-ubuntu-22.04
-      os: linux
     variables:
       DURABLE_TASK_SCHEDULER_CONNECTION_STRING: 'Endpoint=http://localhost:8080;TaskHub=default;Authentication=None'
       AzureWebJobsStorage: 'UseDevelopmentStorage=true'
       REDIS_CONNECTION_STRING: 'localhost:6379'
-      NUGET_CERT_REVOCATION_MODE: offline
     steps:
       - checkout: self
 
@@ -31,32 +30,50 @@ jobs:
         workingDirectory: dotnet
         displayName: 'Build .NET solution'
 
-      - bash: |
-          mkdir -p ../artifacts/test-results
-          dotnet test tests/Microsoft.Agents.AI.DurableTask.IntegrationTests/Microsoft.Agents.AI.DurableTask.IntegrationTests.csproj --configuration Release --no-build --report-xunit-trx --results-directory ../artifacts/test-results
-        workingDirectory: dotnet
+      - task: AzureCLI@2
         displayName: 'Run DurableTask integration tests'
+        inputs:
+          azureSubscription: ${{ parameters.azureServiceConnection }}
+          scriptType: bash
+          scriptLocation: inlineScript
+          workingDirectory: $(Build.SourcesDirectory)/dotnet
+          inlineScript: |
+            mkdir -p ../artifacts/test-results
+            dotnet test tests/Microsoft.Agents.AI.DurableTask.IntegrationTests/Microsoft.Agents.AI.DurableTask.IntegrationTests.csproj \
+              --configuration Release \
+              --no-build \
+              --filter-not-trait Category=IntegrationDisabled \
+              --report-xunit-trx \
+              --results-directory ../artifacts/test-results
         env:
           AZURE_OPENAI_ENDPOINT: $(AZURE_OPENAI_ENDPOINT)
           AZURE_OPENAI_DEPLOYMENT_NAME: $(AZURE_OPENAI_DEPLOYMENT_NAME)
           AZURE_OPENAI_CHAT_DEPLOYMENT_NAME: $(AZURE_OPENAI_DEPLOYMENT_NAME)
-          AZURE_OPENAI_API_KEY: $(AZURE_OPENAI_API_KEY)
 
-      - bash: |
-          mkdir -p ../artifacts/test-results
-          dotnet test tests/Microsoft.Agents.AI.Hosting.AzureFunctions.IntegrationTests/Microsoft.Agents.AI.Hosting.AzureFunctions.IntegrationTests.csproj --configuration Release --no-build --report-xunit-trx --results-directory ../artifacts/test-results
-        workingDirectory: dotnet
+      - task: AzureCLI@2
         displayName: 'Run Azure Functions integration tests'
+        inputs:
+          azureSubscription: ${{ parameters.azureServiceConnection }}
+          scriptType: bash
+          scriptLocation: inlineScript
+          workingDirectory: $(Build.SourcesDirectory)/dotnet
+          inlineScript: |
+            mkdir -p ../artifacts/test-results
+            dotnet test tests/Microsoft.Agents.AI.Hosting.AzureFunctions.IntegrationTests/Microsoft.Agents.AI.Hosting.AzureFunctions.IntegrationTests.csproj \
+              --configuration Release \
+              --no-build \
+              --report-xunit-trx \
+              --results-directory ../artifacts/test-results
         env:
           AZURE_OPENAI_ENDPOINT: $(AZURE_OPENAI_ENDPOINT)
           AZURE_OPENAI_DEPLOYMENT_NAME: $(AZURE_OPENAI_DEPLOYMENT_NAME)
           AZURE_OPENAI_CHAT_DEPLOYMENT_NAME: $(AZURE_OPENAI_DEPLOYMENT_NAME)
-          AZURE_OPENAI_API_KEY: $(AZURE_OPENAI_API_KEY)
 
       - task: PublishTestResults@2
         condition: always()
         inputs:
           testResultsFormat: VSTest
           testResultsFiles: 'artifacts/test-results/**/*.trx'
+          searchFolder: $(Build.SourcesDirectory)
           failTaskOnFailedTests: true
         displayName: 'Publish .NET test results'

--- a/eng/templates/jobs/dotnet-e2e-tests.yml
+++ b/eng/templates/jobs/dotnet-e2e-tests.yml
@@ -10,11 +10,6 @@ jobs:
       DURABLE_TASK_SCHEDULER_CONNECTION_STRING: 'Endpoint=http://localhost:8080;TaskHub=default;Authentication=None'
       AzureWebJobsStorage: 'UseDevelopmentStorage=true'
       REDIS_CONNECTION_STRING: 'localhost:6379'
-      # The agent OS disk (/) is nearly full from the base image, Docker images, and
-      # Azure Functions Core Tools. Keep the NuGet package cache and temp files on the
-      # roomier work volume so the .NET restore/build does not exhaust /.
-      NUGET_PACKAGES: $(Agent.TempDirectory)/.nuget/packages
-      TMPDIR: $(Agent.TempDirectory)
     steps:
       - checkout: self
 

--- a/eng/templates/jobs/dotnet-e2e-tests.yml
+++ b/eng/templates/jobs/dotnet-e2e-tests.yml
@@ -22,7 +22,10 @@ jobs:
 
       - template: setup-integration-infra.yml
 
-      - bash: dotnet restore agent-framework-durable-extension.slnx
+      - task: NuGetAuthenticate@1
+        displayName: 'Authenticate to Azure Artifacts feed'
+
+      - bash: dotnet restore agent-framework-durable-extension.slnx --configfile "$(Build.SourcesDirectory)/eng/nuget.ci.config"
         workingDirectory: dotnet
         displayName: 'Restore .NET solution'
 

--- a/eng/templates/jobs/dotnet-e2e-tests.yml
+++ b/eng/templates/jobs/dotnet-e2e-tests.yml
@@ -22,10 +22,13 @@ jobs:
 
       - template: setup-integration-infra.yml
 
+      - bash: cp "$(Build.SourcesDirectory)/eng/nuget.ci.config" "$(Build.SourcesDirectory)/dotnet/nuget.config"
+        displayName: 'Point NuGet at internal Azure Artifacts feed'
+
       - task: NuGetAuthenticate@1
         displayName: 'Authenticate to Azure Artifacts feed'
 
-      - bash: dotnet restore agent-framework-durable-extension.slnx --configfile "$(Build.SourcesDirectory)/eng/nuget.ci.config"
+      - bash: dotnet restore agent-framework-durable-extension.slnx
         workingDirectory: dotnet
         displayName: 'Restore .NET solution'
 

--- a/eng/templates/jobs/python-e2e-tests.yml
+++ b/eng/templates/jobs/python-e2e-tests.yml
@@ -19,11 +19,20 @@ jobs:
 
       - template: setup-integration-infra.yml
 
+      - task: PipAuthenticate@1
+        displayName: 'Authenticate to Azure Artifacts feed'
+        inputs:
+          artifactFeeds: 'internal/PythonSDK_Internal_PublicPackages'
+
       - bash: |
           uv python install 3.13
           uv sync --python 3.13 --all-packages --group dev --group test
         workingDirectory: python
         displayName: 'Sync Python workspace'
+        env:
+          # PipAuthenticate sets PIP_INDEX_URL (with a token) for the internal feed.
+          # uv reads UV_INDEX_URL first, so point it at the same authenticated URL.
+          UV_INDEX_URL: $(PIP_INDEX_URL)
 
       - task: AzureCLI@2
         displayName: 'Run Python integration tests'
@@ -34,7 +43,7 @@ jobs:
           workingDirectory: $(Build.SourcesDirectory)/python
           inlineScript: |
             mkdir -p ../artifacts/test-results
-            uv run pytest packages/durabletask/tests/integration_tests \
+            uv run --no-sync pytest packages/durabletask/tests/integration_tests \
               -m integration \
               -n logical \
               --dist worksteal \

--- a/eng/templates/jobs/python-e2e-tests.yml
+++ b/eng/templates/jobs/python-e2e-tests.yml
@@ -13,6 +13,7 @@ jobs:
       - checkout: self
 
       - bash: |
+          set -euo pipefail
           # Pin uv to the version declared in python/pyproject.toml for reproducible
           # CI. Astral publishes a versioned install script at astral.sh/uv/<version>.
           curl -LsSf https://astral.sh/uv/0.11.28/install.sh | sh

--- a/eng/templates/jobs/python-e2e-tests.yml
+++ b/eng/templates/jobs/python-e2e-tests.yml
@@ -28,6 +28,7 @@ jobs:
           artifactFeeds: 'internal/upstream'
 
       - bash: |
+          set -euo pipefail
           uv python install 3.13
           uv sync --python 3.13 --all-packages --group dev --group test
         workingDirectory: python

--- a/eng/templates/jobs/python-e2e-tests.yml
+++ b/eng/templates/jobs/python-e2e-tests.yml
@@ -1,21 +1,16 @@
+parameters:
+  - name: azureServiceConnection
+    type: string
+
 jobs:
   - job: PythonE2E
     displayName: 'Python E2E tests'
     timeoutInMinutes: 90
-    pool:
-      name: 1es-pool-azfunc
-      image: 1es-ubuntu-22.04
-      os: linux
     variables:
       DURABLE_TASK_SCHEDULER_CONNECTION_STRING: 'Endpoint=http://localhost:8080;TaskHub=default;Authentication=None'
       REDIS_CONNECTION_STRING: 'redis://localhost:6379'
     steps:
       - checkout: self
-
-      - task: UsePythonVersion@0
-        displayName: 'Use Python 3.13'
-        inputs:
-          versionSpec: '3.13'
 
       - bash: |
           curl -LsSf https://astral.sh/uv/install.sh | sh
@@ -24,26 +19,38 @@ jobs:
 
       - template: setup-integration-infra.yml
 
-      - bash: uv sync --all-packages --group dev --group test
+      - bash: |
+          uv python install 3.13
+          uv sync --python 3.13 --all-packages --group dev --group test
         workingDirectory: python
         displayName: 'Sync Python workspace'
 
-      - bash: |
-          mkdir -p ../artifacts/test-results
-          uv run pytest packages/durabletask/tests/integration_tests -m integration -n logical --dist worksteal --timeout 480 --junitxml ../artifacts/test-results/python-integration.xml
-        workingDirectory: python
+      - task: AzureCLI@2
         displayName: 'Run Python integration tests'
+        inputs:
+          azureSubscription: ${{ parameters.azureServiceConnection }}
+          scriptType: bash
+          scriptLocation: inlineScript
+          workingDirectory: $(Build.SourcesDirectory)/python
+          inlineScript: |
+            mkdir -p ../artifacts/test-results
+            uv run pytest packages/durabletask/tests/integration_tests \
+              -m integration \
+              -n logical \
+              --dist worksteal \
+              --timeout 480 \
+              --junitxml ../artifacts/test-results/python-integration.xml
         env:
           FOUNDRY_PROJECT_ENDPOINT: $(FOUNDRY_PROJECT_ENDPOINT)
           FOUNDRY_MODEL: $(FOUNDRY_MODEL)
           AZURE_OPENAI_ENDPOINT: $(AZURE_OPENAI_ENDPOINT)
-          AZURE_OPENAI_MODEL: $(AZURE_OPENAI_MODEL)
-          AZURE_OPENAI_API_KEY: $(AZURE_OPENAI_API_KEY)
+          AZURE_OPENAI_MODEL: $(AZURE_OPENAI_DEPLOYMENT_NAME)
 
       - task: PublishTestResults@2
         condition: always()
         inputs:
           testResultsFormat: JUnit
           testResultsFiles: 'artifacts/test-results/python-integration.xml'
+          searchFolder: $(Build.SourcesDirectory)
           failTaskOnFailedTests: true
         displayName: 'Publish Python test results'

--- a/eng/templates/jobs/python-e2e-tests.yml
+++ b/eng/templates/jobs/python-e2e-tests.yml
@@ -13,7 +13,9 @@ jobs:
       - checkout: self
 
       - bash: |
-          curl -LsSf https://astral.sh/uv/install.sh | sh
+          # Pin uv to the version declared in python/pyproject.toml for reproducible
+          # CI. Astral publishes a versioned install script at astral.sh/uv/<version>.
+          curl -LsSf https://astral.sh/uv/0.11.28/install.sh | sh
           echo "##vso[task.prependpath]$HOME/.local/bin"
         displayName: 'Install uv'
 

--- a/eng/templates/jobs/python-e2e-tests.yml
+++ b/eng/templates/jobs/python-e2e-tests.yml
@@ -22,7 +22,7 @@ jobs:
       - task: PipAuthenticate@1
         displayName: 'Authenticate to Azure Artifacts feed'
         inputs:
-          artifactFeeds: 'internal/PythonSDK_Internal_PublicPackages'
+          artifactFeeds: 'internal/upstream'
 
       - bash: |
           uv python install 3.13

--- a/eng/templates/jobs/setup-integration-infra.yml
+++ b/eng/templates/jobs/setup-integration-infra.yml
@@ -38,14 +38,16 @@ steps:
       timeout 60 bash -c 'until docker exec redis redis-cli ping | grep -q PONG; do sleep 2; done'
     displayName: 'Start Redis'
 
-  - task: UseNode@1
-    displayName: 'Use Node.js 22'
-    inputs:
-      version: '22.x'
-
   - bash: |
       set -euo pipefail
 
-      npm install -g azure-functions-core-tools@4 --unsafe-perm true
+      # Azure Functions Core Tools. The governed 1ES pool cannot reach npmjs.org,
+      # so install from Microsoft's package feed (packages.microsoft.com) instead
+      # of npm. This is Microsoft's documented Linux install path for func v4.
+      ubuntu_version="$(lsb_release -rs)"
+      wget -q "https://packages.microsoft.com/config/ubuntu/${ubuntu_version}/packages-microsoft-prod.deb" -O /tmp/packages-microsoft-prod.deb
+      sudo dpkg -i /tmp/packages-microsoft-prod.deb
+      sudo apt-get update
+      sudo apt-get install -y azure-functions-core-tools-4
       func --version
     displayName: 'Install Azure Functions Core Tools'

--- a/eng/templates/jobs/setup-integration-infra.yml
+++ b/eng/templates/jobs/setup-integration-infra.yml
@@ -50,4 +50,9 @@ steps:
       sudo apt-get update
       sudo apt-get install -y azure-functions-core-tools-4
       func --version
+
+      # Reclaim disk on the OS volume (/): the apt cache and package lists are no
+      # longer needed after install, and the agent OS disk is space-constrained.
+      sudo apt-get clean
+      sudo rm -rf /var/lib/apt/lists/*
     displayName: 'Install Azure Functions Core Tools'

--- a/eng/templates/jobs/setup-integration-infra.yml
+++ b/eng/templates/jobs/setup-integration-infra.yml
@@ -31,7 +31,9 @@ steps:
         docker rm -f redis
       fi
 
-      docker run -d --name redis -p 6379:6379 redis:latest
+      # Docker Hub is not reachable from the governed 1ES pool, so pull Redis from
+      # Microsoft's Docker Hub mirror on MCR (same source style as the images above).
+      docker run -d --name redis -p 6379:6379 mcr.microsoft.com/mirror/docker/library/redis:latest
       timeout 60 bash -c 'until docker exec redis redis-cli ping | grep -q PONG; do sleep 2; done'
     displayName: 'Start Redis'
 

--- a/eng/templates/jobs/setup-integration-infra.yml
+++ b/eng/templates/jobs/setup-integration-infra.yml
@@ -44,9 +44,17 @@ steps:
       # Azure Functions Core Tools. The governed 1ES pool cannot reach npmjs.org,
       # so install from Microsoft's package feed (packages.microsoft.com) instead
       # of npm. This is Microsoft's documented Linux install path for func v4.
-      ubuntu_version="$(lsb_release -rs)"
-      wget -q "https://packages.microsoft.com/config/ubuntu/${ubuntu_version}/packages-microsoft-prod.deb" -O /tmp/packages-microsoft-prod.deb
-      sudo dpkg -i /tmp/packages-microsoft-prod.deb
+      #
+      # The 1ES image usually already has the Microsoft feed configured, so only add
+      # it when missing. This avoids downgrading the image's packages-microsoft-prod
+      # and skips a redundant download.
+      if ! grep -rqi "packages.microsoft.com" /etc/apt/sources.list /etc/apt/sources.list.d 2>/dev/null; then
+        ubuntu_version="$(lsb_release -rs)"
+        wget -q "https://packages.microsoft.com/config/ubuntu/${ubuntu_version}/packages-microsoft-prod.deb" -O /tmp/packages-microsoft-prod.deb
+        sudo dpkg -i /tmp/packages-microsoft-prod.deb
+        rm -f /tmp/packages-microsoft-prod.deb
+      fi
+
       sudo apt-get update
       sudo apt-get install -y azure-functions-core-tools-4
       func --version

--- a/eng/templates/jobs/setup-integration-infra.yml
+++ b/eng/templates/jobs/setup-integration-infra.yml
@@ -49,7 +49,9 @@ steps:
       # it when missing. This avoids downgrading the image's packages-microsoft-prod
       # and skips a redundant download.
       if ! grep -rqi "packages.microsoft.com" /etc/apt/sources.list /etc/apt/sources.list.d 2>/dev/null; then
-        ubuntu_version="$(lsb_release -rs)"
+        # Read the Ubuntu version from /etc/os-release rather than lsb_release, which
+        # is not guaranteed to be installed on minimal images.
+        ubuntu_version="$(. /etc/os-release && echo "$VERSION_ID")"
         wget -q "https://packages.microsoft.com/config/ubuntu/${ubuntu_version}/packages-microsoft-prod.deb" -O /tmp/packages-microsoft-prod.deb
         sudo dpkg -i /tmp/packages-microsoft-prod.deb
         rm -f /tmp/packages-microsoft-prod.deb

--- a/eng/templates/jobs/setup-integration-infra.yml
+++ b/eng/templates/jobs/setup-integration-infra.yml
@@ -32,8 +32,9 @@ steps:
       fi
 
       # Docker Hub is not reachable from the governed 1ES pool, so pull Redis from
-      # Microsoft's Docker Hub mirror on MCR (same source style as the images above).
-      docker run -d --name redis -p 6379:6379 mcr.microsoft.com/mirror/docker/library/redis:latest
+      # Microsoft's Docker Hub mirror on MCR. The mirror only publishes specific
+      # version tags (6, 7, 7.0, 7.2) and no 'latest' tag.
+      docker run -d --name redis -p 6379:6379 mcr.microsoft.com/mirror/docker/library/redis:7
       timeout 60 bash -c 'until docker exec redis redis-cli ping | grep -q PONG; do sleep 2; done'
     displayName: 'Start Redis'
 

--- a/eng/templates/jobs/setup-integration-infra.yml
+++ b/eng/templates/jobs/setup-integration-infra.yml
@@ -1,4 +1,7 @@
 steps:
+  - bash: docker version
+    displayName: 'Check Docker'
+
   - bash: |
       set -euo pipefail
 
@@ -31,6 +34,11 @@ steps:
       docker run -d --name redis -p 6379:6379 redis:latest
       timeout 60 bash -c 'until docker exec redis redis-cli ping | grep -q PONG; do sleep 2; done'
     displayName: 'Start Redis'
+
+  - task: UseNode@1
+    displayName: 'Use Node.js 22'
+    inputs:
+      version: '22.x'
 
   - bash: |
       set -euo pipefail

--- a/eng/templates/official/jobs/build-packages.yml
+++ b/eng/templates/official/jobs/build-packages.yml
@@ -27,6 +27,14 @@ jobs:
         inputs:
           versionSpec: '3.13'
 
+      # Authenticate to the internal feed before installing uv. The governed pool
+      # cannot reach PyPI directly, so pip must use the authenticated feed (via the
+      # PIP_INDEX_URL this task sets) to install uv.
+      - task: PipAuthenticate@1
+        displayName: 'Authenticate to Azure Artifacts feed'
+        inputs:
+          artifactFeeds: 'internal/upstream'
+
       - pwsh: python -m pip install --upgrade uv
         displayName: 'Install uv'
 
@@ -66,11 +74,6 @@ jobs:
           dotnet pack src/Microsoft.Agents.AI.Hosting.AzureFunctions/Microsoft.Agents.AI.Hosting.AzureFunctions.csproj --configuration Release --no-build --output "$(Build.ArtifactStagingDirectory)/packages/dotnet"
         workingDirectory: dotnet
         displayName: 'Pack .NET packages'
-
-      - task: PipAuthenticate@1
-        displayName: 'Authenticate to Azure Artifacts feed'
-        inputs:
-          artifactFeeds: 'internal/upstream'
 
       - pwsh: uv sync --all-packages --group dev --group test
         workingDirectory: python

--- a/eng/templates/official/jobs/build-packages.yml
+++ b/eng/templates/official/jobs/build-packages.yml
@@ -35,7 +35,7 @@ jobs:
         inputs:
           artifactFeeds: 'internal/upstream'
 
-      - pwsh: python -m pip install --upgrade uv
+      - pwsh: python -m pip install uv==0.11.28
         displayName: 'Install uv'
 
       - pwsh: Copy-Item "$(Build.SourcesDirectory)/eng/nuget.ci.config" "$(Build.SourcesDirectory)/dotnet/nuget.config" -Force

--- a/eng/templates/official/jobs/build-packages.yml
+++ b/eng/templates/official/jobs/build-packages.yml
@@ -30,7 +30,10 @@ jobs:
       - pwsh: python -m pip install --upgrade uv
         displayName: 'Install uv'
 
-      - pwsh: dotnet restore agent-framework-durable-extension.slnx
+      - task: NuGetAuthenticate@1
+        displayName: 'Authenticate to Azure Artifacts feed'
+
+      - pwsh: dotnet restore agent-framework-durable-extension.slnx --configfile "$(Build.SourcesDirectory)/eng/nuget.ci.config"
         workingDirectory: dotnet
         displayName: 'Restore .NET solution'
 
@@ -61,9 +64,16 @@ jobs:
         workingDirectory: dotnet
         displayName: 'Pack .NET packages'
 
+      - task: PipAuthenticate@1
+        displayName: 'Authenticate to Azure Artifacts feed'
+        inputs:
+          artifactFeeds: 'internal/PythonSDK_Internal_PublicPackages'
+
       - pwsh: uv sync --all-packages --group dev --group test
         workingDirectory: python
         displayName: 'Sync Python workspace'
+        env:
+          UV_INDEX_URL: $(PIP_INDEX_URL)
 
       - pwsh: uv run ruff check packages/durabletask
         workingDirectory: python

--- a/eng/templates/official/jobs/build-packages.yml
+++ b/eng/templates/official/jobs/build-packages.yml
@@ -109,6 +109,10 @@ jobs:
           uv build packages/durabletask --out-dir "$(Build.ArtifactStagingDirectory)/packages/python"
         workingDirectory: python
         displayName: 'Build Python package'
+        env:
+          # uv build resolves the build backend (flit-core) in an isolated environment.
+          # The governed pool blocks PyPI, so point uv at the authenticated internal feed.
+          UV_INDEX_URL: $(PIP_INDEX_URL)
 
       - pwsh: Get-ChildItem -Recurse "$(Build.ArtifactStagingDirectory)/packages" | Select-Object -ExpandProperty FullName
         displayName: 'List package artifacts'

--- a/eng/templates/official/jobs/build-packages.yml
+++ b/eng/templates/official/jobs/build-packages.yml
@@ -30,10 +30,13 @@ jobs:
       - pwsh: python -m pip install --upgrade uv
         displayName: 'Install uv'
 
+      - pwsh: Copy-Item "$(Build.SourcesDirectory)/eng/nuget.ci.config" "$(Build.SourcesDirectory)/dotnet/nuget.config" -Force
+        displayName: 'Point NuGet at internal Azure Artifacts feed'
+
       - task: NuGetAuthenticate@1
         displayName: 'Authenticate to Azure Artifacts feed'
 
-      - pwsh: dotnet restore agent-framework-durable-extension.slnx --configfile "$(Build.SourcesDirectory)/eng/nuget.ci.config"
+      - pwsh: dotnet restore agent-framework-durable-extension.slnx
         workingDirectory: dotnet
         displayName: 'Restore .NET solution'
 

--- a/eng/templates/official/jobs/build-packages.yml
+++ b/eng/templates/official/jobs/build-packages.yml
@@ -70,7 +70,7 @@ jobs:
       - task: PipAuthenticate@1
         displayName: 'Authenticate to Azure Artifacts feed'
         inputs:
-          artifactFeeds: 'internal/PythonSDK_Internal_PublicPackages'
+          artifactFeeds: 'internal/upstream'
 
       - pwsh: uv sync --all-packages --group dev --group test
         workingDirectory: python

--- a/eng/templates/official/jobs/build-packages.yml
+++ b/eng/templates/official/jobs/build-packages.yml
@@ -6,10 +6,6 @@ parameters:
 jobs:
   - job: BuildPackages
     displayName: 'Build package artifacts'
-    pool:
-      name: 1es-pool-azfunc
-      image: 1es-ubuntu-22.04
-      os: linux
     templateContext:
       outputParentDirectory: $(Build.ArtifactStagingDirectory)
       outputs:
@@ -31,54 +27,72 @@ jobs:
         inputs:
           versionSpec: '3.13'
 
-      - bash: |
-          curl -LsSf https://astral.sh/uv/install.sh | sh
-          echo "##vso[task.prependpath]$HOME/.local/bin"
+      - pwsh: python -m pip install --upgrade uv
         displayName: 'Install uv'
 
-      - bash: dotnet restore agent-framework-durable-extension.slnx
+      - pwsh: dotnet restore agent-framework-durable-extension.slnx
         workingDirectory: dotnet
         displayName: 'Restore .NET solution'
 
-      - bash: dotnet build agent-framework-durable-extension.slnx --configuration Release --no-restore
+      - pwsh: dotnet build agent-framework-durable-extension.slnx --configuration Release --no-restore
         workingDirectory: dotnet
         displayName: 'Build .NET solution'
 
-      - bash: |
-          mkdir -p ../artifacts/test-results
+      - pwsh: |
+          New-Item -ItemType Directory -Force -Path ../artifacts/test-results | Out-Null
           dotnet test tests/Microsoft.Agents.AI.DurableTask.UnitTests/Microsoft.Agents.AI.DurableTask.UnitTests.csproj --configuration Release --no-build --report-xunit-trx --results-directory ../artifacts/test-results
           dotnet test tests/Microsoft.Agents.AI.Hosting.AzureFunctions.UnitTests/Microsoft.Agents.AI.Hosting.AzureFunctions.UnitTests.csproj --configuration Release --no-build --report-xunit-trx --results-directory ../artifacts/test-results
         workingDirectory: dotnet
         displayName: 'Run .NET unit tests'
 
-      - bash: |
-          mkdir -p "$(Build.ArtifactStagingDirectory)/packages/dotnet"
+      - task: PublishTestResults@2
+        condition: always()
+        displayName: 'Publish .NET test results'
+        inputs:
+          testResultsFormat: VSTest
+          testResultsFiles: 'artifacts/test-results/**/*.trx'
+          searchFolder: $(Build.SourcesDirectory)
+          failTaskOnFailedTests: true
+
+      - pwsh: |
+          New-Item -ItemType Directory -Force -Path "$(Build.ArtifactStagingDirectory)/packages/dotnet" | Out-Null
           dotnet pack src/Microsoft.Agents.AI.DurableTask/Microsoft.Agents.AI.DurableTask.csproj --configuration Release --no-build --output "$(Build.ArtifactStagingDirectory)/packages/dotnet"
           dotnet pack src/Microsoft.Agents.AI.Hosting.AzureFunctions/Microsoft.Agents.AI.Hosting.AzureFunctions.csproj --configuration Release --no-build --output "$(Build.ArtifactStagingDirectory)/packages/dotnet"
         workingDirectory: dotnet
         displayName: 'Pack .NET packages'
 
-      - bash: uv sync --all-packages --group dev --group test
+      - pwsh: uv sync --all-packages --group dev --group test
         workingDirectory: python
         displayName: 'Sync Python workspace'
 
-      - bash: uv run ruff check packages/durabletask
+      - pwsh: uv run ruff check packages/durabletask
         workingDirectory: python
         displayName: 'Run Python lint'
 
-      - bash: uv run mypy --config-file packages/durabletask/pyproject.toml packages/durabletask/agent_framework_durabletask
+      - pwsh: uv run mypy --config-file packages/durabletask/pyproject.toml packages/durabletask/agent_framework_durabletask
         workingDirectory: python
         displayName: 'Run Python type check'
 
-      - bash: uv run pytest -m "not integration" packages/durabletask/tests
+      - pwsh: |
+          New-Item -ItemType Directory -Force -Path ../artifacts/test-results | Out-Null
+          uv run pytest -m "not integration" packages/durabletask/tests --junitxml ../artifacts/test-results/python-unit.xml
         workingDirectory: python
         displayName: 'Run Python unit tests'
 
-      - bash: |
-          mkdir -p "$(Build.ArtifactStagingDirectory)/packages/python"
+      - task: PublishTestResults@2
+        condition: always()
+        displayName: 'Publish Python test results'
+        inputs:
+          testResultsFormat: JUnit
+          testResultsFiles: 'artifacts/test-results/python-unit.xml'
+          searchFolder: $(Build.SourcesDirectory)
+          failTaskOnFailedTests: true
+
+      - pwsh: |
+          New-Item -ItemType Directory -Force -Path "$(Build.ArtifactStagingDirectory)/packages/python" | Out-Null
           uv build packages/durabletask --out-dir "$(Build.ArtifactStagingDirectory)/packages/python"
         workingDirectory: python
         displayName: 'Build Python package'
 
-      - bash: find "$(Build.ArtifactStagingDirectory)/packages" -type f | sort
+      - pwsh: Get-ChildItem -Recurse "$(Build.ArtifactStagingDirectory)/packages" | Select-Object -ExpandProperty FullName
         displayName: 'List package artifacts'

--- a/eng/templates/official/jobs/publish-packages.yml
+++ b/eng/templates/official/jobs/publish-packages.yml
@@ -81,6 +81,14 @@ jobs:
         inputs:
           versionSpec: '3.13'
 
+      # Authenticate to the internal feed before installing twine. The governed pool
+      # cannot reach PyPI directly, so pip must install twine from the authenticated
+      # feed (via the PIP_INDEX_URL this task sets).
+      - task: PipAuthenticate@1
+        displayName: 'Authenticate to Azure Artifacts feed'
+        inputs:
+          artifactFeeds: 'internal/upstream'
+
       - pwsh: python -m pip install --upgrade pip twine
         displayName: 'Install Twine'
 

--- a/eng/templates/official/jobs/publish-packages.yml
+++ b/eng/templates/official/jobs/publish-packages.yml
@@ -8,6 +8,12 @@ parameters:
   - name: publishPython
     type: boolean
     default: false
+  - name: nugetServiceConnection
+    type: string
+    default: 'agent-framework-durable-extension-nuget-org'
+  - name: pypiServiceConnection
+    type: string
+    default: 'agent-framework-durable-extension-pypi'
 
 jobs:
   - job: ValidateRelease
@@ -28,52 +34,24 @@ jobs:
     dependsOn: ValidateRelease
     condition: and(succeeded(), ${{ eq(parameters.publishDotNet, true) }})
     displayName: 'Publish .NET packages'
-    pool:
-      name: 1es-pool-azfunc
-      image: 1es-ubuntu-22.04
-      os: linux
     steps:
       - checkout: none
-
-      - task: UseDotNet@2
-        displayName: 'Use .NET SDK 10.0.x'
-        inputs:
-          packageType: sdk
-          version: 10.0.x
 
       - download: current
         artifact: ${{ parameters.artifactName }}
 
-      - bash: |
-          set -euo pipefail
-          shopt -s nullglob
-
-          packages=("$(Pipeline.Workspace)/${{ parameters.artifactName }}/dotnet"/*.nupkg)
-          if [ ${#packages[@]} -eq 0 ]; then
-            echo "No .nupkg files found"
-            exit 1
-          fi
-
-          for package in "${packages[@]}"; do
-            dotnet nuget push "$package" --source https://api.nuget.org/v3/index.json --api-key "$NUGET_API_KEY" --skip-duplicate
-          done
-
-          symbols=("$(Pipeline.Workspace)/${{ parameters.artifactName }}/dotnet"/*.snupkg)
-          for symbols_package in "${symbols[@]}"; do
-            dotnet nuget push "$symbols_package" --source https://api.nuget.org/v3/index.json --api-key "$NUGET_API_KEY" --skip-duplicate
-          done
-        displayName: 'Push .NET packages to NuGet'
-        env:
-          NUGET_API_KEY: $(NUGET_API_KEY)
+      - task: NuGetCommand@2
+        displayName: 'Push .NET packages to NuGet.org'
+        inputs:
+          command: push
+          packagesToPush: '$(Pipeline.Workspace)/${{ parameters.artifactName }}/dotnet/*.nupkg'
+          nuGetFeedType: external
+          publishFeedCredentials: ${{ parameters.nugetServiceConnection }}
 
   - job: PublishPython
     dependsOn: ValidateRelease
     condition: and(succeeded(), ${{ eq(parameters.publishPython, true) }})
     displayName: 'Publish Python package'
-    pool:
-      name: 1es-pool-azfunc
-      image: 1es-ubuntu-22.04
-      os: linux
     steps:
       - checkout: none
 
@@ -85,11 +63,24 @@ jobs:
         inputs:
           versionSpec: '3.13'
 
-      - bash: |
-          set -euo pipefail
-          python -m pip install --upgrade pip twine
-          python -m twine upload --non-interactive "$(Pipeline.Workspace)/${{ parameters.artifactName }}/python"/*
+      - pwsh: python -m pip install --upgrade pip twine
+        displayName: 'Install Twine'
+
+      - task: TwineAuthenticate@1
+        displayName: 'Authenticate to PyPI'
+        inputs:
+          pythonUploadServiceConnection: ${{ parameters.pypiServiceConnection }}
+
+      - pwsh: |
+          $packages = Get-ChildItem -File "$(Pipeline.Workspace)/${{ parameters.artifactName }}/python" |
+            Where-Object { $_.Name.EndsWith(".whl") -or $_.Name.EndsWith(".tar.gz") }
+          if ($packages.Count -eq 0) {
+            throw "No Python packages were found."
+          }
+
+          python -m twine upload `
+            --non-interactive `
+            --repository "${{ parameters.pypiServiceConnection }}" `
+            --config-file "$(PYPIRC_PATH)" `
+            @($packages.FullName)
         displayName: 'Upload Python package to PyPI'
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: $(PYPI_TOKEN)

--- a/eng/templates/official/jobs/publish-packages.yml
+++ b/eng/templates/official/jobs/publish-packages.yml
@@ -40,6 +40,12 @@ jobs:
       - download: current
         artifact: ${{ parameters.artifactName }}
 
+      # Note on reruns: NuGetCommand@2's skip-duplicate (allowPackageConflicts) only
+      # applies to Azure Artifacts feeds, not external registries like NuGet.org, so it
+      # is not set here. A rerun that re-pushes an already-published version will fail
+      # with HTTP 409. Releases bump the package version each time, and publishing is
+      # gated behind the manual validation above, so this is expected: on a partial
+      # failure, bump the version or remove the already-published package before rerunning.
       - task: NuGetCommand@2
         displayName: 'Push .NET packages to NuGet.org'
         inputs:

--- a/eng/templates/official/jobs/publish-packages.yml
+++ b/eng/templates/official/jobs/publish-packages.yml
@@ -48,6 +48,18 @@ jobs:
           nuGetFeedType: external
           publishFeedCredentials: ${{ parameters.nugetServiceConnection }}
 
+      # NuGetCommand@2 does not auto-push co-located symbol packages, so publish the
+      # .snupkg files explicitly. The repo produces symbol packages (IncludeSymbols +
+      # SymbolPackageFormat=snupkg in dotnet/nuget/nuget-package.props); without this
+      # step, symbols would silently stop reaching NuGet.org's symbol server.
+      - task: NuGetCommand@2
+        displayName: 'Push .NET symbol packages to NuGet.org'
+        inputs:
+          command: push
+          packagesToPush: '$(Pipeline.Workspace)/${{ parameters.artifactName }}/dotnet/*.snupkg'
+          nuGetFeedType: external
+          publishFeedCredentials: ${{ parameters.nugetServiceConnection }}
+
   - job: PublishPython
     dependsOn: ValidateRelease
     condition: and(succeeded(), ${{ eq(parameters.publishPython, true) }})
@@ -71,6 +83,9 @@ jobs:
         inputs:
           pythonUploadServiceConnection: ${{ parameters.pypiServiceConnection }}
 
+      # TwineAuthenticate writes a .pypirc whose repository section is named after the
+      # service connection, so `--repository` must be that same service connection name
+      # (this matches the documented pattern for external PyPI upload connections).
       - pwsh: |
           $packages = Get-ChildItem -File "$(Pipeline.Workspace)/${{ parameters.artifactName }}/python" |
             Where-Object { $_.Name.EndsWith(".whl") -or $_.Name.EndsWith(".tar.gz") }

--- a/eng/templates/official/jobs/publish-packages.yml
+++ b/eng/templates/official/jobs/publish-packages.yml
@@ -101,8 +101,10 @@ jobs:
       # service connection, so `--repository` must be that same service connection name
       # (this matches the documented pattern for external PyPI upload connections).
       - pwsh: |
-          $packages = Get-ChildItem -File "$(Pipeline.Workspace)/${{ parameters.artifactName }}/python" |
-            Where-Object { $_.Name.EndsWith(".whl") -or $_.Name.EndsWith(".tar.gz") }
+          # Force array context with @(...) so .Count is reliable even when
+          # Get-ChildItem returns nothing ($null) or a single item.
+          $packages = @(Get-ChildItem -File "$(Pipeline.Workspace)/${{ parameters.artifactName }}/python" |
+            Where-Object { $_.Name.EndsWith(".whl") -or $_.Name.EndsWith(".tar.gz") })
           if ($packages.Count -eq 0) {
             throw "No Python packages were found."
           }

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -49,6 +49,10 @@ test = [
     "azure-monitor-opentelemetry",
     "mcp[ws]",
     "redis",
+    # Model provider packages used by the sample workers that the integration
+    # tests launch as subprocesses (agent_framework.openai / agent_framework.foundry).
+    "agent-framework-openai>=1.10.1,<2",
+    "agent-framework-foundry>=1.10.1,<2",
 ]
 
 [tool.uv]


### PR DESCRIPTION
## Summary

This PR updates the E2E test pipeline definition & setup to work correctly with an internally managed ADO mirror that has governed pipeline support. The previously generated e2e-tests.yml was not correctly set up to work in this kind of setup.

## Notable changes

One big change that was made is the removal of API keys for accessing Foundry / Azure OpenAI models. The governed ADO pipeline has been set up to allow using a user-defined managed identity to access the Foundry-hosted models, so there are no secrets anywhere (yay!), making it more secure than the previous MAF pipeline.

## Validation

I have verified that both the .NET and Python E2E tests are working with this configuration. There is still work to enable some tests that were previously disabled in the MAF repo, but we can do that in a later PR.

## Running E2E tests

E2E tests are currently set up to run daily. They will not run as part of a GitHub PR since only the ADO mirror can trigger the pipeline. They can also be run manually in ADO. If they need to be run manually to validate a PR, the PR branch will need to first be manually pushed to the mirrored repo.

This is something we can look into improving further in a later PR.