### PR TITLE
Ensure RequestPort responses only populate the result property

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI.DurableTask/CHANGELOG.md
+++ b/dotnet/src/Microsoft.Agents.AI.DurableTask/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Wrap RequestPort external responses in a controlled `DurableExecutorOutput` envelope so that only the `result` property is populated during deserialization ([#20](https://github.com/microsoft/agent-framework-durable-extension/pull/20))
 - Bound the live workflow status to a trailing event window so multi-executor workflows with large typed outputs no longer overflow the Durable Task 16&#160;KB custom status cap ([#6775](https://github.com/microsoft/agent-framework/pull/6775))
 - Fixed `WorkflowOutputEvent` streaming deserialization to read `executorId` instead of the renamed `sourceId` property, with fallback for backward compatibility ([#6896](https://github.com/microsoft/agent-framework/pull/6896))
 - Fix issue with resuming checkpoint after package version upgrade ([#6670](https://github.com/microsoft/agent-framework/pull/6670))

--- a/dotnet/src/Microsoft.Agents.AI.DurableTask/Workflows/DurableExecutorDispatcher.cs
+++ b/dotnet/src/Microsoft.Agents.AI.DurableTask/Workflows/DurableExecutorDispatcher.cs
@@ -129,10 +129,26 @@ internal static class DurableExecutorDispatcher
 
         logger.LogReceivedExternalEvent(eventName);
 
-        // Wrap the external response in a DurableExecutorOutput envelope so that
-        // ProcessSuperstepResults handles it consistently with activity results.
-        DurableExecutorOutput output = new() { Result = response };
-        return JsonSerializer.Serialize(output, DurableWorkflowJsonContext.Default.DurableExecutorOutput);
+        return CreateExecutorOutputEnvelope(response);
+    }
+
+    /// <summary>
+    /// Instead of blindly taking the incoming JSON to produce the output of the executor,
+    /// builds a <see cref="DurableExecutorOutput"/>-compatible JSON envelope where only
+    /// the <c>result</c> property is set from the response value.
+    /// Other properties are serialized with their defaults (empty collections).
+    /// This prevents the incoming JSON payload from inadvertently populating other properties
+    /// of <see cref="DurableExecutorOutput"/> during deserialization.
+    /// </summary>
+    /// <example>
+    /// For input <c>{"Approved":true,"Comments":"ok"}</c>, produces:
+    /// <c>{"result":"{\"Approved\":true,\"Comments\":\"ok\"}","stateUpdates":{},"clearedScopes":[],"events":[],"sentMessages":[]}</c>
+    /// </example>
+    internal static string CreateExecutorOutputEnvelope(string response)
+    {
+        return JsonSerializer.Serialize(
+            new DurableExecutorOutput { Result = response },
+            DurableWorkflowJsonContext.Default.DurableExecutorOutput);
     }
 
     /// <summary>

--- a/dotnet/src/Microsoft.Agents.AI.DurableTask/Workflows/DurableExecutorDispatcher.cs
+++ b/dotnet/src/Microsoft.Agents.AI.DurableTask/Workflows/DurableExecutorDispatcher.cs
@@ -129,7 +129,10 @@ internal static class DurableExecutorDispatcher
 
         logger.LogReceivedExternalEvent(eventName);
 
-        return response;
+        // Wrap the external response in a DurableExecutorOutput envelope so that
+        // ProcessSuperstepResults handles it consistently with activity results.
+        DurableExecutorOutput output = new() { Result = response };
+        return JsonSerializer.Serialize(output, DurableWorkflowJsonContext.Default.DurableExecutorOutput);
     }
 
     /// <summary>

--- a/dotnet/tests/Microsoft.Agents.AI.DurableTask.UnitTests/Workflows/DurableExecutorDispatcherTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.DurableTask.UnitTests/Workflows/DurableExecutorDispatcherTests.cs
@@ -1,0 +1,89 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System.Text.Json;
+using Microsoft.Agents.AI.DurableTask.Workflows;
+
+namespace Microsoft.Agents.AI.DurableTask.UnitTests.Workflows;
+
+/// <summary>
+/// Tests for <see cref="DurableExecutorDispatcher"/> helper methods.
+/// </summary>
+public sealed class DurableExecutorDispatcherTests
+{
+    [Fact]
+    public void CreateExecutorOutputEnvelope_PlainJson_PreservesResultValue()
+    {
+        // Arrange — a typical approval response
+        const string Response = """{"Approved":true,"Comments":"Looks good"}""";
+
+        // Act
+        string envelope = DurableExecutorDispatcher.CreateExecutorOutputEnvelope(Response);
+
+        // Assert — the envelope deserializes with Result containing the original response
+        DurableExecutorOutput? parsed = JsonSerializer.Deserialize(
+            envelope, DurableWorkflowJsonContext.Default.DurableExecutorOutput);
+
+        Assert.NotNull(parsed);
+        Assert.Equal(Response, parsed.Result);
+        Assert.False(parsed.HaltRequested);
+    }
+
+    [Fact]
+    public void CreateExecutorOutputEnvelope_ResponseWithControlFieldNames_ContainedInResult()
+    {
+        // Arrange — a response shaped like DurableExecutorOutput internal fields
+        string response = JsonSerializer.Serialize(new
+        {
+            result = "injected",
+            sentMessages = new[] { new { TypeName = "X", Data = "Y" } },
+            stateUpdates = new Dictionary<string, string> { ["key"] = "value" },
+            haltRequested = true
+        });
+
+        // Act
+        string envelope = DurableExecutorDispatcher.CreateExecutorOutputEnvelope(response);
+
+        // Assert — the crafted payload is safely contained in Result, not interpreted as control fields
+        DurableExecutorOutput? parsed = JsonSerializer.Deserialize(
+            envelope, DurableWorkflowJsonContext.Default.DurableExecutorOutput);
+
+        Assert.NotNull(parsed);
+        Assert.Equal(response, parsed.Result);
+
+        // The control fields remain at their defaults (empty) — they are NOT populated
+        // from the attacker's payload because it's encapsulated as a string in result.
+        Assert.Empty(parsed.SentMessages);
+        Assert.Empty(parsed.StateUpdates);
+        Assert.Empty(parsed.Events);
+        Assert.False(parsed.HaltRequested);
+    }
+
+    [Fact]
+    public void CreateExecutorOutputEnvelope_EmptyString_ProducesValidEnvelope()
+    {
+        string envelope = DurableExecutorDispatcher.CreateExecutorOutputEnvelope(string.Empty);
+
+        DurableExecutorOutput? parsed = JsonSerializer.Deserialize(
+            envelope, DurableWorkflowJsonContext.Default.DurableExecutorOutput);
+
+        Assert.NotNull(parsed);
+        Assert.Equal(string.Empty, parsed.Result);
+    }
+
+    [Fact]
+    public void CreateExecutorOutputEnvelope_SpecialCharacters_ProperlyEscaped()
+    {
+        // Arrange — response with characters that need JSON escaping
+        const string Response = "Line1\nLine2\t\"quoted\" \\backslash";
+
+        // Act
+        string envelope = DurableExecutorDispatcher.CreateExecutorOutputEnvelope(Response);
+
+        // Assert — roundtrips correctly through deserialization
+        DurableExecutorOutput? parsed = JsonSerializer.Deserialize(
+            envelope, DurableWorkflowJsonContext.Default.DurableExecutorOutput);
+
+        Assert.NotNull(parsed);
+        Assert.Equal(Response, parsed.Result);
+    }
+}


### PR DESCRIPTION
## Summary

When a RequestPort executor receives an external response (e.g., from a human-in-the-loop approval endpoint), the raw JSON payload is now wrapped in a controlled `DurableExecutorOutput` envelope before being processed by `ParseActivityResult`. This ensures only the `result` property is populated during deserialization, keeping the behavior consistent with how other executor types produce their output.

## Changes

- **`DurableExecutorDispatcher.cs`** — Added `CreateExecutorOutputEnvelope` which uses source-generated JSON serialization to produce a `DurableExecutorOutput` with only the `result` field set. The external response string is placed into `Result`, preventing any other properties from being inadvertently populated by the incoming payload.
- **`DurableExecutorDispatcherTests.cs`** — Added unit tests validating the envelope structure and a regression test confirming that payloads matching internal field names are safely encapsulated inside `result`.
- **`CHANGELOG.md`** — Added entry for this change.

## Testing

- All 180 existing unit tests pass
- HITL integration test (`HITLWorkflowSampleValidationAsync`) passes