### PR TITLE
Sync durabletask and add azurefunctions packages from agent-framework

### DIFF
--- a/.github/workflows/python-integration-tests.yml
+++ b/.github/workflows/python-integration-tests.yml
@@ -42,3 +42,7 @@ jobs:
       - name: Integration tests
         working-directory: python
         run: uv run pytest packages/durabletask/tests/integration_tests -m integration -n logical --dist worksteal --timeout 480
+
+      - name: Azure Functions integration tests
+        working-directory: python
+        run: uv run pytest packages/azurefunctions/tests/integration_tests -m integration -n logical --dist worksteal --timeout 480

--- a/.github/workflows/python-merge-tests.yml
+++ b/.github/workflows/python-merge-tests.yml
@@ -39,19 +39,29 @@ jobs:
 
       - name: Ruff
         working-directory: python
-        run: uv run ruff check packages/durabletask
+        run: uv run ruff check packages/durabletask packages/azurefunctions
 
-      - name: MyPy
+      - name: Pyright (source)
         working-directory: python
-        run: uv run mypy --config-file packages/durabletask/pyproject.toml packages/durabletask/agent_framework_durabletask
+        run: |
+          uv run pyright -p packages/durabletask/pyproject.toml
+          uv run pyright -p packages/azurefunctions/pyproject.toml
+
+      - name: MyPy (tests)
+        working-directory: python
+        run: |
+          uv run mypy --config-file pyproject.toml packages/durabletask/tests
+          uv run mypy --config-file pyproject.toml packages/azurefunctions/tests
 
       - name: Unit tests
         working-directory: python
-        run: uv run pytest -m "not integration" packages/durabletask/tests --cov=agent_framework_durabletask --cov-report=term-missing:skip-covered
+        run: uv run pytest -m "not integration" packages/durabletask/tests packages/azurefunctions/tests --cov=agent_framework_durabletask --cov=agent_framework_azurefunctions --cov-report=term-missing:skip-covered
 
       - name: Build package
         working-directory: python
-        run: uv build packages/durabletask --out-dir dist
+        run: |
+          uv build packages/durabletask --out-dir dist
+          uv build packages/azurefunctions --out-dir dist
 
       - name: Upload package
         if: matrix.python-version == '3.13'

--- a/python/packages/azurefunctions/AGENTS.md
+++ b/python/packages/azurefunctions/AGENTS.md
@@ -1,0 +1,23 @@
+# Azure Functions Package (agent-framework-azurefunctions)
+
+Hosting agents as Azure Functions.
+
+## Main Classes
+
+- **`AgentFunctionApp`** - Azure Functions app wrapper for agents
+
+## Usage
+
+```python
+from agent_framework.azure import AgentFunctionApp
+
+app = AgentFunctionApp(agent=my_agent)
+```
+
+## Import Path
+
+```python
+from agent_framework.azure import AgentFunctionApp
+# or directly:
+from agent_framework_azurefunctions import AgentFunctionApp
+```

--- a/python/packages/azurefunctions/AGENTS.md
+++ b/python/packages/azurefunctions/AGENTS.md
@@ -11,7 +11,7 @@ Hosting agents as Azure Functions.
 ```python
 from agent_framework.azure import AgentFunctionApp
 
-app = AgentFunctionApp(agent=my_agent)
+app = AgentFunctionApp(agents=[my_agent])
 ```
 
 ## Import Path

--- a/python/packages/azurefunctions/LICENSE
+++ b/python/packages/azurefunctions/LICENSE
@@ -1,0 +1,21 @@
+    MIT License
+
+    Copyright (c) Microsoft Corporation.
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE

--- a/python/packages/azurefunctions/README.md
+++ b/python/packages/azurefunctions/README.md
@@ -1,0 +1,28 @@
+# Get Started with Microsoft Agent Framework Durable Functions
+
+[![PyPI](https://img.shields.io/pypi/v/agent-framework-azurefunctions)](https://pypi.org/project/agent-framework-azurefunctions/)
+
+Please install this package via pip:
+
+```bash
+pip install agent-framework-azurefunctions --pre
+```
+
+## Durable Agent Extension
+
+The durable agent extension lets you host Microsoft Agent Framework agents on Azure Durable Functions so they can persist state, replay conversation history, and recover from failures automatically.
+
+### Basic Usage Example
+
+See the durable functions integration sample in the repository to learn how to:
+
+```python
+from agent_framework.azure import AgentFunctionApp
+
+_app = AgentFunctionApp()
+```
+
+- Register agents with `AgentFunctionApp`
+- Post messages using the generated `/api/agents/{agent_name}/run` endpoint
+
+For more details, review the Python [README](https://github.com/microsoft/agent-framework/tree/main/python/README.md) and the samples directory.

--- a/python/packages/azurefunctions/agent_framework_azurefunctions/__init__.py
+++ b/python/packages/azurefunctions/agent_framework_azurefunctions/__init__.py
@@ -1,0 +1,17 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+import importlib.metadata
+
+from ._app import AgentFunctionApp
+from ._hitl_context import WorkflowHitlContext
+
+try:
+    __version__ = importlib.metadata.version(__name__)
+except importlib.metadata.PackageNotFoundError:
+    __version__ = "0.0.0"  # Fallback for development mode
+
+__all__ = [
+    "AgentFunctionApp",
+    "WorkflowHitlContext",
+    "__version__",
+]

--- a/python/packages/azurefunctions/agent_framework_azurefunctions/_app.py
+++ b/python/packages/azurefunctions/agent_framework_azurefunctions/_app.py
@@ -1,0 +1,1625 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+"""AgentFunctionApp - Main application class.
+
+This module provides the AgentFunctionApp class that integrates Microsoft Agent Framework
+with Azure Durable Entities, enabling stateful and durable AI agent execution.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import re
+import uuid
+from collections.abc import Callable, Mapping
+from dataclasses import asdict, dataclass, is_dataclass
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING, Any, TypeVar, cast
+
+import azure.durable_functions as df
+import azure.functions as func
+from agent_framework import SupportsAgentRun, Workflow
+from agent_framework_durabletask import (
+    DEFAULT_MAX_POLL_RETRIES,
+    DEFAULT_POLL_INTERVAL_SECONDS,
+    MIMETYPE_APPLICATION_JSON,
+    MIMETYPE_TEXT_PLAIN,
+    REQUEST_RESPONSE_FORMAT_JSON,
+    REQUEST_RESPONSE_FORMAT_TEXT,
+    THREAD_ID_FIELD,
+    THREAD_ID_HEADER,
+    WAIT_FOR_RESPONSE_FIELD,
+    WAIT_FOR_RESPONSE_HEADER,
+    AgentResponseCallbackProtocol,
+    AgentSessionId,
+    ApiResponseFields,
+    DurableAgentState,
+    DurableAIAgent,
+    RunRequest,
+    deserialize_workflow_output,
+    execute_workflow_activity,
+    plan_workflow_registration,
+)
+from agent_framework_durabletask._workflows.naming import (
+    SUBWORKFLOW_REQUEST_SEPARATOR,
+    split_subworkflow_request_id,
+    validate_executor_id,
+    validate_workflow_name,
+    workflow_executor_activity_name,
+    workflow_orchestrator_name,
+    workflow_scoped_executor_id,
+)
+from agent_framework_durabletask._workflows.registration import collect_hosted_workflows
+from agent_framework_durabletask._workflows.serialization import strip_pickle_markers, strip_subworkflow_markers
+
+from ._entities import create_agent_entity
+from ._errors import IncomingRequestError
+from ._orchestration import AgentOrchestrationContextType, AgentTask, AzureFunctionsAgentExecutor
+from ._routes import build_workflow_respond_url, build_workflow_status_url, split_request_url
+from ._workflow import run_workflow_orchestrator
+
+logger = logging.getLogger("agent_framework.azurefunctions")
+
+EntityHandler = Callable[[df.DurableEntityContext], None]
+HandlerT = TypeVar("HandlerT", bound=Callable[..., Any])
+
+
+def _json_default(obj: Any) -> Any:
+    """JSON fallback encoder for reconstructed workflow outputs.
+
+    A workflow's yielded outputs are reconstructed (see ``deserialize_workflow_output``)
+    before they reach the HTTP response, so they may be framework models
+    (e.g. ``AgentResponse``), dataclasses, or other non-JSON-native objects.
+    Prefer the type's own serialization so the response carries clean domain
+    JSON, falling back to ``str`` for anything without one.
+    """
+    to_dict = getattr(obj, "to_dict", None)
+    if callable(to_dict):
+        try:
+            return to_dict()
+        except Exception:
+            logger.debug("to_dict() failed while encoding %s for HTTP output", type(obj).__name__)
+    model_dump = getattr(obj, "model_dump", None)
+    if callable(model_dump):
+        try:
+            return model_dump(mode="json")
+        except Exception:
+            logger.debug("model_dump() failed while encoding %s for HTTP output", type(obj).__name__)
+    if is_dataclass(obj) and not isinstance(obj, type):
+        return asdict(obj)
+    return str(obj)
+
+
+@dataclass
+class AgentMetadata:
+    """Metadata for a registered agent.
+
+    Attributes:
+        agent: The agent instance implementing SupportsAgentRun
+        http_endpoint_enabled: Whether HTTP endpoint is enabled for this agent
+        mcp_tool_enabled: Whether MCP tool endpoint is enabled for this agent
+    """
+
+    agent: SupportsAgentRun
+    http_endpoint_enabled: bool
+    mcp_tool_enabled: bool
+
+
+if TYPE_CHECKING:
+
+    class DFAppBase:
+        def __init__(self, http_auth_level: func.AuthLevel = func.AuthLevel.FUNCTION) -> None: ...
+
+        def function_name(self, name: str) -> Callable[[HandlerT], HandlerT]: ...
+
+        def route(self, route: str, methods: list[str]) -> Callable[[HandlerT], HandlerT]: ...
+
+        def durable_client_input(self, client_name: str) -> Callable[[HandlerT], HandlerT]: ...
+
+        def entity_trigger(self, context_name: str, entity_name: str) -> Callable[[EntityHandler], EntityHandler]: ...
+
+        def orchestration_trigger(self, context_name: str) -> Callable[[HandlerT], HandlerT]: ...
+
+        def activity_trigger(self, input_name: str) -> Callable[[HandlerT], HandlerT]: ...
+
+        def mcp_tool_trigger(
+            self,
+            arg_name: str,
+            tool_name: str,
+            description: str,
+            tool_properties: str,
+            data_type: func.DataType,
+        ) -> Callable[[HandlerT], HandlerT]: ...
+
+else:
+    DFAppBase = df.DFApp  # type: ignore[assignment]
+
+
+class AgentFunctionApp(DFAppBase):
+    """Main application class for creating durable agent function apps using Durable Entities.
+
+    This class uses Durable Entities pattern for agent execution, providing:
+
+    - Stateful agent conversations
+    - Conversation history management
+    - Signal-based operation invocation
+    - Better state management than orchestrations
+
+    Example:
+    -------
+
+    .. code-block:: python
+
+        from agent_framework.azure import AgentFunctionApp
+        from agent_framework.openai import OpenAIChatCompletionClient
+
+        # Create agents with unique names
+        weather_agent = OpenAIChatCompletionClient(...).as_agent(
+            name="WeatherAgent",
+            instructions="You are a helpful weather agent.",
+            tools=[get_weather],
+        )
+
+        math_agent = OpenAIChatCompletionClient(...).as_agent(
+            name="MathAgent",
+            instructions="You are a helpful math assistant.",
+            tools=[calculate],
+        )
+
+        # Option 1: Pass list of agents during initialization
+        app = AgentFunctionApp(agents=[weather_agent, math_agent])
+
+        # Option 2: Add agents after initialization
+        app = AgentFunctionApp()
+        app.add_agent(weather_agent)
+        app.add_agent(math_agent)
+
+
+        @app.orchestration_trigger(context_name="context")
+        def my_orchestration(context):
+            writer = app.get_agent(context, "WeatherAgent")
+            session = writer.create_session()
+            forecast_task = writer.run("What's the forecast?", session=session)
+            forecast = yield forecast_task
+            return forecast
+
+    This creates:
+
+    - HTTP trigger endpoint for each agent's requests (if enabled)
+    - Durable entity for each agent's state management and execution
+    - Full access to all Azure Functions capabilities
+
+    Attributes:
+        agents: Dictionary of agent name to SupportsAgentRun instance
+        enable_health_check: Whether health check endpoint is enabled
+        enable_http_endpoints: Whether HTTP endpoints are created for agents
+        enable_mcp_tool_trigger: Whether MCP tool triggers are created for agents
+        max_poll_retries: Maximum polling attempts when waiting for responses
+        poll_interval_seconds: Delay (seconds) between polling attempts
+        workflow: The sole hosted Workflow when exactly one is hosted, else ``None``
+            (use :attr:`workflows` to access all hosted workflows by name)
+    """
+
+    _agent_metadata: dict[str, AgentMetadata]
+    _workflows: dict[str, Workflow]
+    enable_health_check: bool
+    enable_http_endpoints: bool
+    enable_mcp_tool_trigger: bool
+    workflow: Workflow | None
+
+    def __init__(
+        self,
+        agents: list[SupportsAgentRun] | None = None,
+        workflow: Workflow | None = None,
+        workflows: list[Workflow] | Mapping[str, Workflow] | None = None,
+        http_auth_level: func.AuthLevel = func.AuthLevel.FUNCTION,
+        enable_health_check: bool = True,
+        enable_http_endpoints: bool = True,
+        max_poll_retries: int = DEFAULT_MAX_POLL_RETRIES,
+        poll_interval_seconds: float = DEFAULT_POLL_INTERVAL_SECONDS,
+        enable_mcp_tool_trigger: bool = False,
+        default_callback: AgentResponseCallbackProtocol | None = None,
+    ):
+        """Initialize the AgentFunctionApp.
+
+        :param agents: List of agent instances to register.
+        :param workflow: Optional single Workflow to host. Convenience alias for
+            ``workflows=[workflow]``; an app may host several workflows via ``workflows``.
+        :param workflows: Optional workflows to host, as a list (keyed by each
+            ``Workflow.name``) or a name->Workflow mapping. Each workflow gets its own
+            ``dafx-{name}`` orchestration and ``workflow/{name}/...`` HTTP routes.
+        :param http_auth_level: HTTP authentication level (default: ``func.AuthLevel.FUNCTION``).
+        :param enable_health_check: Enable the built-in health check endpoint (default: ``True``).
+        :param enable_http_endpoints: Enable HTTP endpoints for agents (default: ``True``).
+        :param enable_mcp_tool_trigger: Enable MCP tool triggers for agents (default: ``False``).
+            When enabled, agents will be exposed as MCP tools that can be invoked by MCP-compatible clients.
+        :param max_poll_retries: Maximum polling attempts when waiting for a response.
+            Defaults to ``DEFAULT_MAX_POLL_RETRIES``.
+        :param poll_interval_seconds: Delay in seconds between polling attempts.
+            Defaults to ``DEFAULT_POLL_INTERVAL_SECONDS``.
+        :param default_callback: Optional callback invoked for agents without specific callbacks.
+
+        :note: If no agents are provided, they can be added later using :meth:`add_agent`.
+        """
+        logger.debug("[AgentFunctionApp] Initializing with Durable Entities...")
+
+        # Initialize parent DFApp
+        super().__init__(http_auth_level=http_auth_level)
+
+        # Initialize agent metadata dictionary
+        self._agent_metadata = {}
+        self._workflows: dict[str, Workflow] = {}
+        # Every workflow whose orchestration has been registered (top-level plus
+        # nested sub-workflows), keyed by case-folded name -> the registered instance,
+        # so a shared sub-workflow is registered once while two different workflows
+        # whose names collide (including case-only differences) are rejected.
+        self._registered_orchestrations: dict[str, Workflow] = {}
+        self.enable_health_check = enable_health_check
+        self.enable_http_endpoints = enable_http_endpoints
+        self.enable_mcp_tool_trigger = enable_mcp_tool_trigger
+        self.default_callback = default_callback
+
+        try:
+            retries = int(max_poll_retries)
+        except (TypeError, ValueError):
+            retries = DEFAULT_MAX_POLL_RETRIES
+        self.max_poll_retries = max(1, retries)
+
+        try:
+            interval = float(poll_interval_seconds)
+        except (TypeError, ValueError):
+            interval = DEFAULT_POLL_INTERVAL_SECONDS
+        self.poll_interval_seconds = interval if interval > 0 else DEFAULT_POLL_INTERVAL_SECONDS
+
+        # Register each hosted workflow. ``workflow=`` is a convenience alias for a
+        # single-element ``workflows``; both may be combined.
+        for wf in self._collect_workflows(workflow, workflows):
+            self._register_workflow(wf)
+
+        # Back-compat: expose the sole workflow as ``.workflow`` when exactly one is
+        # hosted (multi-workflow apps must address workflows by name).
+        self.workflow = next(iter(self._workflows.values())) if len(self._workflows) == 1 else None
+
+        if agents:
+            # Register all provided agents
+            logger.debug(f"[AgentFunctionApp] Registering {len(agents)} agent(s)")
+            for agent_instance in agents:
+                self.add_agent(agent_instance)
+
+        # Setup health check if enabled
+        if self.enable_health_check:
+            self._setup_health_route()
+
+        logger.debug("[AgentFunctionApp] Initialization complete")
+
+    def _collect_workflows(
+        self,
+        workflow: Workflow | None,
+        workflows: list[Workflow] | Mapping[str, Workflow] | None,
+    ) -> list[Workflow]:
+        """Combine the ``workflow`` alias and ``workflows`` into a de-duplicated list.
+
+        A name->Workflow mapping must agree with each ``Workflow.name`` so a single
+        identity drives the durable names and HTTP routes.
+
+        Raises:
+            ValueError: If a mapping key disagrees with its ``Workflow.name``.
+        """
+        collected: list[Workflow] = []
+        if workflow is not None:
+            collected.append(workflow)
+        if isinstance(workflows, Mapping):
+            for key, wf in workflows.items():
+                if key != wf.name:
+                    raise ValueError(f"workflows mapping key '{key}' does not match Workflow.name '{wf.name}'.")
+                collected.append(wf)
+        elif workflows is not None:
+            collected.extend(workflows)
+        return collected
+
+    def _register_workflow(self, workflow: Workflow) -> None:
+        """Register a top-level workflow's durable primitives and HTTP routes.
+
+        The "what to register" decision (agent -> entity, non-agent -> activity,
+        sub-workflow -> child orchestration) is shared with the standalone
+        durabletask host via ``plan_workflow_registration``. Nested sub-workflows
+        have their orchestration primitives registered (deduped by name) so the
+        parent can drive them as child orchestrations, but only the top-level
+        workflow gets HTTP ``workflow/{name}/...`` routes.
+
+        Raises:
+            ValueError: If the workflow (or a nested sub-workflow) name is
+                missing/invalid/auto-generated, or a top-level workflow with the
+                same name is already registered.
+        """
+        validate_workflow_name(workflow.name)
+        if any(name.casefold() == workflow.name.casefold() for name in self._workflows):
+            raise ValueError(
+                f"Workflow '{workflow.name}' is already registered on this app "
+                "(workflow names are compared case-insensitively)."
+            )
+
+        # Validate the whole composition (top-level plus every nested sub-workflow)
+        # up front, so an invalid/auto-generated nested name (or an executor id that
+        # would break durable naming / nested-HITL addressing) fails before any
+        # registration side effects leave the app partially configured.
+        hosted_workflows = list(collect_hosted_workflows(workflow))
+        for hosted in hosted_workflows:
+            validate_workflow_name(hosted.name)
+            for executor_id in hosted.executors:
+                validate_executor_id(executor_id)
+
+        # Check every cross-call collision *before* mutating any state, so a clash
+        # between a nested sub-workflow and an already-registered orchestration cannot
+        # leave the app partially configured (e.g. the top-level name added to
+        # ``_workflows`` while a later child fails). Registration below is then a pure
+        # commit step.
+        for hosted in hosted_workflows:
+            existing = self._registered_orchestrations.get(hosted.name.casefold())
+            if existing is not None and existing is not hosted:
+                raise ValueError(
+                    f"A different workflow named '{hosted.name}' collides with already-registered "
+                    f"'{existing.name}' on this app. A workflow name maps to a single durable "
+                    f"orchestration ('dafx-{hosted.name}'), compared case-insensitively; rename one "
+                    "of them."
+                )
+
+        self._workflows[workflow.name] = workflow
+
+        # Commit: register orchestration primitives for the top-level workflow and every
+        # nested sub-workflow (deduped by name).
+        for hosted in hosted_workflows:
+            if hosted.name.casefold() in self._registered_orchestrations:
+                continue
+            self._register_workflow_primitives(hosted)
+
+        # HTTP routes are only exposed for the top-level workflow; sub-workflows are
+        # driven by the parent via call_sub_orchestrator, not addressed directly.
+        self._register_workflow_routes(workflow)
+
+    def _register_workflow_primitives(self, workflow: Workflow) -> None:
+        """Register one workflow's entities, activities, and orchestrator (no routes)."""
+        validate_workflow_name(workflow.name)
+        self._registered_orchestrations[workflow.name.casefold()] = workflow
+
+        logger.debug("[AgentFunctionApp] Registering workflow '%s'", workflow.name)
+        plan = plan_workflow_registration(workflow)
+        for agent_executor in plan.agent_executors:
+            # Register each workflow agent through the same surface as a standalone
+            # agent (so it stays tracked in ``agents`` / ``get_agent``), under the
+            # workflow-scoped entity id ``{workflow}-{executor}`` the orchestrator
+            # dispatches to. This keeps two co-hosted workflows that reuse an executor
+            # id from colliding on one global entity name.
+            self.add_agent(
+                agent_executor.agent,
+                callback=self.default_callback,
+                entity_id=workflow_scoped_executor_id(workflow.name, agent_executor.id),
+            )
+        for executor in plan.activity_executors:
+            # Set up a Functions activity trigger for each non-agent executor, scoped
+            # by workflow name to match the orchestrator's dispatch. WorkflowExecutor
+            # nodes are not registered here: their inner workflows are registered
+            # separately and driven as child orchestrations.
+            self._setup_executor_activity(workflow, executor.id)
+
+        self._setup_workflow_orchestration(workflow)
+
+    def _setup_executor_activity(self, workflow: Workflow, executor_id: str) -> None:
+        """Register an activity for executing a specific non-agent executor.
+
+        Args:
+            workflow: The owning workflow (scopes the activity name and provides the
+                executor instance at run time).
+            executor_id: The ID of the executor to create an activity for.
+        """
+        activity_name = workflow_executor_activity_name(workflow.name, executor_id)
+        logger.debug(f"[AgentFunctionApp] Registering activity '{activity_name}' for executor '{executor_id}'")
+
+        # Capture the specific workflow + executor id in the closure so the right
+        # executor runs even when several workflows are hosted.
+        captured_workflow = workflow
+        captured_executor_id = executor_id
+
+        @self.function_name(activity_name)
+        @self.activity_trigger(input_name="inputData")
+        def executor_activity(inputData: str) -> str:
+            """Activity to execute a specific non-agent executor.
+
+            Note: We use str type annotations instead of dict to work around
+            Azure Functions worker type validation issues with dict[str, Any].
+            The execution body is shared with the standalone durabletask host via
+            ``execute_workflow_activity``.
+            """
+            executor = captured_workflow.executors.get(captured_executor_id)
+            if not executor:
+                raise ValueError(f"Unknown executor: {captured_executor_id}")
+
+            return execute_workflow_activity(executor, inputData, captured_workflow)
+
+        # Ensure the function is registered (prevents garbage collection)
+        _ = executor_activity
+
+    def _setup_workflow_orchestration(self, workflow: Workflow) -> None:
+        """Register a workflow's orchestrator function under its ``dafx-{name}`` name.
+
+        HTTP routes are registered separately (:meth:`_register_workflow_routes`) and
+        only for top-level workflows; this orchestrator function is registered for
+        every hosted workflow (including nested sub-workflows) so the parent can drive
+        them via ``call_sub_orchestrator``.
+        """
+        captured_workflow = workflow
+        orchestrator_name = workflow_orchestrator_name(workflow.name)
+
+        @self.function_name(orchestrator_name)
+        @self.orchestration_trigger(context_name="context")
+        def workflow_orchestrator(context: df.DurableOrchestrationContext) -> Any:
+            """Generic orchestrator for running the configured workflow."""
+            input_data = context.get_input()
+
+            # Pass the deserialized client input straight to the shared engine, which
+            # reconstructs the start executor's declared type (see _coerce_initial_input).
+            initial_message = input_data
+
+            # Create local shared state dict for cross-executor state sharing
+            shared_state: dict[str, Any] = {}
+
+            outputs = yield from run_workflow_orchestrator(context, captured_workflow, initial_message, shared_state)
+            # Durable Functions runtime extracts return value from StopIteration
+            return outputs  # noqa: B901
+
+        # Ensure the orchestrator function is registered (prevents garbage collection)
+        _ = workflow_orchestrator
+
+    def _register_workflow_routes(self, workflow: Workflow) -> None:
+        """Register a top-level workflow's per-workflow HTTP endpoints.
+
+        Routes are scoped by workflow name (``workflow/{name}/run`` etc.) so the URL
+        shape stays the same whether the app hosts one workflow or many; callers do
+        not have to change URLs as an app grows.
+        """
+        workflow_name = workflow.name
+        orchestrator_name = workflow_orchestrator_name(workflow_name)
+
+        @self.function_name(f"{orchestrator_name}-start")
+        @self.route(route=f"workflow/{workflow_name}/run", methods=["POST"])
+        @self.durable_client_input(client_name="client")
+        async def start_workflow_orchestration(
+            req: func.HttpRequest, client: df.DurableOrchestrationClient
+        ) -> func.HttpResponse:
+            """HTTP endpoint to start the workflow."""
+            try:
+                client_input: Any = req.get_json()
+            except ValueError:
+                # The orchestrator accepts plain strings as well as JSON objects, so fall
+                # back to the raw request body (e.g. text/plain) instead of rejecting it.
+                raw_body = req.get_body()
+                if not raw_body:
+                    return self._build_error_response("Request body is required")
+                client_input = raw_body.decode("utf-8")
+
+            # Neutralize a forged sub-workflow envelope before scheduling: only an
+            # internal child dispatch (post trust boundary) may carry those reserved
+            # keys, so stripping them here keeps untrusted input off the orchestrator's
+            # trusted-deserialization path (see strip_subworkflow_markers).
+            client_input = strip_subworkflow_markers(client_input)
+
+            instance_id = await client.start_new(orchestrator_name, client_input=client_input)
+
+            base_url, route_prefix = split_request_url(req.url)
+            status_url = build_workflow_status_url(base_url, workflow_name, instance_id, prefix=route_prefix)
+
+            return func.HttpResponse(
+                json.dumps({
+                    "instanceId": instance_id,
+                    "statusQueryGetUri": status_url,
+                    "respondUri": build_workflow_respond_url(
+                        base_url, workflow_name, instance_id, "{requestId}", prefix=route_prefix
+                    ),
+                    "message": "Workflow started",
+                }),
+                status_code=202,
+                mimetype="application/json",
+            )
+
+        @self.function_name(f"{orchestrator_name}-status")
+        @self.route(route=f"workflow/{workflow_name}/status/{{instanceId}}", methods=["GET"])
+        @self.durable_client_input(client_name="client")
+        async def get_workflow_status(
+            req: func.HttpRequest, client: df.DurableOrchestrationClient
+        ) -> func.HttpResponse:
+            """HTTP endpoint to get workflow status."""
+            instance_id = req.route_params.get("instanceId")
+            if not instance_id:
+                return self._build_error_response("Instance ID is required", status_code=400)
+
+            status = await client.get_status(instance_id)
+
+            # Scope the endpoint to this workflow's orchestrator. The durable client
+            # resolves instance IDs across every orchestration in the task hub, so an ID
+            # belonging to a different orchestration (or a different workflow) must be
+            # treated as "not found" rather than leaking its status / HITL details.
+            if not self._is_owned_orchestration(status, workflow_name):
+                return self._build_error_response("Instance not found", status_code=404)
+
+            # The workflow's yielded outputs are checkpoint-encoded by the shared
+            # activity (typed objects become pickle/type-marker dicts). Reconstruct
+            # the originals so the HTTP response carries clean domain JSON, matching
+            # what DurableWorkflowClient.await_workflow_output returns in-process.
+            # status.output is the workflow's own (trusted) orchestration result.
+            decoded_output = deserialize_workflow_output(status.output) if status.output is not None else None
+
+            response = {
+                "instanceId": status.instance_id,
+                "runtimeStatus": status.runtime_status.name if status.runtime_status else None,
+                "customStatus": status.custom_status,
+                "output": decoded_output,
+                "error": decoded_output if status.runtime_status == df.OrchestrationRuntimeStatus.Failed else None,
+                "createdTime": status.created_time.isoformat() if status.created_time else None,
+                "lastUpdatedTime": status.last_updated_time.isoformat() if status.last_updated_time else None,
+            }
+
+            # Add pending HITL requests info if available. Requests originating in a
+            # nested sub-workflow are bubbled up here with a qualified requestId
+            # ({executorId}~{ordinal}~{requestId}, nested deeper for deeper levels); the
+            # respondUrl always targets this top-level instance, so the caller has a
+            # single addressing surface.
+            custom_status = status.custom_status
+            if isinstance(custom_status, dict):
+                gathered = await self._gather_pending_hitl_requests(client, cast("dict[str, Any]", custom_status))
+                if gathered:
+                    base_url, route_prefix = split_request_url(req.url)
+                    pending_requests: list[dict[str, Any]] = [
+                        {
+                            "requestId": qualified_id,
+                            "sourceExecutor": req_data.get("source_executor_id"),
+                            "requestData": req_data.get("data"),
+                            "requestType": req_data.get("request_type"),
+                            "responseType": req_data.get("response_type"),
+                            "respondUrl": build_workflow_respond_url(
+                                base_url, workflow_name, instance_id, qualified_id, prefix=route_prefix
+                            ),
+                        }
+                        for qualified_id, req_data in gathered
+                    ]
+                    response["pendingHumanInputRequests"] = pending_requests
+
+            return func.HttpResponse(
+                json.dumps(response, default=_json_default),
+                status_code=200,
+                mimetype="application/json",
+            )
+
+        @self.function_name(f"{orchestrator_name}-respond")
+        @self.route(route=f"workflow/{workflow_name}/respond/{{instanceId}}/{{requestId}}", methods=["POST"])
+        @self.durable_client_input(client_name="client")
+        async def send_hitl_response(req: func.HttpRequest, client: df.DurableOrchestrationClient) -> func.HttpResponse:
+            """HTTP endpoint to send a response to a pending HITL request.
+
+            The requestId in the URL corresponds to the request_id from the RequestInfoEvent.
+            The request body should contain the response data matching the expected response_type.
+            """
+            instance_id = req.route_params.get("instanceId")
+            request_id = req.route_params.get("requestId")
+
+            if not instance_id or not request_id:
+                return self._build_error_response("Instance ID and Request ID are required.")
+
+            # Scope the endpoint to this workflow's orchestrator before raising an
+            # external event, so a leaked instance ID cannot be used to inject events into
+            # a different orchestration (or a different workflow) in the task hub.
+            status = await client.get_status(instance_id)
+            if not self._is_owned_orchestration(status, workflow_name):
+                return self._build_error_response("Instance not found", status_code=404)
+
+            try:
+                response_data = req.get_json()
+            except ValueError:
+                return self._build_error_response("Request body must be valid JSON.")
+
+            # Sanitize untrusted HTTP input before it reaches pickle.loads().
+            # See strip_pickle_markers() docstring for details on the attack vector.
+            response_data = strip_pickle_markers(response_data)
+
+            # A qualified requestId ({executorId}~{ordinal}~{requestId}) addresses a request that
+            # originated in a nested sub-workflow: resolve it to the owning child
+            # orchestration instance and the bare request id it is waiting on.
+            resolved = await self._resolve_hitl_target(client, instance_id, request_id)
+            if resolved is None:
+                return self._build_error_response("Pending request not found", status_code=404)
+            target_instance_id, bare_request_id = resolved
+
+            # Send the response as an external event. The (bare) request_id is used as the
+            # event name for correlation on the owning orchestration instance.
+            await client.raise_event(
+                instance_id=target_instance_id,
+                event_name=bare_request_id,
+                event_data=response_data,
+            )
+
+            return func.HttpResponse(
+                json.dumps({
+                    "message": "Response delivered successfully",
+                    "instanceId": instance_id,
+                    "requestId": request_id,
+                }),
+                status_code=200,
+                mimetype="application/json",
+            )
+
+        # Ensure route handlers are registered (prevents unused function warnings)
+        _ = start_workflow_orchestration
+        _ = get_workflow_status
+        _ = send_hitl_response
+
+    async def _gather_pending_hitl_requests(
+        self,
+        client: df.DurableOrchestrationClient,
+        custom_status: dict[str, Any],
+        *,
+        prefix: str = "",
+    ) -> list[tuple[str, dict[str, Any]]]:
+        """Collect ``(qualifiedRequestId, requestData)`` pairs for an instance and its sub-workflows.
+
+        ``custom_status`` is the already-fetched custom status of the instance at the
+        current level. Nested sub-workflows (listed in its ``subworkflows`` map as
+        ``{executorId: [childInstanceId, ...]}``) are fetched by id and recursed into,
+        accumulating an ``{executorId}~{ordinal}~`` prefix so a request deep in the tree
+        carries its full path and a node with several children this superstep keeps each
+        child distinctly addressable. Child instances come from the trusted parent
+        status, so no per-child ownership check is applied (the caller validated the
+        top-level instance).
+        """
+        gathered: list[tuple[str, dict[str, Any]]] = []
+
+        pending = custom_status.get("pending_requests")
+        if isinstance(pending, dict):
+            for req_id, req_data in cast("dict[str, Any]", pending).items():
+                if isinstance(req_data, dict):
+                    typed = cast("dict[str, Any]", req_data)
+                    # Use the request's own id field (the event name the orchestrator
+                    # waits on), falling back to the map key; the durabletask client
+                    # qualifies against the same value so a qualified id round-trips.
+                    bare_id = typed.get("request_id", req_id)
+                    gathered.append((f"{prefix}{bare_id}", typed))
+
+        subworkflows = custom_status.get("subworkflows")
+        if isinstance(subworkflows, dict):
+            sep = SUBWORKFLOW_REQUEST_SEPARATOR
+            for executor_id, child_ids in cast("dict[str, Any]", subworkflows).items():
+                children: list[Any] = cast("list[Any]", child_ids) if isinstance(child_ids, list) else []
+                for ordinal, child_instance_id in enumerate(children):
+                    if not isinstance(child_instance_id, str):
+                        continue
+                    child_status = await client.get_status(child_instance_id)
+                    child_custom = child_status.custom_status if child_status else None
+                    if isinstance(child_custom, dict):
+                        gathered.extend(
+                            await self._gather_pending_hitl_requests(
+                                client,
+                                cast("dict[str, Any]", child_custom),
+                                prefix=f"{prefix}{executor_id}{sep}{ordinal}{sep}",
+                            )
+                        )
+
+        return gathered
+
+    async def _resolve_hitl_target(
+        self,
+        client: df.DurableOrchestrationClient,
+        instance_id: str,
+        request_id: str,
+    ) -> tuple[str, str] | None:
+        """Resolve a possibly-qualified request id to ``(owningInstanceId, bareRequestId)``.
+
+        An unqualified id (no well-formed hop) targets ``instance_id`` directly. A
+        qualified id ``{executorId}~{ordinal}~{rest}`` addresses a nested sub-workflow:
+        the executor's child instance id is read from this instance's ``subworkflows``
+        custom-status map (a list selected by ``ordinal``) and the remainder resolved
+        recursively. Returns ``None`` when a referenced sub-workflow child is not
+        currently active (so the caller can return "not found").
+        """
+        hop = split_subworkflow_request_id(request_id)
+        if hop is None:
+            return instance_id, request_id
+
+        executor_id, ordinal, remainder = hop
+        status = await client.get_status(instance_id)
+        custom_status = status.custom_status if status else None
+        if not isinstance(custom_status, dict):
+            return None
+        subworkflows = cast("dict[str, Any]", custom_status).get("subworkflows")
+        if not isinstance(subworkflows, dict):
+            return None
+        children_raw = cast("dict[str, Any]", subworkflows).get(executor_id)
+        if not isinstance(children_raw, list):
+            return None
+        children = cast("list[Any]", children_raw)
+        if ordinal < 0 or ordinal >= len(children):
+            return None
+        child_instance_id = children[ordinal]
+        if not isinstance(child_instance_id, str):
+            return None
+        return await self._resolve_hitl_target(client, child_instance_id, remainder)
+
+    def _is_owned_orchestration(self, status: Any, workflow_name: str) -> bool:
+        """Return whether a durable orchestration status belongs to the named workflow.
+
+        The ``workflow/{name}/status`` and ``.../respond`` endpoints address instances
+        by ``instanceId`` alone, but the durable client resolves IDs across *every*
+        orchestration in the task hub -- agent entities, other workflows on this app,
+        any user-registered orchestrations, and other apps sharing the hub. Without
+        this check a caller holding one instance ID could read another orchestration's
+        status (including pending HITL request payloads) or inject external events into
+        it. Scoping to the route's ``dafx-{workflow_name}`` orchestration keeps each
+        endpoint bound to its own workflow; anything else is treated as "not found".
+
+        The orchestration name is compared case-insensitively so the check stays robust
+        to host/runtime casing differences.
+        """
+        expected = workflow_orchestrator_name(workflow_name)
+        name = getattr(status, "name", None)
+        return isinstance(name, str) and name.casefold() == expected.casefold()
+
+    @property
+    def agents(self) -> dict[str, SupportsAgentRun]:
+        """Returns dict of agent names to agent instances.
+
+        Returns:
+            Dictionary mapping agent names to their SupportsAgentRun instances.
+        """
+        return {name: metadata.agent for name, metadata in self._agent_metadata.items()}
+
+    @property
+    def workflows(self) -> dict[str, Workflow]:
+        """Returns a dict of workflow name to the hosted :class:`Workflow` instances."""
+        return dict(self._workflows)
+
+    def add_agent(
+        self,
+        agent: SupportsAgentRun,
+        callback: AgentResponseCallbackProtocol | None = None,
+        enable_http_endpoint: bool | None = None,
+        enable_mcp_tool_trigger: bool | None = None,
+        *,
+        entity_id: str | None = None,
+    ) -> None:
+        """Add an agent to the function app after initialization.
+
+        Args:
+            agent: The Microsoft Agent Framework agent instance (must implement SupportsAgentRun)
+                   The agent must have a 'name' attribute.
+            callback: Optional callback invoked during agent execution
+            enable_http_endpoint: Optional flag to enable/disable HTTP endpoint for this agent.
+                                  The app level enable_http_endpoints setting will override this setting.
+            enable_mcp_tool_trigger: Optional flag to enable/disable MCP tool trigger for this agent.
+                                     The app level enable_mcp_tool_trigger setting will override this setting.
+            entity_id: Optional identity to register the agent under instead of
+                ``agent.name``. Workflow hosting passes the executor's ``id`` so the
+                durable entity (and the ``agents`` / ``get_agent`` key) matches the
+                identity the orchestrator dispatches to. Mirrors
+                ``DurableAIAgentWorker.add_agent(entity_id=...)``.
+
+        Raises:
+            ValueError: If the agent doesn't have a 'name' attribute.
+        """
+        # Get agent name from the agent's name attribute
+        name = getattr(agent, "name", None)
+        if name is None:
+            raise ValueError("Agent does not have a 'name' attribute. All agents must have a 'name' attribute.")
+
+        # The registration name keys the agent everywhere on this app (metadata,
+        # routes, entity). It defaults to the agent name but can be overridden so a
+        # workflow agent is keyed by its executor id.
+        registration_name = entity_id or name
+
+        if registration_name in self._agent_metadata:
+            logger.warning(
+                "[AgentFunctionApp] Agent '%s' is already registered, skipping duplicate.", registration_name
+            )
+            return
+
+        effective_enable_http_endpoint = (
+            self.enable_http_endpoints if enable_http_endpoint is None else self._coerce_to_bool(enable_http_endpoint)
+        )
+        effective_enable_mcp_endpoint = (
+            self.enable_mcp_tool_trigger
+            if enable_mcp_tool_trigger is None
+            else self._coerce_to_bool(enable_mcp_tool_trigger)
+        )
+
+        logger.debug(f"[AgentFunctionApp] Adding agent: {registration_name}")
+        logger.debug(f"[AgentFunctionApp] Route: /api/agents/{registration_name}")
+        logger.debug(
+            "[AgentFunctionApp] HTTP endpoint %s for agent '%s'",
+            "enabled" if effective_enable_http_endpoint else "disabled",
+            registration_name,
+        )
+        logger.debug(
+            f"[AgentFunctionApp] MCP tool trigger: {'enabled' if effective_enable_mcp_endpoint else 'disabled'}"
+        )
+
+        # Store agent metadata
+        self._agent_metadata[registration_name] = AgentMetadata(
+            agent=agent,
+            http_endpoint_enabled=effective_enable_http_endpoint,
+            mcp_tool_enabled=effective_enable_mcp_endpoint,
+        )
+
+        effective_callback = callback or self.default_callback
+
+        self._setup_agent_functions(
+            agent, registration_name, effective_callback, effective_enable_http_endpoint, effective_enable_mcp_endpoint
+        )
+
+        logger.debug(f"[AgentFunctionApp] Agent '{registration_name}' added successfully")
+
+    def get_agent(
+        self,
+        context: AgentOrchestrationContextType,
+        agent_name: str,
+        workflow_name: str | None = None,
+    ) -> DurableAIAgent[AgentTask]:
+        """Return a DurableAIAgent proxy for a registered agent.
+
+        Args:
+            context: Durable Functions orchestration context invoking the agent.
+            agent_name: Name of the agent registered on this app. For an agent that
+                belongs to a hosted workflow, pass ``workflow_name`` to resolve it
+                under its workflow-scoped identity; for an agent registered standalone
+                via ``agents=`` / ``add_agent`` use its bare name.
+            workflow_name: Optional owning workflow name. When given, the agent is
+                resolved under the scoped id ``{workflow_name}-{agent_name}``.
+
+        Returns:
+            DurableAIAgent[AgentTask] wrapper bound to the orchestration context.
+
+        Raises:
+            ValueError: If the requested agent has not been registered.
+        """
+        normalized_name = (
+            workflow_scoped_executor_id(workflow_name, str(agent_name)) if workflow_name else str(agent_name)
+        )
+
+        if normalized_name not in self._agent_metadata:
+            raise ValueError(f"Agent '{normalized_name}' is not registered with this app.")
+
+        executor = AzureFunctionsAgentExecutor(context)
+        return DurableAIAgent(executor, normalized_name)
+
+    def _setup_agent_functions(
+        self,
+        agent: SupportsAgentRun,
+        agent_name: str,
+        callback: AgentResponseCallbackProtocol | None,
+        enable_http_endpoint: bool,
+        enable_mcp_tool_trigger: bool,
+    ) -> None:
+        """Set up the HTTP trigger, entity, and MCP tool trigger for a specific agent.
+
+        Args:
+            agent: The agent instance
+            agent_name: The name to use for routing and entity registration
+            callback: Optional callback to receive response updates
+            enable_http_endpoint: Whether to create HTTP endpoint
+            enable_mcp_tool_trigger: Whether to create MCP tool trigger
+        """
+        logger.debug(f"[AgentFunctionApp] Setting up functions for agent '{agent_name}'...")
+
+        if enable_http_endpoint:
+            self._setup_http_run_route(agent_name)
+        else:
+            logger.debug(
+                "[AgentFunctionApp] HTTP run route disabled for agent '%s'",
+                agent_name,
+            )
+        self._setup_agent_entity(agent, agent_name, callback)
+
+        if enable_mcp_tool_trigger:
+            agent_description = agent.description
+            self._setup_mcp_tool_trigger(agent_name, agent_description)
+        else:
+            logger.debug(f"[AgentFunctionApp] MCP tool trigger disabled for agent '{agent_name}'")
+
+    def _setup_http_run_route(self, agent_name: str) -> None:
+        """Register the POST route that triggers agent execution.
+
+        Args:
+            agent_name: The agent name (used for both routing and entity identification)
+        """
+        run_function_name = self._build_function_name(agent_name, "http")
+
+        function_name_decorator = self.function_name(run_function_name)
+        route_decorator = self.route(route=f"agents/{agent_name}/run", methods=["POST"])
+        durable_client_decorator = self.durable_client_input(client_name="client")
+
+        @function_name_decorator
+        @route_decorator
+        @durable_client_decorator
+        async def http_start(req: func.HttpRequest, client: df.DurableOrchestrationClient) -> func.HttpResponse:
+            """HTTP trigger that calls a durable entity to execute the agent and returns the result.
+
+            Expected request body (RunRequest format):
+            {
+                "message": "user message to agent",
+                "thread_id": "optional conversation identifier",
+                "role": "user|system" (optional, default: "user"),
+                "response_format": {...} (optional JSON schema for structured responses),
+                "enable_tool_calls": true|false (optional, default: true)
+            }
+            """
+            request_response_format: str = REQUEST_RESPONSE_FORMAT_JSON
+            thread_id: str | None = None
+
+            try:
+                req_body, message, request_response_format = self._parse_incoming_request(req)
+                thread_id = self._resolve_thread_id(req=req, req_body=req_body)
+                wait_for_response = self._should_wait_for_response(req=req, req_body=req_body)
+
+                logger.debug(
+                    f"[HTTP Trigger] Message: {message}, Thread ID: {thread_id}, wait_for_response: {wait_for_response}"
+                )
+
+                if not message:
+                    logger.warning("[HTTP Trigger] Request rejected: Missing message")
+                    return self._create_http_response(
+                        payload={"error": "Message is required"},
+                        status_code=400,
+                        request_response_format=request_response_format,
+                        thread_id=thread_id,
+                    )
+
+                session_id = self._create_session_id(agent_name, thread_id)
+                correlation_id = self._generate_unique_id()
+
+                logger.debug(
+                    f"[HTTP Trigger] Calling entity to run agent using session ID: {session_id} "
+                    f"and correlation ID: {correlation_id}"
+                )
+
+                entity_instance_id = df.EntityId(
+                    name=session_id.entity_name,
+                    key=session_id.key,
+                )
+                run_request = self._build_request_data(
+                    req_body,
+                    message,
+                    correlation_id,
+                    request_response_format,
+                )
+                logger.debug("Signalling entity %s with request: %s", entity_instance_id, run_request)
+                await client.signal_entity(entity_instance_id, "run", run_request)
+
+                logger.debug(f"[HTTP Trigger] Signal sent to entity {session_id}")
+
+                if wait_for_response:
+                    result = await self._get_response_from_entity(
+                        client=client,
+                        entity_instance_id=entity_instance_id,
+                        correlation_id=correlation_id,
+                        message=message,
+                        thread_id=thread_id,
+                    )
+
+                    logger.debug(f"[HTTP Trigger] Result status: {result.get('status', 'unknown')}")
+                    return self._create_http_response(
+                        payload=result,
+                        status_code=200 if result.get("status") == "success" else 500,
+                        request_response_format=request_response_format,
+                        thread_id=thread_id,
+                    )
+
+                logger.debug("[HTTP Trigger] wait_for_response disabled; returning correlation ID")
+
+                accepted_response = self._build_accepted_response(
+                    message=message, thread_id=thread_id, correlation_id=correlation_id
+                )
+
+                return self._create_http_response(
+                    payload=accepted_response,
+                    status_code=202,
+                    request_response_format=request_response_format,
+                    thread_id=thread_id,
+                )
+
+            except IncomingRequestError as exc:
+                logger.warning(f"[HTTP Trigger] Request rejected: {exc!s}")
+                return self._create_http_response(
+                    payload={"error": str(exc)},
+                    status_code=exc.status_code,
+                    request_response_format=request_response_format,
+                    thread_id=thread_id,
+                )
+            except ValueError as exc:
+                logger.error(f"[HTTP Trigger] Invalid JSON: {exc!s}")
+                return self._create_http_response(
+                    payload={"error": "Invalid JSON"},
+                    status_code=400,
+                    request_response_format=request_response_format,
+                    thread_id=thread_id,
+                )
+            except Exception as exc:
+                logger.error(f"[HTTP Trigger] Error: {exc!s}", exc_info=True)
+                return self._create_http_response(
+                    payload={"error": str(exc)},
+                    status_code=500,
+                    request_response_format=request_response_format,
+                    thread_id=thread_id,
+                )
+
+        _ = http_start
+
+    def _setup_agent_entity(
+        self,
+        agent: SupportsAgentRun,
+        agent_name: str,
+        callback: AgentResponseCallbackProtocol | None,
+    ) -> None:
+        """Register the durable entity responsible for agent state.
+
+        Args:
+            agent: The agent instance
+            agent_name: The agent name (used for both entity identification and function naming)
+            callback: Optional callback for response updates
+        """
+        # Use the prefixed entity name for both registration and function naming
+        entity_name_with_prefix = AgentSessionId.to_entity_name(agent_name)
+
+        def entity_function(context: df.DurableEntityContext) -> None:
+            """Durable entity that manages agent execution and conversation state.
+
+            Operations:
+            - run: Execute the agent with a message
+            - run_agent: (Deprecated) Execute the agent with a message
+            - reset: Clear conversation history
+            """
+            entity_handler = create_agent_entity(agent, callback)
+            entity_handler(context)
+
+        # Set function name for Azure Functions (used in function.json generation)
+        # Use the prefixed entity name as the function name too.
+        entity_function.__name__ = entity_name_with_prefix
+        self.entity_trigger(context_name="context", entity_name=entity_name_with_prefix)(entity_function)
+
+    def _setup_mcp_tool_trigger(self, agent_name: str, agent_description: str | None) -> None:
+        """Register an MCP tool trigger for an agent using Azure Functions native MCP support.
+
+        This creates a native Azure Functions MCP tool trigger that exposes the agent
+        as an MCP tool, allowing it to be invoked by MCP-compatible clients.
+
+        Args:
+            agent_name: The agent name (used as the MCP tool name)
+            agent_description: Optional description for the MCP tool (shown to clients)
+        """
+        mcp_function_name = self._build_function_name(agent_name, "mcptool")
+
+        # Define tool properties as JSON (MCP tool parameters)
+        tool_properties = json.dumps([
+            {
+                "propertyName": "query",
+                "propertyType": "string",
+                "description": "The query to send to the agent.",
+                "isRequired": True,
+                "isArray": False,
+            },
+            {
+                "propertyName": "threadId",
+                "propertyType": "string",
+                "description": "Optional thread identifier for conversation continuity.",
+                "isRequired": False,
+                "isArray": False,
+            },
+        ])
+
+        function_name_decorator = self.function_name(mcp_function_name)
+        mcp_tool_decorator = self.mcp_tool_trigger(
+            arg_name="context",
+            tool_name=agent_name,
+            description=agent_description or f"Interact with {agent_name} agent",
+            tool_properties=tool_properties,
+            data_type=func.DataType.UNDEFINED,
+        )
+        durable_client_decorator = self.durable_client_input(client_name="client")
+
+        @function_name_decorator
+        @mcp_tool_decorator
+        @durable_client_decorator
+        async def mcp_tool_handler(context: str, client: df.DurableOrchestrationClient) -> str:
+            """Handle MCP tool invocation for the agent.
+
+            Args:
+                context: MCP tool invocation context containing arguments (query, threadId)
+                client: Durable orchestration client for entity communication
+
+            Returns:
+                Agent response text
+            """
+            logger.debug("[MCP Tool Trigger] Received invocation for agent: %s", agent_name)
+            return await self._handle_mcp_tool_invocation(agent_name=agent_name, context=context, client=client)
+
+        _ = mcp_tool_handler
+        logger.debug("[AgentFunctionApp] Registered MCP tool trigger for agent: %s", agent_name)
+
+    async def _handle_mcp_tool_invocation(
+        self, agent_name: str, context: str, client: df.DurableOrchestrationClient
+    ) -> str:
+        """Handle an MCP tool invocation.
+
+        This method processes MCP tool requests and delegates to the agent entity.
+
+        Args:
+            agent_name: Name of the agent being invoked
+            context: MCP tool invocation context as a JSON string
+            client: Durable orchestration client
+
+        Returns:
+            Agent response text
+
+        Raises:
+            ValueError: If required arguments are missing or context is invalid JSON
+            RuntimeError: If agent execution fails
+        """
+        logger.debug("[MCP Tool Handler] Processing invocation for agent '%s'", agent_name)
+
+        # Parse JSON context string
+        try:
+            parsed_context: Any = json.loads(context)
+        except json.JSONDecodeError as e:
+            raise ValueError(f"Invalid MCP context format: {e}") from e
+
+        parsed_context = cast(Mapping[str, Any], parsed_context) if isinstance(parsed_context, dict) else {}
+
+        # Extract arguments from MCP context
+        arguments: dict[str, Any] = parsed_context.get("arguments", {})
+
+        # Validate required 'query' argument
+        query: Any = arguments.get("query")
+        if not query or not isinstance(query, str):
+            raise ValueError("MCP Tool invocation is missing required 'query' argument of type string.")
+
+        # Extract optional threadId
+        thread_id = arguments.get("threadId")
+
+        # Create or parse session ID
+        if thread_id and isinstance(thread_id, str) and thread_id.strip():
+            try:
+                session_id = AgentSessionId.parse(thread_id, agent_name=agent_name)
+            except ValueError as e:
+                logger.warning(
+                    "Failed to parse AgentSessionId from thread_id '%s': %s. Falling back to new session ID.",
+                    thread_id,
+                    e,
+                )
+                session_id = AgentSessionId(name=agent_name, key=thread_id)
+        else:
+            # Generate new session ID
+            session_id = AgentSessionId.with_random_key(agent_name)
+
+        # Build entity instance ID
+        entity_instance_id = df.EntityId(
+            name=session_id.entity_name,
+            key=session_id.key,
+        )
+
+        # Create run request
+        correlation_id = self._generate_unique_id()
+        run_request = self._build_request_data(
+            req_body={"message": query, "role": "user"},
+            message=query,
+            correlation_id=correlation_id,
+            request_response_format=REQUEST_RESPONSE_FORMAT_TEXT,
+        )
+
+        query_preview = query[:50] + "..." if len(query) > 50 else query
+        logger.info("[MCP Tool] Invoking agent '%s' with query: %s", agent_name, query_preview)
+
+        # Signal entity to run agent
+        await client.signal_entity(entity_instance_id, "run", run_request)
+
+        # Poll for response (similar to HTTP handler)
+        try:
+            result = await self._get_response_from_entity(
+                client=client,
+                entity_instance_id=entity_instance_id,
+                correlation_id=correlation_id,
+                message=query,
+                thread_id=str(session_id),
+            )
+
+            # Extract and return response text
+            if result.get("status") == "success":
+                response_text = str(result.get("response", "No response"))
+                logger.info("[MCP Tool] Agent '%s' responded successfully", agent_name)
+                return response_text
+            error_msg = result.get("error", "Unknown error")
+            logger.error("[MCP Tool] Agent '%s' execution failed: %s", agent_name, error_msg)
+            raise RuntimeError(f"Agent execution failed: {error_msg}")
+
+        except Exception as exc:
+            logger.error("[MCP Tool] Error invoking agent '%s': %s", agent_name, exc, exc_info=True)
+            raise
+
+    def _setup_health_route(self) -> None:
+        """Register the optional health check route."""
+        health_route = self.route(route="health", methods=["GET"])
+
+        @health_route
+        def health_check(req: func.HttpRequest) -> func.HttpResponse:
+            """Built-in health check endpoint."""
+            agent_info = [
+                {
+                    "name": name,
+                    "type": type(metadata.agent).__name__,
+                    "http_endpoint_enabled": metadata.http_endpoint_enabled,
+                    "mcp_tool_enabled": metadata.mcp_tool_enabled,
+                }
+                for name, metadata in self._agent_metadata.items()
+            ]
+            return func.HttpResponse(
+                json.dumps({"status": "healthy", "agents": agent_info, "agent_count": len(self._agent_metadata)}),
+                status_code=200,
+                mimetype=MIMETYPE_APPLICATION_JSON,
+            )
+
+        _ = health_check
+
+    @staticmethod
+    def _build_function_name(agent_name: str, prefix: str) -> str:
+        """Generate the sanitized function name in the form "{prefix}-{sanitized_agent_name}".
+
+        Example: agent_name="Weather Agent" and prefix="http" becomes "http-Weather_Agent".
+        """
+        sanitized_agent = re.sub(r"[^0-9a-zA-Z_]", "_", agent_name or "agent").strip("_")
+
+        if not sanitized_agent:
+            sanitized_agent = "agent"
+
+        if sanitized_agent[0].isdigit():
+            sanitized_agent = f"agent_{sanitized_agent}"
+
+        return f"{prefix}-{sanitized_agent}"
+
+    async def _read_cached_state(
+        self,
+        client: df.DurableOrchestrationClient,
+        entity_instance_id: df.EntityId,
+    ) -> DurableAgentState | None:
+        state_response = await client.read_entity_state(entity_instance_id)
+        if not state_response or not state_response.entity_exists:
+            return None
+
+        state_payload = state_response.entity_state
+        if not isinstance(state_payload, dict):
+            return None
+
+        typed_state_payload = cast(dict[str, Any], state_payload)
+
+        return DurableAgentState.from_dict(typed_state_payload)
+
+    async def _get_response_from_entity(
+        self,
+        client: df.DurableOrchestrationClient,
+        entity_instance_id: df.EntityId,
+        correlation_id: str,
+        message: str,
+        thread_id: str,
+    ) -> dict[str, Any]:
+        """Poll the entity state until a response is available or timeout occurs."""
+        max_retries = self.max_poll_retries
+        interval = self.poll_interval_seconds
+        retry_count = 0
+        result: dict[str, Any] | None = None
+
+        logger.debug(f"[HTTP Trigger] Waiting for response with correlation ID: {correlation_id}")
+
+        while retry_count < max_retries:
+            await asyncio.sleep(interval)
+
+            result = await self._poll_entity_for_response(
+                client=client,
+                entity_instance_id=entity_instance_id,
+                correlation_id=correlation_id,
+                message=message,
+                thread_id=thread_id,
+            )
+            if result is not None:
+                break
+
+            logger.debug(f"[HTTP Trigger] Response not available yet (retry {retry_count})")
+            retry_count += 1
+
+        if result is not None:
+            return result
+
+        logger.warning(
+            f"[HTTP Trigger] Response with correlation ID {correlation_id} "
+            f"not found in time (waited {max_retries * interval} seconds)"
+        )
+        return await self._build_timeout_result(message=message, thread_id=thread_id, correlation_id=correlation_id)
+
+    async def _poll_entity_for_response(
+        self,
+        client: df.DurableOrchestrationClient,
+        entity_instance_id: df.EntityId,
+        correlation_id: str,
+        message: str,
+        thread_id: str,
+    ) -> dict[str, Any] | None:
+        result: dict[str, Any] | None = None
+        try:
+            state = await self._read_cached_state(client, entity_instance_id)
+
+            if state is None:
+                return None
+
+            agent_response = state.try_get_agent_response(correlation_id)
+            if agent_response:
+                result = self._build_success_result(
+                    response_message=agent_response.text,
+                    message=message,
+                    thread_id=thread_id,
+                    correlation_id=correlation_id,
+                    state=state,
+                )
+                logger.debug(f"[HTTP Trigger] Found response for correlation ID: {correlation_id}")
+
+        except Exception as exc:
+            logger.warning(f"[HTTP Trigger] Error reading entity state: {exc}")
+
+        return result
+
+    def _build_response_payload(
+        self,
+        *,
+        response: str | None,
+        message: str,
+        thread_id: str,
+        status: str,
+        correlation_id: str,
+        extra_fields: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Create a consistent response structure and allow optional extra fields."""
+        payload = {
+            "response": response,
+            "message": message,
+            THREAD_ID_FIELD: thread_id,
+            "status": status,
+            "correlation_id": correlation_id,
+        }
+        if extra_fields:
+            payload.update(extra_fields)
+        return payload
+
+    async def _build_timeout_result(self, message: str, thread_id: str, correlation_id: str) -> dict[str, Any]:
+        """Create the timeout response."""
+        return self._build_response_payload(
+            response="Agent is still processing or timed out...",
+            message=message,
+            thread_id=thread_id,
+            status="timeout",
+            correlation_id=correlation_id,
+        )
+
+    def _build_success_result(
+        self, response_message: str, message: str, thread_id: str, correlation_id: str, state: DurableAgentState
+    ) -> dict[str, Any]:
+        """Build the success result returned to the HTTP caller."""
+        return self._build_response_payload(
+            response=response_message,
+            message=message,
+            thread_id=thread_id,
+            status="success",
+            correlation_id=correlation_id,
+            extra_fields={ApiResponseFields.MESSAGE_COUNT: state.message_count},
+        )
+
+    def _build_request_data(
+        self,
+        req_body: dict[str, Any],
+        message: str,
+        correlation_id: str,
+        request_response_format: str,
+    ) -> dict[str, Any]:
+        """Create the durable entity request payload."""
+        enable_tool_calls_value = req_body.get("enable_tool_calls")
+        enable_tool_calls = True if enable_tool_calls_value is None else self._coerce_to_bool(enable_tool_calls_value)
+
+        return RunRequest(
+            message=message,
+            role=req_body.get("role"),
+            request_response_format=request_response_format,
+            response_format=req_body.get("response_format"),
+            enable_tool_calls=enable_tool_calls,
+            correlation_id=correlation_id,
+            created_at=datetime.now(timezone.utc),
+        ).to_dict()
+
+    def _build_accepted_response(self, message: str, thread_id: str, correlation_id: str) -> dict[str, Any]:
+        """Build the response returned when not waiting for completion."""
+        return self._build_response_payload(
+            response="Agent request accepted",
+            message=message,
+            thread_id=thread_id,
+            status="accepted",
+            correlation_id=correlation_id,
+        )
+
+    def _create_http_response(
+        self,
+        payload: dict[str, Any] | str,
+        status_code: int,
+        request_response_format: str,
+        thread_id: str | None,
+    ) -> func.HttpResponse:
+        """Create the HTTP response using helper serializers for clarity."""
+        if request_response_format == REQUEST_RESPONSE_FORMAT_TEXT:
+            return self._build_plain_text_response(payload=payload, status_code=status_code, thread_id=thread_id)
+
+        return self._build_json_response(payload=payload, status_code=status_code)
+
+    def _build_plain_text_response(
+        self,
+        payload: dict[str, Any] | str,
+        status_code: int,
+        thread_id: str | None,
+    ) -> func.HttpResponse:
+        """Return a plain-text response with optional thread identifier header."""
+        body_text = payload if isinstance(payload, str) else self._convert_payload_to_text(payload)
+        headers = {THREAD_ID_HEADER: thread_id} if thread_id is not None else None
+        return func.HttpResponse(body_text, status_code=status_code, mimetype=MIMETYPE_TEXT_PLAIN, headers=headers)
+
+    def _build_json_response(self, payload: dict[str, Any] | str, status_code: int) -> func.HttpResponse:
+        """Return the JSON response, serializing dictionaries as needed."""
+        body_json = payload if isinstance(payload, str) else json.dumps(payload)
+        return func.HttpResponse(body_json, status_code=status_code, mimetype=MIMETYPE_APPLICATION_JSON)
+
+    @staticmethod
+    def _build_error_response(message: str, status_code: int = 400) -> func.HttpResponse:
+        """Return a JSON error response with the given message and status code."""
+        return func.HttpResponse(
+            json.dumps({"error": message}),
+            status_code=status_code,
+            mimetype=MIMETYPE_APPLICATION_JSON,
+        )
+
+    def _convert_payload_to_text(self, payload: dict[str, Any]) -> str:
+        """Convert a structured payload into a human-readable text response."""
+        for key in ("response", "error", "message"):
+            value = payload.get(key)
+            if isinstance(value, str) and value:
+                return value
+        return json.dumps(payload)
+
+    def _generate_unique_id(self) -> str:
+        """Generate a new unique identifier."""
+        return uuid.uuid4().hex
+
+    def _create_session_id(self, agent_name: str, thread_id: str | None) -> AgentSessionId:
+        """Create a session identifier using the provided thread id or a random value."""
+        if thread_id:
+            return AgentSessionId(name=agent_name, key=thread_id)
+        return AgentSessionId.with_random_key(name=agent_name)
+
+    def _resolve_thread_id(self, req: func.HttpRequest, req_body: dict[str, Any]) -> str:
+        """Retrieve the thread identifier from request body or query parameters."""
+        params = req.params or {}
+
+        if THREAD_ID_FIELD in req_body:
+            value = req_body.get(THREAD_ID_FIELD)
+            if value is not None:
+                return str(value)
+
+        if THREAD_ID_FIELD in params:
+            value = params.get(THREAD_ID_FIELD)
+            if value is not None:
+                return str(value)
+
+        logger.debug("[HTTP Trigger] No thread identifier provided; using random thread id")
+        return self._generate_unique_id()
+
+    def _parse_incoming_request(self, req: func.HttpRequest) -> tuple[dict[str, Any], str, str]:
+        """Parse the incoming run request supporting JSON and plain text bodies."""
+        headers = self._extract_normalized_headers(req)
+
+        normalized_content_type = self._extract_content_type(headers)
+        body_parser, body_format = self._select_body_parser(normalized_content_type)
+        prefers_json = self._accepts_json_response(headers)
+        request_response_format = self._select_request_response_format(
+            body_format=body_format, prefers_json=prefers_json
+        )
+
+        req_body, message = body_parser(req)
+        return req_body, message, request_response_format
+
+    def _extract_normalized_headers(self, req: func.HttpRequest) -> dict[str, str]:
+        """Create a lowercase header mapping from the incoming request."""
+        headers: dict[str, str] = {}
+        raw_headers = req.headers
+        for key, value in cast(Mapping[str, str], raw_headers).items():
+            headers[key.lower()] = value
+
+        return headers
+
+    @staticmethod
+    def _extract_content_type(headers: dict[str, str]) -> str:
+        """Return the normalized content-type value (without parameters)."""
+        content_type_header = headers.get("content-type", "")
+        return content_type_header.split(";")[0].strip().lower() if content_type_header else ""
+
+    def _select_body_parser(
+        self,
+        normalized_content_type: str,
+    ) -> tuple[Callable[[func.HttpRequest], tuple[dict[str, Any], str]], str]:
+        """Choose the body parser and declared body format."""
+        if normalized_content_type in {MIMETYPE_APPLICATION_JSON} or normalized_content_type.endswith("+json"):
+            return self._parse_json_body, REQUEST_RESPONSE_FORMAT_JSON
+        return self._parse_text_body, REQUEST_RESPONSE_FORMAT_TEXT
+
+    @staticmethod
+    def _accepts_json_response(headers: dict[str, str]) -> bool:
+        """Check whether the caller explicitly requests a JSON response."""
+        accept_header = headers.get("accept")
+        if not accept_header:
+            return False
+
+        for value in accept_header.split(","):
+            media_type = value.split(";")[0].strip().lower()
+            if media_type == MIMETYPE_APPLICATION_JSON:
+                return True
+        return False
+
+    @staticmethod
+    def _select_request_response_format(body_format: str, prefers_json: bool) -> str:
+        """Combine body format and accept preference to determine response format."""
+        if body_format == REQUEST_RESPONSE_FORMAT_JSON or prefers_json:
+            return REQUEST_RESPONSE_FORMAT_JSON
+        return REQUEST_RESPONSE_FORMAT_TEXT
+
+    @staticmethod
+    def _parse_json_body(req: func.HttpRequest) -> tuple[dict[str, Any], str]:
+        req_body = req.get_json()
+        if not isinstance(req_body, dict):
+            raise IncomingRequestError("Invalid JSON payload. Expected an object.")
+
+        typed_req_body = cast(dict[str, Any], req_body)
+        message_value = typed_req_body.get("message", "")
+        message = message_value if isinstance(message_value, str) else str(message_value)
+        return typed_req_body, message
+
+    @staticmethod
+    def _parse_text_body(req: func.HttpRequest) -> tuple[dict[str, Any], str]:
+        body_bytes = req.get_body()
+        text_body = body_bytes.decode("utf-8", errors="replace") if body_bytes else ""
+        message = text_body.strip()
+
+        return {}, message
+
+    def _should_wait_for_response(self, req: func.HttpRequest, req_body: dict[str, Any]) -> bool:
+        """Determine whether the caller requested to wait for the response."""
+        headers: dict[str, str] = self._extract_normalized_headers(req)
+        header_value: str | None = headers.get(WAIT_FOR_RESPONSE_HEADER)
+
+        if header_value is not None:
+            return self._coerce_to_bool(header_value)
+
+        params = req.params or {}
+        if WAIT_FOR_RESPONSE_FIELD in params:
+            return self._coerce_to_bool(params.get(WAIT_FOR_RESPONSE_FIELD))
+
+        if WAIT_FOR_RESPONSE_FIELD in req_body:
+            return self._coerce_to_bool(req_body.get(WAIT_FOR_RESPONSE_FIELD))
+
+        return True
+
+    def _coerce_to_bool(self, value: Any) -> bool:
+        """Convert various representations into a boolean flag."""
+        if isinstance(value, bool):
+            return value
+        if value is None:
+            return False
+        if isinstance(value, (int, float)):
+            return bool(value)
+        if isinstance(value, str):
+            return value.strip().lower() in {"true", "1", "yes", "y", "on"}
+        return False

--- a/python/packages/azurefunctions/agent_framework_azurefunctions/_context.py
+++ b/python/packages/azurefunctions/agent_framework_azurefunctions/_context.py
@@ -1,10 +1,9 @@
 # Copyright (c) Microsoft. All rights reserved.
 
-"""Runner context for activity execution within durable orchestrations.
+"""Runner context for Azure Functions activity execution.
 
-This module provides the :class:`CapturingRunnerContext` class that captures
-messages and events produced during executor execution within activities.
-It is host-agnostic and works on any durable task host.
+This module provides the CapturingRunnerContext class that captures messages
+and events produced during executor execution within Azure Functions activities.
 """
 
 from __future__ import annotations
@@ -23,56 +22,55 @@ from agent_framework import (
 from agent_framework._workflows._runner_context import YieldOutputClassifier, YieldOutputEventType
 from agent_framework._workflows._state import State
 
-# Keys of the host-metadata mapping the durable host attaches to each executor (as the
-# activity's ``host_context`` input, surfaced here via ``set_host_metadata``). These form
-# a cross-package contract: the orchestrator writes them and
-# ``WorkflowHitlContext.from_context`` in agent-framework-azurefunctions reads them back by
-# the same names, so they live here as shared constants to keep producer and consumer from
-# drifting silently (a rename would just make HITL URLs stop being built, with no error).
-HOST_METADATA_INSTANCE_ID = "instance_id"
-HOST_METADATA_WORKFLOW_NAME = "workflow_name"
-HOST_METADATA_REQUEST_PATH_PREFIX = "request_path_prefix"
-
 
 class CapturingRunnerContext(RunnerContext):
-    """A RunnerContext that captures messages and events for durable activities.
+    """A RunnerContext implementation that captures messages and events for Azure Functions activities.
 
-    This context captures all messages and events produced during execution
-    without requiring durable entity storage, allowing the results to be
-    returned to the orchestrator.
+    This context is designed for executing standard Executors within Azure Functions activities.
+    It captures all messages and events produced during execution without requiring durable
+    entity storage, allowing the results to be returned to the orchestrator.
 
-    Checkpointing is not supported — the orchestrator manages state.
+    Unlike InProcRunnerContext, this implementation does NOT support checkpointing
+    (always returns False for has_checkpointing). The orchestrator manages state
+    coordination; this context just captures execution output.
     """
 
     def __init__(self) -> None:
+        """Initialize the capturing runner context."""
         self._messages: dict[str, list[WorkflowMessage]] = {}
         self._event_queue: asyncio.Queue[WorkflowEvent] = asyncio.Queue()
         self._pending_request_info_events: dict[str, WorkflowEvent[Any]] = {}
         self._workflow_id: str | None = None
         self._streaming: bool = False
         self._yield_output_classifier: YieldOutputClassifier = lambda _executor_id: "output"
-        self._host_metadata: dict[str, Any] | None = None
 
-    # -- Messaging ------------------------------------------------------------
+    # region Messaging
 
     async def send_message(self, message: WorkflowMessage) -> None:
+        """Capture a message sent by an executor."""
         self._messages.setdefault(message.source_id, [])
         self._messages[message.source_id].append(message)
 
     async def drain_messages(self) -> dict[str, list[WorkflowMessage]]:
+        """Drain and return all captured messages."""
         messages = copy(self._messages)
         self._messages.clear()
         return messages
 
     async def has_messages(self) -> bool:
+        """Check if there are any captured messages."""
         return bool(self._messages)
 
-    # -- Events ---------------------------------------------------------------
+    # endregion Messaging
+
+    # region Events
 
     async def add_event(self, event: WorkflowEvent) -> None:
+        """Capture an event produced during execution."""
         await self._event_queue.put(event)
 
     async def drain_events(self) -> list[WorkflowEvent]:
+        """Drain all currently queued events without blocking."""
         events: list[WorkflowEvent] = []
         while True:
             try:
@@ -82,20 +80,27 @@ class CapturingRunnerContext(RunnerContext):
         return events
 
     async def has_events(self) -> bool:
+        """Check if there are any queued events."""
         return not self._event_queue.empty()
 
     async def next_event(self) -> WorkflowEvent:
+        """Wait for and return the next event."""
         return await self._event_queue.get()
 
-    # -- Checkpointing (not supported) ----------------------------------------
+    # endregion Events
+
+    # region Checkpointing (not supported in activity context)
 
     def has_checkpointing(self) -> bool:
+        """Checkpointing is not supported in activity context."""
         return False
 
     def set_runtime_checkpoint_storage(self, storage: CheckpointStorage) -> None:
+        """No-op: checkpointing not supported in activity context."""
         pass
 
     def clear_runtime_checkpoint_storage(self) -> None:
+        """No-op: checkpointing not supported in activity context."""
         pass
 
     async def create_checkpoint(
@@ -107,71 +112,70 @@ class CapturingRunnerContext(RunnerContext):
         iteration_count: int,
         metadata: dict[str, Any] | None = None,
     ) -> str:
-        raise NotImplementedError("Checkpointing is not supported in activity context")
+        """Checkpointing not supported in activity context."""
+        raise NotImplementedError("Checkpointing is not supported in Azure Functions activity context")
 
     async def load_checkpoint(self, checkpoint_id: str) -> WorkflowCheckpoint | None:
-        raise NotImplementedError("Checkpointing is not supported in activity context")
+        """Checkpointing not supported in activity context."""
+        raise NotImplementedError("Checkpointing is not supported in Azure Functions activity context")
 
     async def apply_checkpoint(self, checkpoint: WorkflowCheckpoint) -> None:
-        raise NotImplementedError("Checkpointing is not supported in activity context")
+        """Checkpointing not supported in activity context."""
+        raise NotImplementedError("Checkpointing is not supported in Azure Functions activity context")
 
-    # -- Workflow configuration -----------------------------------------------
+    # endregion Checkpointing
+
+    # region Workflow Configuration
 
     def set_workflow_id(self, workflow_id: str) -> None:
+        """Set the workflow ID."""
         self._workflow_id = workflow_id
 
     def reset_for_new_run(self) -> None:
+        """Reset the context for a new run."""
         self._messages.clear()
         self._event_queue = asyncio.Queue()
         self._pending_request_info_events.clear()
         self._streaming = False
 
     def set_streaming(self, streaming: bool) -> None:
+        """Set streaming mode (not used in activity context)."""
         self._streaming = streaming
 
     def is_streaming(self) -> bool:
+        """Check if streaming mode is enabled (always False in activity context)."""
         return self._streaming
 
-    # -- Host metadata --------------------------------------------------------
-
-    @property
-    def host_metadata(self) -> dict[str, Any] | None:
-        """Orchestration metadata injected by the durable host, or ``None`` in-process.
-
-        The durable orchestrator populates this from its own context (e.g. the
-        orchestration ``instance_id`` and ``workflow_name``) so an executor can
-        address the running orchestration -- for example to build a human-in-the-loop
-        respond URL and notify a reviewer -- without the caller threading those ids by
-        hand. It is ``None`` when the same executor runs in-process (no durable host),
-        so host-specific helpers can degrade gracefully.
-        """
-        return self._host_metadata
-
-    def set_host_metadata(self, metadata: dict[str, Any] | None) -> None:
-        """Set the orchestration metadata for this activity execution."""
-        self._host_metadata = metadata
-
-    # -- Yield-output classification -------------------------------------------
-
     def set_yield_output_classifier(self, classifier: YieldOutputClassifier) -> None:
-        """Set the classifier used by ``WorkflowContext.yield_output()``."""
+        """Set the classifier used by WorkflowContext.yield_output()."""
         self._yield_output_classifier = classifier
 
     def classify_yielded_output(self, executor_id: str) -> YieldOutputEventType | None:
         """Classify an executor's yield_output payload as output, intermediate, or hidden."""
         return self._yield_output_classifier(executor_id)
 
-    # -- Request Info Events --------------------------------------------------
+    # endregion Workflow Configuration
+
+    # region Request Info Events
 
     async def add_request_info_event(self, event: WorkflowEvent[Any]) -> None:
+        """Add a request_info WorkflowEvent and track it for correlation."""
         self._pending_request_info_events[event.request_id] = event
         await self.add_event(event)
 
     async def send_request_info_response(self, request_id: str, response: Any) -> None:
+        """Send a response correlated to a pending request.
+
+        Note: This is not supported in activity context since human-in-the-loop
+        scenarios require orchestrator-level coordination.
+        """
         raise NotImplementedError(
-            "send_request_info_response is not supported in activity context. "
+            "send_request_info_response is not supported in Azure Functions activity context. "
             "Human-in-the-loop scenarios should be handled at the orchestrator level."
         )
 
     async def get_pending_request_info_events(self) -> dict[str, WorkflowEvent[Any]]:
+        """Get the mapping of request IDs to their corresponding request_info events."""
         return dict(self._pending_request_info_events)
+
+    # endregion Request Info Events

--- a/python/packages/azurefunctions/agent_framework_azurefunctions/_entities.py
+++ b/python/packages/azurefunctions/agent_framework_azurefunctions/_entities.py
@@ -1,0 +1,118 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+"""Durable Entity for Agent Execution.
+
+This module defines a durable entity that manages agent state and execution.
+Using entities instead of orchestrations provides better state management and
+allows for long-running agent conversations.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from typing import Any, cast
+
+import azure.durable_functions as df
+from agent_framework import SupportsAgentRun
+from agent_framework_durabletask import (
+    AgentEntity,
+    AgentEntityStateProviderMixin,
+    AgentResponseCallbackProtocol,
+    run_agent_coroutine,
+)
+
+logger = logging.getLogger("agent_framework.azurefunctions")
+
+
+class AzureFunctionEntityStateProvider(AgentEntityStateProviderMixin):
+    """Azure Functions Durable Entity state provider for AgentEntity.
+
+    This class utilizes the Durable Entity context from `azure-functions-durable` package
+    to get and set the state of the agent entity.
+    """
+
+    def __init__(self, context: df.DurableEntityContext) -> None:
+        self._context = context
+
+    def _get_state_dict(self) -> dict[str, Any]:
+        raw_state = self._context.get_state(lambda: {})
+        if not isinstance(raw_state, dict):
+            return {}
+        return cast(dict[str, Any], raw_state)
+
+    def _set_state_dict(self, state: dict[str, Any]) -> None:
+        self._context.set_state(state)
+
+    def _get_thread_id_from_entity(self) -> str:
+        return str(self._context.entity_key)
+
+
+def create_agent_entity(
+    agent: SupportsAgentRun,
+    callback: AgentResponseCallbackProtocol | None = None,
+) -> Callable[[df.DurableEntityContext], None]:
+    """Factory function to create an agent entity class.
+
+    Args:
+        agent: The Microsoft Agent Framework agent instance (must implement SupportsAgentRun)
+        callback: Optional callback invoked during streaming and final responses
+
+    Returns:
+        Entity function configured with the agent
+    """
+
+    async def _entity_coroutine(context: df.DurableEntityContext) -> None:
+        """Async handler that executes the entity operations."""
+        try:
+            logger.debug("[entity_function] Entity triggered")
+            logger.debug("[entity_function] Operation: %s", context.operation_name)
+
+            state_provider = AzureFunctionEntityStateProvider(context)
+            entity = AgentEntity(agent, callback, state_provider=state_provider)
+
+            operation = context.operation_name
+
+            if operation == "run" or operation == "run_agent":
+                input_data: Any = context.get_input()
+
+                request: str | dict[str, Any]
+                if isinstance(input_data, dict) and "message" in input_data:
+                    request = cast(dict[str, Any], input_data)
+                else:
+                    # Fall back to treating input as message string
+                    request = "" if input_data is None else str(cast(object, input_data))
+
+                result = await entity.run(request)
+                context.set_result(result.to_dict())
+
+            elif operation == "reset":
+                entity.reset()
+                context.set_result({"status": "reset"})
+
+            else:
+                logger.error("[entity_function] Unknown operation: %s", operation)
+                context.set_result({"error": f"Unknown operation: {operation}"})
+
+            logger.info("[entity_function] Operation %s completed successfully", operation)
+
+        except Exception as exc:
+            logger.exception("[entity_function] Error executing entity operation %s", exc)
+            context.set_result({"error": str(exc), "status": "error"})
+
+    def entity_function(context: df.DurableEntityContext) -> None:
+        """Synchronous wrapper invoked by the Durable Functions runtime.
+
+        All agent coroutines run on a single process-wide persistent event loop
+        (see ``run_agent_coroutine``). This keeps async resources created by
+        shared agent clients/credentials bound to a live loop across every
+        invocation, preventing cross-loop hangs when the host dispatches
+        successive entity operations onto different worker threads.
+        """
+        try:
+            run_agent_coroutine(_entity_coroutine(context))
+        except Exception as exc:  # pragma: no cover - defensive logging
+            logger.error("[entity_function] Unexpected error executing entity: %s", exc, exc_info=True)
+            context.set_result({"error": str(exc), "status": "error"})
+
+    return entity_function

--- a/python/packages/azurefunctions/agent_framework_azurefunctions/_errors.py
+++ b/python/packages/azurefunctions/agent_framework_azurefunctions/_errors.py
@@ -1,0 +1,11 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+"""Custom exception types for the durable agent framework."""
+
+
+class IncomingRequestError(ValueError):
+    """Raised when an incoming HTTP request cannot be parsed or validated."""
+
+    def __init__(self, message: str, status_code: int = 400) -> None:
+        super().__init__(message)
+        self.status_code = status_code

--- a/python/packages/azurefunctions/agent_framework_azurefunctions/_hitl_context.py
+++ b/python/packages/azurefunctions/agent_framework_azurefunctions/_hitl_context.py
@@ -1,0 +1,223 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+"""Human-in-the-loop (HITL) addressing helper for workflow executors.
+
+When a MAF :class:`~agent_framework.Workflow` runs on the Azure Functions durable
+host, an executor can ask a human for input via ``ctx.request_info(...)``. To notify
+that human out-of-band (for example by emailing them an approval link), the executor
+needs the orchestration's ``instanceId`` and the request's ``requestId`` so it can
+build the ``/respond`` URL the reviewer will POST back to.
+
+:class:`WorkflowHitlContext` packages that addressing. It reads the orchestration
+metadata the durable host surfaces on the executor's runner context (see
+``CapturingRunnerContext.host_metadata``) and builds the canonical respond/status
+URLs that :class:`~agent_framework_azurefunctions.AgentFunctionApp` exposes -- so the
+executor never has to thread the instance id or base URL by hand.
+
+Typical use, from inside a notify executor reached by an edge from the executor that
+called ``request_info``::
+
+    hitl = WorkflowHitlContext.from_context(ctx)
+    if hitl is not None:  # None when not on the Azure Functions durable host
+        url = hitl.build_respond_url(request_id)
+        send_email(to=reviewer, body=f"Approve or reject here: {url}")
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Any, cast
+
+from agent_framework_durabletask._workflows.runner_context import (
+    HOST_METADATA_INSTANCE_ID,
+    HOST_METADATA_REQUEST_PATH_PREFIX,
+    HOST_METADATA_WORKFLOW_NAME,
+)
+
+from ._routes import build_workflow_respond_url, build_workflow_status_url
+
+# App setting carrying the function app's host (e.g. ``myapp.azurewebsites.net``).
+# Azure Functions sets this automatically in the cloud; for local ``func start`` runs
+# add it to the ``Values`` map in ``local.settings.json`` (e.g. ``localhost:7071``).
+WEBSITE_HOSTNAME_ENV = "WEBSITE_HOSTNAME"
+
+# Loopback hosts that resolve to ``http`` (not ``https``) when WEBSITE_HOSTNAME is
+# host-only; covers the addresses ``func start`` can bind locally.
+_LOOPBACK_HOSTS = frozenset({"localhost", "0.0.0.0", "::1"})  # noqa: S104  # nosec B104
+
+
+def _is_loopback(host: str) -> bool:
+    """Return whether ``host`` (optionally ``host:port``) is a local loopback address.
+
+    Handles ``localhost``, IPv4 ``127.0.0.0/8`` and ``0.0.0.0``, and IPv6 ``::1``
+    (including the bracketed ``[::1]:port`` form ``func start`` prints).
+    """
+    normalized = host.strip().lower()
+    if normalized.startswith("["):  # bracketed IPv6 like [::1]:7071
+        normalized = normalized[1 : normalized.find("]")] if "]" in normalized else normalized[1:]
+    elif normalized.count(":") == 1:  # host:port (bare IPv6 has multiple colons)
+        normalized = normalized.split(":", 1)[0]
+    return normalized in _LOOPBACK_HOSTS or normalized.startswith("127.")
+
+
+@dataclass(frozen=True)
+class WorkflowHitlContext:
+    """Builds Azure Functions HITL respond/status URLs from inside a workflow executor.
+
+    Obtain one with :meth:`from_context`. It exposes the addressable *root*
+    orchestration's ``instance_id`` and ``workflow_name`` and builds the URLs an
+    external reviewer uses to resume the workflow. When the executor runs inside a
+    nested sub-workflow, ``request_path_prefix`` carries the ``{executor}~{ordinal}~``
+    hops from the root down to this level, so :meth:`build_respond_url` qualifies a bare
+    request id back to the top-level instance automatically. The base URL is resolved
+    lazily (see :attr:`base_url`) from an explicit override or the ``WEBSITE_HOSTNAME``
+    app setting.
+    """
+
+    instance_id: str
+    workflow_name: str
+    base_url_override: str | None = None
+    request_path_prefix: str = ""
+
+    @classmethod
+    def from_context(
+        cls,
+        ctx: Any,
+        *,
+        base_url: str | None = None,
+    ) -> WorkflowHitlContext | None:
+        """Build a HITL context from a workflow executor's ``WorkflowContext``.
+
+        Reads the orchestration metadata the durable host attached to the executor's
+        runner context. Returns ``None`` when that metadata is absent -- i.e. the same
+        executor is running in-process rather than on the Azure Functions durable host
+        -- so callers can skip notification and degrade gracefully.
+
+        Args:
+            ctx: The ``WorkflowContext`` passed to the executor's handler.
+            base_url: Optional explicit base URL (scheme + host, e.g.
+                ``https://contoso.example.com``). Use this when the public URL differs
+                from ``WEBSITE_HOSTNAME`` -- for example behind a custom domain or API
+                Management gateway, where ``WEBSITE_HOSTNAME`` still reports the default
+                ``*.azurewebsites.net`` host. When omitted, the base URL is resolved
+                from ``WEBSITE_HOSTNAME`` on first use.
+
+        Returns:
+            A :class:`WorkflowHitlContext`, or ``None`` if not running on a durable host.
+        """
+        runner_context = getattr(ctx, "_runner_context", None)
+        raw_metadata = getattr(runner_context, "host_metadata", None)
+        if not isinstance(raw_metadata, dict):
+            return None
+        metadata = cast("dict[str, Any]", raw_metadata)
+
+        instance_id = metadata.get(HOST_METADATA_INSTANCE_ID)
+        workflow_name = metadata.get(HOST_METADATA_WORKFLOW_NAME)
+        if not isinstance(instance_id, str) or not isinstance(workflow_name, str):
+            return None
+
+        # Present when the executor runs inside a nested sub-workflow; absent/empty at
+        # the top level. Defaults to "" so the request id is used unqualified.
+        raw_prefix = metadata.get(HOST_METADATA_REQUEST_PATH_PREFIX)
+        request_path_prefix = raw_prefix if isinstance(raw_prefix, str) else ""
+
+        return cls(
+            instance_id=instance_id,
+            workflow_name=workflow_name,
+            base_url_override=base_url,
+            request_path_prefix=request_path_prefix,
+        )
+
+    @staticmethod
+    async def pending_request_id(ctx: Any) -> str | None:
+        """Return the id of the most recently emitted ``request_info`` on ``ctx``.
+
+        Call this **immediately after** ``await ctx.request_info(...)`` to recover the
+        request id the framework generated, so it can be forwarded (e.g. in a message
+        to a downstream notify executor that builds the respond URL) without the caller
+        generating an id by hand.
+
+        Why "immediately after" is the rule, and why it is safe on the durable host:
+        the returned id is simply the newest entry in the executor's pending
+        request-info set, so reading right after a call always yields *that* call's id.
+        On the Azure Functions durable host every executor runs in its own activity with
+        its own runner context, so that set only ever holds this executor's own
+        requests (never another executor's), and the request you just emitted is always
+        the latest. If a single executor emits several ``request_info`` calls in one
+        turn, read this after **each** call (the only case where reading once at the end
+        would lose the earlier ids); or pass an explicit ``request_id`` to
+        ``request_info`` to address them directly.
+
+        Returns ``None`` only when no request is pending (or the runner context does not
+        track request-info events, e.g. in process off the durable host).
+        """
+        runner_context = getattr(ctx, "_runner_context", None)
+        getter = getattr(runner_context, "get_pending_request_info_events", None)
+        if getter is None:
+            return None
+        events = await getter()
+        if not events:
+            return None
+        # Dicts preserve insertion order, so the last key is the most recent request.
+        return next(reversed(events))
+
+    @property
+    def base_url(self) -> str:
+        """The scheme + host the respond/status URLs are built on (no trailing slash).
+
+        Resolution order: the explicit ``base_url`` passed to :meth:`from_context`, then
+        the ``WEBSITE_HOSTNAME`` app setting (``http`` for localhost, otherwise
+        ``https``).
+
+        Raises:
+            RuntimeError: If neither an override nor ``WEBSITE_HOSTNAME`` is available.
+        """
+        if self.base_url_override:
+            return self.base_url_override.rstrip("/")
+
+        hostname = os.environ.get(WEBSITE_HOSTNAME_ENV)
+        if not hostname:
+            raise RuntimeError(
+                "Cannot build a HITL URL: no base URL is available. Set the "
+                f"'{WEBSITE_HOSTNAME_ENV}' app setting (present automatically on Azure "
+                "Functions; add it to the 'Values' map in local.settings.json for local "
+                "`func start` runs, e.g. 'localhost:7071'), or pass base_url=... to "
+                "WorkflowHitlContext.from_context()."
+            )
+
+        # WEBSITE_HOSTNAME may include a scheme (unusual but possible); otherwise it is
+        # host-only, so infer one (http for local loopback, https otherwise).
+        if hostname.startswith(("http://", "https://")):
+            return hostname.rstrip("/")
+        scheme = "http" if _is_loopback(hostname) else "https"
+        return f"{scheme}://{hostname.rstrip('/')}"
+
+    def build_respond_url(self, request_id: str) -> str:
+        """Build the URL a reviewer POSTs their response to, resuming the workflow.
+
+        Mirrors the ``respondUrl`` AgentFunctionApp returns from its run/status
+        endpoints: ``{base}/{prefix}/workflow/{name}/respond/{instanceId}/{requestId}``
+        (``prefix`` is the app's ``routePrefix``, ``api`` by default), always targeting
+        the addressable top-level instance.
+
+        Args:
+            request_id: The pending request's id -- the id passed to (or generated by)
+                ``ctx.request_info``. Pass the **bare** id even from inside a nested
+                sub-workflow: any :attr:`request_path_prefix` is prepended for you to
+                qualify it (``{executor}~{ordinal}~{requestId}``) back to the root.
+
+        Returns:
+            The fully-qualified respond URL.
+        """
+        qualified_id = f"{self.request_path_prefix}{request_id}"
+        return build_workflow_respond_url(self.base_url, self.workflow_name, self.instance_id, qualified_id)
+
+    def build_status_url(self) -> str:
+        """Build the workflow status URL for this orchestration instance.
+
+        Returns ``{base}/{prefix}/workflow/{name}/status/{instanceId}`` (``prefix`` is the
+        app's ``routePrefix``, ``api`` by default), the same endpoint AgentFunctionApp
+        exposes for polling runtime status and pending HITL requests.
+        """
+        return build_workflow_status_url(self.base_url, self.workflow_name, self.instance_id)

--- a/python/packages/azurefunctions/agent_framework_azurefunctions/_orchestration.py
+++ b/python/packages/azurefunctions/agent_framework_azurefunctions/_orchestration.py
@@ -1,0 +1,222 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+"""Orchestration Support for Durable Agents.
+
+This module provides support for using agents inside Durable Function orchestrations.
+"""
+
+import logging
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any, TypeAlias
+
+import azure.durable_functions as df
+from agent_framework import AgentSession
+from agent_framework_durabletask import (
+    DurableAgentExecutor,
+    RunRequest,
+    ensure_response_format,
+    load_agent_response,
+)
+from azure.durable_functions.models import TaskBase
+from azure.durable_functions.models.actions.NoOpAction import NoOpAction
+from azure.durable_functions.models.Task import CompoundTask, TaskState
+from pydantic import BaseModel
+
+logger = logging.getLogger("agent_framework.azurefunctions")
+
+CompoundActionConstructor: TypeAlias = Callable[[list[Any]], Any] | None
+
+if TYPE_CHECKING:
+    from azure.durable_functions import DurableOrchestrationContext
+
+    class _TypedCompoundTask(CompoundTask):
+        _first_error: Any
+
+        def __init__(
+            self,
+            tasks: list[TaskBase],
+            compound_action_constructor: CompoundActionConstructor = None,
+        ) -> None: ...
+
+    AgentOrchestrationContextType: TypeAlias = DurableOrchestrationContext
+else:
+    AgentOrchestrationContextType = Any
+    _TypedCompoundTask = CompoundTask
+
+
+class PreCompletedTask(TaskBase):
+    """A simple task that is already completed with a result.
+
+    Used for fire-and-forget mode where we want to return immediately
+    with an acceptance response without waiting for entity processing.
+    """
+
+    def __init__(self, result: Any):
+        """Initialize with a completed result.
+
+        Args:
+            result: The result value for this completed task
+        """
+        # Initialize with a NoOp action since we don't need actual orchestration actions
+        super().__init__(-1, NoOpAction())
+        # Immediately mark as completed with the result
+        self.set_value(is_error=False, value=result)
+
+
+class AgentTask(_TypedCompoundTask):
+    """A custom Task that wraps entity calls and provides typed AgentResponse results.
+
+    This task wraps the underlying entity call task and intercepts its completion
+    to convert the raw result into a typed AgentResponse object.
+    """
+
+    def __init__(
+        self,
+        entity_task: TaskBase,
+        response_format: type[BaseModel] | None,
+        correlation_id: str,
+    ):
+        """Initialize the AgentTask.
+
+        Args:
+            entity_task: The underlying entity call task
+            response_format: Optional Pydantic model for response parsing
+            correlation_id: Correlation ID for logging
+        """
+        # Set instance variables BEFORE calling super().__init__
+        # because super().__init__ may trigger try_set_value for pre-completed tasks
+        self._response_format = response_format
+        self._correlation_id = correlation_id
+
+        super().__init__([entity_task])
+
+        # Override action_repr to expose the inner task's action directly
+        # This ensures compatibility with ReplaySchema V3 which expects Action objects.
+        self.action_repr = entity_task.action_repr
+
+        # Also copy the task ID to match the entity task's identity
+        self.id = entity_task.id
+
+    def try_set_value(self, child: TaskBase) -> None:
+        """Transition the AgentTask to a terminal state and set its value to `AgentResponse`.
+
+        Parameters
+        ----------
+        child : TaskBase
+            The entity call task that just completed
+        """
+        if child.state is TaskState.SUCCEEDED:
+            # Delegate to parent class for standard completion logic
+            if len(self.pending_tasks) == 0:
+                # Transform the raw result before setting it
+                raw_result = child.result
+                logger.debug(
+                    "[AgentTask] Converting raw result for correlation_id %s",
+                    self._correlation_id,
+                )
+
+                try:
+                    response = load_agent_response(raw_result)
+
+                    if self._response_format is not None:
+                        ensure_response_format(
+                            self._response_format,
+                            self._correlation_id,
+                            response,
+                        )
+
+                    # Set the typed AgentResponse as this task's result
+                    self.set_value(is_error=False, value=response)
+                except Exception as e:
+                    logger.exception(
+                        "[AgentTask] Failed to convert result for correlation_id: %s",
+                        self._correlation_id,
+                    )
+                    self.set_value(is_error=True, value=e)
+        else:
+            # If error not handled by the parent, set it explicitly.
+            if self._first_error is None:
+                self._first_error = child.result
+                self.set_value(is_error=True, value=self._first_error)
+
+
+class AzureFunctionsAgentExecutor(DurableAgentExecutor[AgentTask]):
+    """Executor that executes durable agents inside Azure Functions orchestrations."""
+
+    def __init__(self, context: AgentOrchestrationContextType):
+        self.context = context
+
+    def generate_unique_id(self) -> str:
+        return str(self.context.new_uuid())
+
+    def get_run_request(
+        self,
+        message: str,
+        *,
+        options: dict[str, Any] | None = None,
+    ) -> RunRequest:
+        """Get the current run request from the orchestration context.
+
+        Args:
+            message: The message to send to the agent
+            options: Optional options dictionary. Supported keys include
+                ``response_format``, ``enable_tool_calls``, and ``wait_for_response``.
+                Additional keys are forwarded to the agent execution.
+
+        Returns:
+            RunRequest: The current run request
+
+        Raises:
+            ValueError: If wait_for_response=False (not supported in orchestrations)
+        """
+        # Create a copy to avoid modifying the caller's dict
+
+        request = super().get_run_request(message, options=options)
+        request.orchestration_id = self.context.instance_id
+        return request
+
+    def run_durable_agent(
+        self,
+        agent_name: str,
+        run_request: RunRequest,
+        session: AgentSession | None = None,
+    ) -> AgentTask:
+
+        # Resolve session
+        session_id = self._create_session_id(agent_name, session)
+
+        entity_id = df.EntityId(
+            name=session_id.entity_name,
+            key=session_id.key,
+        )
+
+        logger.debug(
+            "[AzureFunctionsAgentProvider] correlation_id: %s entity_id: %s session_id: %s",
+            run_request.correlation_id,
+            entity_id,
+            session_id,
+        )
+
+        # Branch based on wait_for_response
+        if not run_request.wait_for_response:
+            # Fire-and-forget mode: signal entity and return pre-completed task
+            logger.debug(
+                "[AzureFunctionsAgentExecutor] Fire-and-forget mode: signaling entity (correlation: %s)",
+                run_request.correlation_id,
+            )
+            self.context.signal_entity(entity_id, "run", run_request.to_dict())
+
+            # Create acceptance response using base class helper
+            acceptance_response = self._create_acceptance_response(run_request.correlation_id)
+
+            # Create a pre-completed task with the acceptance response
+            entity_task = PreCompletedTask(acceptance_response)
+        else:
+            # Blocking mode: call entity and wait for response
+            entity_task = self.context.call_entity(entity_id, "run", run_request.to_dict())
+
+        return AgentTask(
+            entity_task=entity_task,
+            response_format=run_request.response_format,
+            correlation_id=run_request.correlation_id,
+        )

--- a/python/packages/azurefunctions/agent_framework_azurefunctions/_orchestration.py
+++ b/python/packages/azurefunctions/agent_framework_azurefunctions/_orchestration.py
@@ -165,9 +165,6 @@ class AzureFunctionsAgentExecutor(DurableAgentExecutor[AgentTask]):
 
         Returns:
             RunRequest: The current run request
-
-        Raises:
-            ValueError: If wait_for_response=False (not supported in orchestrations)
         """
         # Create a copy to avoid modifying the caller's dict
 

--- a/python/packages/azurefunctions/agent_framework_azurefunctions/_routes.py
+++ b/python/packages/azurefunctions/agent_framework_azurefunctions/_routes.py
@@ -1,0 +1,117 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+"""Single source of truth for the AgentFunctionApp HTTP route prefix and HITL URLs.
+
+The server endpoints (:mod:`._app`) and the in-workflow addressing helper
+(:mod:`._hitl_context`) build the same ``{prefix}/workflow/{name}/...`` URLs. Keeping the
+shape and the prefix logic here stops the two sides from drifting -- previously they were
+only kept in sync by an integration test asserting the two strings match -- and lets a
+customized ``routePrefix`` be honored instead of a hardcoded ``api`` that would 404 on
+resume. The server derives the prefix from the incoming request URL (the value the host
+actually routed); the helper, which runs inside an executor with no request context,
+reads it from ``host.json``.
+"""
+
+from __future__ import annotations
+
+import functools
+import json
+import logging
+import os
+from typing import Any, cast
+from urllib.parse import urlsplit
+
+logger = logging.getLogger(__name__)
+
+# Azure Functions' default HTTP route prefix, applied when host.json does not override
+# ``extensions.http.routePrefix``.
+DEFAULT_ROUTE_PREFIX = "api"
+
+
+@functools.lru_cache(maxsize=1)
+def route_prefix() -> str:
+    """Return the app's HTTP route prefix, honoring ``host.json``.
+
+    Azure Functions prepends ``extensions.http.routePrefix`` (default ``api``) to every
+    HTTP route, and it can be customized or set to an empty string. That value is not
+    exposed through an environment variable, so it is read from ``host.json`` under the
+    script root (``AzureWebJobsScriptRoot``, falling back to the current working
+    directory) and cached for the process. Any failure to locate or parse the file falls
+    back to the ``api`` default. Tests that vary ``host.json`` call ``route_prefix.cache_clear()``.
+    """
+    return _read_route_prefix()
+
+
+def _read_route_prefix() -> str:
+    # AzureWebJobsScriptRoot is the host-set path to the app root (mixed case is the real
+    # variable name and is case-sensitive on Linux, so it must not be upper-cased).
+    script_root = os.environ.get("AzureWebJobsScriptRoot") or os.getcwd()  # noqa: SIM112
+    host_json_path = os.path.join(script_root, "host.json")
+    try:
+        with open(host_json_path, encoding="utf-8") as f:
+            loaded = json.load(f)
+    except (OSError, ValueError):
+        logger.debug("Could not read '%s'; defaulting route prefix to '%s'.", host_json_path, DEFAULT_ROUTE_PREFIX)
+        return DEFAULT_ROUTE_PREFIX
+    if not isinstance(loaded, dict):
+        return DEFAULT_ROUTE_PREFIX
+    extensions = cast("dict[str, Any]", loaded).get("extensions")
+    if not isinstance(extensions, dict):
+        return DEFAULT_ROUTE_PREFIX
+    http = cast("dict[str, Any]", extensions).get("http")
+    if not isinstance(http, dict):
+        return DEFAULT_ROUTE_PREFIX
+    prefix = cast("dict[str, Any]", http).get("routePrefix")
+    return prefix.strip("/") if isinstance(prefix, str) else DEFAULT_ROUTE_PREFIX
+
+
+def _prefix_segment(prefix: str | None) -> str:
+    """Return the route-prefix path segment with a trailing slash, or ``""`` when empty."""
+    resolved = route_prefix() if prefix is None else prefix.strip("/")
+    return f"{resolved}/" if resolved else ""
+
+
+def build_workflow_respond_url(
+    base_url: str,
+    workflow_name: str,
+    instance_id: str,
+    request_id: str,
+    *,
+    prefix: str | None = None,
+) -> str:
+    """Build the canonical HITL respond URL a reviewer POSTs to.
+
+    ``{base}/{prefix}/workflow/{name}/respond/{instanceId}/{requestId}``. When ``prefix``
+    is omitted it is resolved from ``host.json``. ``request_id`` may be a literal
+    ``{requestId}`` placeholder to produce the templated form the run endpoint returns.
+    """
+    return f"{base_url}/{_prefix_segment(prefix)}workflow/{workflow_name}/respond/{instance_id}/{request_id}"
+
+
+def build_workflow_status_url(
+    base_url: str,
+    workflow_name: str,
+    instance_id: str,
+    *,
+    prefix: str | None = None,
+) -> str:
+    """Build the workflow status URL: ``{base}/{prefix}/workflow/{name}/status/{instanceId}``."""
+    return f"{base_url}/{_prefix_segment(prefix)}workflow/{workflow_name}/status/{instance_id}"
+
+
+def split_request_url(request_url: str) -> tuple[str, str]:
+    """Return ``(base_url, route_prefix)`` derived from an incoming request URL.
+
+    On the server the request URL is the authoritative source for the prefix, since the
+    host served it through the configured ``routePrefix``. The scheme and host form the
+    base URL, and the path before the first ``/workflow/`` segment is the prefix (empty
+    when the routes sit directly under the host). Falls back to ``(request_url, "")`` when
+    the value is not an absolute URL.
+    """
+    parts = urlsplit(request_url)
+    if not (parts.scheme and parts.netloc):
+        return request_url.rstrip("/"), ""
+    base_url = f"{parts.scheme}://{parts.netloc}"
+    index = parts.path.find("/workflow/")
+    prefix = parts.path[:index].strip("/") if index != -1 else ""
+    return base_url, prefix

--- a/python/packages/azurefunctions/agent_framework_azurefunctions/_workflow.py
+++ b/python/packages/azurefunctions/agent_framework_azurefunctions/_workflow.py
@@ -1,0 +1,83 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+"""Workflow Execution for Durable Functions.
+
+This module provides the Azure Functions entry point for workflow orchestration.
+The actual orchestration logic lives in the shared module
+``agent_framework_durabletask._workflows.orchestrator`` and is host-agnostic.
+This module re-exports the public API and provides the AF-specific
+``run_workflow_orchestrator`` wrapper that creates an
+:class:`AzureFunctionsWorkflowContext` before delegating.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Generator
+from typing import Any
+
+from agent_framework import Workflow
+from agent_framework_durabletask._workflows.orchestrator import (
+    SOURCE_HITL_RESPONSE,
+    SOURCE_ORCHESTRATOR,
+    SOURCE_WORKFLOW_START,
+    ExecutorResult,
+    PendingHITLRequest,
+    TaskMetadata,
+    TaskType,
+    _extract_message_content,  # pyright: ignore[reportPrivateUsage]
+    build_agent_executor_response,
+    execute_hitl_response_handler,
+    route_message_through_edge_groups,
+)
+from agent_framework_durabletask._workflows.orchestrator import (
+    run_workflow_orchestrator as _run_workflow_orchestrator_shared,
+)
+from azure.durable_functions import DurableOrchestrationContext
+
+from ._workflow_af_context import AzureFunctionsWorkflowContext
+
+logger = logging.getLogger(__name__)
+
+# Re-export shared symbols for backward compatibility
+__all__ = [
+    "SOURCE_HITL_RESPONSE",
+    "SOURCE_ORCHESTRATOR",
+    "SOURCE_WORKFLOW_START",
+    "ExecutorResult",
+    "PendingHITLRequest",
+    "TaskMetadata",
+    "TaskType",
+    "_extract_message_content",
+    "build_agent_executor_response",
+    "execute_hitl_response_handler",
+    "route_message_through_edge_groups",
+    "run_workflow_orchestrator",
+]
+
+
+def run_workflow_orchestrator(
+    context: DurableOrchestrationContext,
+    workflow: Workflow,
+    initial_message: Any,
+    shared_state: dict[str, Any] | None = None,
+) -> Generator[Any, Any, list[Any] | dict[str, Any]]:
+    """Azure Functions wrapper around the shared workflow orchestrator.
+
+    Creates an :class:`AzureFunctionsWorkflowContext` and delegates to the
+    host-agnostic :func:`run_workflow_orchestrator` in the durabletask package.
+
+    Args:
+        context: The Azure Functions ``DurableOrchestrationContext``.
+        workflow: The MAF Workflow instance to execute.
+        initial_message: Initial message to send to the start executor.
+        shared_state: Optional dict for cross-executor state sharing.
+
+    Returns:
+        For a top-level run, the list of workflow outputs collected from executor
+        activities. For a sub-workflow run, a result envelope ``{"outputs": [...],
+        "events": [...]}`` so the parent can bubble nested progress (see the shared
+        ``run_workflow_orchestrator`` in the durabletask package).
+    """
+    af_ctx = AzureFunctionsWorkflowContext(context)
+    return _run_workflow_orchestrator_shared(af_ctx, workflow, initial_message, shared_state)

--- a/python/packages/azurefunctions/agent_framework_azurefunctions/_workflow_af_context.py
+++ b/python/packages/azurefunctions/agent_framework_azurefunctions/_workflow_af_context.py
@@ -1,0 +1,105 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+"""Azure Functions adapter for WorkflowOrchestrationContext.
+
+Wraps ``azure.durable_functions.DurableOrchestrationContext`` to satisfy the
+:class:`~agent_framework_durabletask.WorkflowOrchestrationContext` protocol.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from typing import Any
+
+from agent_framework_durabletask import AgentSessionId, DurableAgentSession, DurableAIAgent
+from azure.durable_functions import DurableOrchestrationContext
+
+from ._orchestration import AzureFunctionsAgentExecutor
+
+logger = logging.getLogger(__name__)
+
+
+class AzureFunctionsWorkflowContext:
+    """Adapter that maps ``DurableOrchestrationContext`` to ``WorkflowOrchestrationContext``."""
+
+    def __init__(self, context: DurableOrchestrationContext) -> None:
+        self._context = context
+
+    # -- Properties -----------------------------------------------------------
+
+    @property
+    def instance_id(self) -> str:
+        # Typed local (not cast): mypy sees the untyped context as Any, while
+        # pyright sees a concrete str - the annotation satisfies both.
+        instance_id: str = self._context.instance_id
+        return instance_id
+
+    @property
+    def is_replaying(self) -> bool:
+        is_replaying: bool = self._context.is_replaying
+        return is_replaying
+
+    @property
+    def supports_event_streaming(self) -> bool:
+        # The Azure Functions host has no workflow event-streaming endpoint, and its
+        # Durable Functions custom status is capped at 16 KB by the WebJobs extension.
+        # Publishing the accumulating event log would overflow that cap and fail the
+        # orchestrator, so events are omitted; state, pending HITL requests, and the
+        # final output remain available via the workflow status endpoint.
+        return False
+
+    @property
+    def current_utc_datetime(self) -> datetime:
+        current: datetime = self._context.current_utc_datetime
+        return current
+
+    # -- Agent / Activity dispatch --------------------------------------------
+
+    def prepare_agent_task(self, executor_id: str, message: str, orchestration_instance_id: str) -> Any:
+        session_id = AgentSessionId(name=executor_id, key=orchestration_instance_id)
+        session = DurableAgentSession(durable_session_id=session_id)
+        az_executor = AzureFunctionsAgentExecutor(self._context)
+        agent = DurableAIAgent(az_executor, executor_id)
+        return agent.run(message, session=session)
+
+    def prepare_activity_task(self, activity_name: str, input_json: str) -> Any:
+        orchestration_context: Any = self._context
+        return orchestration_context.call_activity(activity_name, input_json)
+
+    def call_sub_orchestrator(self, name: str, input: Any, instance_id: str | None = None) -> Any:
+        orchestration_context: Any = self._context
+        return orchestration_context.call_sub_orchestrator(name, input_=input, instance_id=instance_id)
+
+    # -- Composite tasks ------------------------------------------------------
+
+    def task_all(self, tasks: list[Any]) -> Any:
+        return self._context.task_all(tasks)
+
+    def task_any(self, tasks: list[Any]) -> Any:
+        return self._context.task_any(tasks)
+
+    # -- External events / timers ---------------------------------------------
+
+    def wait_for_external_event(self, name: str) -> Any:
+        return self._context.wait_for_external_event(name)
+
+    def create_timer(self, fire_at: datetime) -> Any:
+        return self._context.create_timer(fire_at)
+
+    # -- Status / utility -----------------------------------------------------
+
+    def set_custom_status(self, status: Any) -> None:
+        self._context.set_custom_status(status)
+
+    def new_uuid(self) -> str:
+        new_uuid: str = self._context.new_uuid()
+        return new_uuid
+
+    def cancel_task(self, task: Any) -> None:
+        cancel_fn = getattr(task, "cancel", None)
+        if callable(cancel_fn):
+            cancel_fn()
+
+    def get_task_result(self, task: Any) -> Any:
+        return getattr(task, "result", None)

--- a/python/packages/azurefunctions/pyproject.toml
+++ b/python/packages/azurefunctions/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
-name = "agent-framework-durabletask"
-description = "Durable Task integration for Microsoft Agent Framework."
+name = "agent-framework-azurefunctions"
+description = "Azure Functions integration for Microsoft Agent Framework."
 authors = [{ name = "Microsoft", email = "af-support@microsoft.com"}]
 readme = "README.md"
 requires-python = ">=3.10"
@@ -23,14 +23,9 @@ classifiers = [
 ]
 dependencies = [
     "agent-framework-core>=1.11.0,<2",
-    "durabletask>=1.5.0,<2",
-    "durabletask-azuremanaged>=1.4.0,<2",
-    "python-dateutil>=2.8.0,<3",
-]
-
-[dependency-groups]
-dev = [
-    "types-python-dateutil==2.9.0.20260518",
+    "agent-framework-durabletask>=1.0.0b260709,<2",
+    "azure-functions>=1.24.0,<2",
+    "azure-functions-durable>=1.3.1,<2",
 ]
 
 [tool.uv]
@@ -53,14 +48,10 @@ asyncio_default_fixture_loop_scope = "function"
 filterwarnings = [
     "ignore:Support for class-based `config` is deprecated:DeprecationWarning:pydantic.*"
 ]
-timeout = 120
+timeout = 300
 markers = [
-    "integration: marks tests as integration tests",
-    "integration_test: marks tests as integration tests (alternative marker)",
-    "sample: marks tests as sample tests",
-    "requires_azure_openai: marks tests that require Azure OpenAI",
-    "requires_dts: marks tests that require Durable Task Scheduler",
-    "requires_redis: marks tests that require Redis"
+    "integration: marks tests as integration tests (require running function app)",
+    "orchestration: marks tests that use orchestrations (require Azurite)",
 ]
 
 [tool.ruff]
@@ -73,10 +64,10 @@ omit = [
 
 [tool.pyright]
 extends = "../../pyproject.toml"
-include = ["agent_framework_durabletask"]
+include = ["agent_framework_azurefunctions"]
 
 [tool.bandit]
-targets = ["agent_framework_durabletask"]
+targets = ["agent_framework_azurefunctions"]
 exclude_dirs = ["tests"]
 
 [tool.poe]
@@ -89,7 +80,7 @@ cmd = "mypy --config-file $POE_ROOT/pyproject.toml tests"
 
 [tool.poe.tasks.test]
 help = "Run the default unit test suite for this package."
-cmd = 'pytest -m "not integration" --cov=agent_framework_durabletask --cov-report=term-missing:skip-covered tests'
+cmd = 'pytest -m "not integration" --cov=agent_framework_azurefunctions --cov-report=term-missing:skip-covered tests'
 
 [build-system]
 requires = ["flit-core >= 3.11,<4.0"]

--- a/python/packages/azurefunctions/tests/integration_tests/.env.example
+++ b/python/packages/azurefunctions/tests/integration_tests/.env.example
@@ -1,0 +1,10 @@
+# Azure OpenAI Configuration
+AZURE_OPENAI_ENDPOINT=https://your-resource.openai.azure.com/
+AZURE_OPENAI_MODEL=your-deployment-name
+FUNCTIONS_WORKER_RUNTIME=python
+
+# Azure Functions Configuration
+AzureWebJobsStorage=UseDevelopmentStorage=true
+DURABLE_TASK_SCHEDULER_CONNECTION_STRING=Endpoint=http://localhost:8080;Authentication=None
+
+# Note: TASKHUB_NAME is not required for integration tests; it is auto-generated per test run.

--- a/python/packages/azurefunctions/tests/integration_tests/README.md
+++ b/python/packages/azurefunctions/tests/integration_tests/README.md
@@ -1,0 +1,81 @@
+# Sample Integration Tests
+
+Integration tests that validate the Durable Agent Framework samples by running them as Azure Functions.
+
+## Setup
+
+### 1. Create `.env` file
+
+Copy `.env.example` to `.env` and fill in your Azure credentials:
+
+```bash
+cp .env.example .env
+```
+
+Required variables:
+- `AZURE_OPENAI_ENDPOINT`
+- `AZURE_OPENAI_MODEL`
+- `AZURE_OPENAI_API_KEY`
+- `AzureWebJobsStorage`
+- `DURABLE_TASK_SCHEDULER_CONNECTION_STRING`
+- `FUNCTIONS_WORKER_RUNTIME`
+
+### 2. Start required services
+
+**Azurite (for orchestration tests):**
+```bash
+docker run -d -p 10000:10000 -p 10001:10001 -p 10002:10002 mcr.microsoft.com/azure-storage/azurite
+```
+
+**Durable Task Scheduler:**
+```bash
+docker run -d -p 8080:8080 -p 8082:8082 -e DTS_USE_DYNAMIC_TASK_HUBS=true mcr.microsoft.com/dts/dts-emulator:latest
+```
+
+## Running Tests
+
+The tests automatically start and stop the Azure Functions app for each sample.
+
+### Run all sample tests
+```bash
+uv run pytest packages/azurefunctions/tests/integration_tests -v
+```
+
+### Run specific sample
+```bash
+uv run pytest packages/azurefunctions/tests/integration_tests/test_01_single_agent.py -v
+```
+
+### Run with verbose output
+```bash
+uv run pytest packages/azurefunctions/tests/integration_tests -sv
+```
+
+## How It Works
+
+Each test file uses pytest markers to automatically configure and start the function app:
+
+```python
+pytestmark = [
+    pytest.mark.sample("01_single_agent"),
+    pytest.mark.usefixtures("function_app_for_test"),
+    skip_if_azure_functions_integration_tests_disabled,
+]
+```
+
+The `function_app_for_test` fixture:
+1. Loads environment variables from `.env`
+2. Validates required variables are present
+3. Starts the function app on a dynamically allocated port
+4. Waits for the app to be ready
+5. Runs your tests
+6. Tears down the function app
+
+## Troubleshooting
+
+
+**Missing environment variables:**
+Ensure your `.env` file contains all required variables from `.env.example`.
+
+**Tests timeout:**
+Check that Azure OpenAI credentials are valid and the service is accessible.

--- a/python/packages/azurefunctions/tests/integration_tests/conftest.py
+++ b/python/packages/azurefunctions/tests/integration_tests/conftest.py
@@ -1,0 +1,613 @@
+# Copyright (c) Microsoft. All rights reserved.
+"""
+Pytest configuration for Azure Functions integration tests.
+
+This module provides fixtures, configuration, and test utilities for pytest.
+"""
+
+import os
+import shutil
+import socket
+import subprocess
+import sys
+import time
+import uuid
+from collections.abc import Iterator, Mapping
+from contextlib import suppress
+from pathlib import Path
+from typing import Any
+
+import pytest
+import requests
+
+# =============================================================================
+# Configuration Constants
+# =============================================================================
+
+TIMEOUT = 30  # seconds
+ORCHESTRATION_TIMEOUT = 180  # seconds for orchestrations
+_DEFAULT_HOST = "localhost"
+
+# Emulator ports (match CI workflow configuration)
+_AZURITE_BLOB_PORT = 10000
+_DTS_EMULATOR_PORT = 8080
+
+
+# =============================================================================
+# Exceptions
+# =============================================================================
+
+
+class FunctionAppStartupError(RuntimeError):
+    """Raised when the Azure Functions host fails to start reliably."""
+
+    pass
+
+
+# =============================================================================
+# Environment and Service Checks
+# =============================================================================
+
+
+def _load_env_file_if_present() -> None:
+    """Load environment variables from the local .env file when available."""
+    env_file = Path(__file__).parent / ".env"
+    if not env_file.exists():
+        return
+
+    try:
+        from dotenv import load_dotenv
+
+        load_dotenv(env_file)
+    except ImportError:
+        # python-dotenv not available; rely on existing environment
+        pass
+
+
+def _check_func_cli_available() -> bool:
+    """Check if Azure Functions Core Tools (func) is installed and available."""
+    return shutil.which("func") is not None
+
+
+def _check_port_listening(port: int, host: str = _DEFAULT_HOST) -> bool:
+    """Check if a service is listening on the given port."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.settimeout(1)
+        return sock.connect_ex((host, port)) == 0
+
+
+def _check_azurite_available() -> bool:
+    """Check if Azurite (Azure Storage emulator) is available on the expected port."""
+    return _check_port_listening(_AZURITE_BLOB_PORT)
+
+
+def _check_dts_emulator_available() -> bool:
+    """Check if Durable Task Scheduler emulator is available on the expected port."""
+    return _check_port_listening(_DTS_EMULATOR_PORT)
+
+
+def _should_skip_azure_functions_integration_tests() -> tuple[bool, str]:
+    """Determine whether Azure Functions integration tests should be skipped."""
+    _load_env_file_if_present()
+
+    # Check for Azure Functions Core Tools
+    if not _check_func_cli_available():
+        return (
+            True,
+            "Azure Functions Core Tools (func) not installed. Install with: npm install -g azure-functions-core-tools@4",  # noqa: E501
+        )
+
+    # Check for Azurite (Azure Storage emulator)
+    if not _check_azurite_available():
+        return (
+            True,
+            f"Azurite not running on port {_AZURITE_BLOB_PORT}. Start with: docker run -d -p 10000:10000 -p 10001:10001 -p 10002:10002 mcr.microsoft.com/azure-storage/azurite",  # noqa: E501
+        )
+
+    # Check for Durable Task Scheduler emulator
+    if not _check_dts_emulator_available():
+        return (
+            True,
+            f"Durable Task Scheduler emulator not running on port {_DTS_EMULATOR_PORT}. Start with: docker run -d -p 8080:8080 -p 8082:8082 mcr.microsoft.com/dts/dts-emulator:latest",  # noqa: E501
+        )
+
+    has_foundry_config = bool(os.getenv("FOUNDRY_PROJECT_ENDPOINT", "").strip()) and bool(
+        os.getenv("FOUNDRY_MODEL", "").strip()
+    )
+    has_azure_openai_config = bool(os.getenv("AZURE_OPENAI_ENDPOINT", "").strip()) and bool(
+        os.getenv("AZURE_OPENAI_MODEL", "").strip()
+    )
+    if not has_foundry_config and not has_azure_openai_config:
+        return (
+            True,
+            "No real FOUNDRY_* or AZURE_OPENAI_* configuration provided; skipping integration tests.",
+        )
+
+    return False, "Integration tests enabled."
+
+
+_SKIP_AZURE_FUNCTIONS_INTEGRATION_TESTS, _AZURE_FUNCTIONS_SKIP_REASON = _should_skip_azure_functions_integration_tests()
+
+skip_if_azure_functions_integration_tests_disabled = pytest.mark.skipif(
+    _SKIP_AZURE_FUNCTIONS_INTEGRATION_TESTS,
+    reason=_AZURE_FUNCTIONS_SKIP_REASON,
+)
+
+
+# =============================================================================
+# Test Helper Class
+# =============================================================================
+
+
+class SampleTestHelper:
+    """Helper class for testing samples."""
+
+    @staticmethod
+    def post_json(url: str, data: dict[str, Any], timeout: int = TIMEOUT) -> requests.Response:
+        """POST JSON data to a URL."""
+        return requests.post(url, json=data, headers={"Content-Type": "application/json"}, timeout=timeout)
+
+    @staticmethod
+    def post_text(url: str, text: str, timeout: int = TIMEOUT) -> requests.Response:
+        """POST plain text to a URL."""
+        return requests.post(url, data=text, headers={"Content-Type": "text/plain"}, timeout=timeout)
+
+    @staticmethod
+    def get(url: str, timeout: int = TIMEOUT) -> requests.Response:
+        """GET request to a URL."""
+        return requests.get(url, timeout=timeout)
+
+    @staticmethod
+    def wait_for_orchestration(
+        status_url: str, max_wait: int = ORCHESTRATION_TIMEOUT, poll_interval: int = 2
+    ) -> dict[str, Any]:
+        """Wait for an orchestration to complete.
+
+        Args:
+            status_url: URL to poll for orchestration status
+            max_wait: Maximum seconds to wait
+            poll_interval: Seconds between polls
+
+        Returns:
+            Final orchestration status
+
+        Raises:
+            TimeoutError: If orchestration doesn't complete in time
+        """
+        start_time = time.time()
+        while time.time() - start_time < max_wait:
+            response = requests.get(status_url, timeout=TIMEOUT)
+            response.raise_for_status()
+            status = response.json()
+
+            runtime_status = status.get("runtimeStatus", "")
+            if runtime_status in ["Completed", "Failed", "Terminated"]:
+                return status
+
+            time.sleep(poll_interval)
+
+        raise TimeoutError(f"Orchestration did not complete within {max_wait} seconds")
+
+    @staticmethod
+    def wait_for_orchestration_with_output(
+        status_url: str, max_wait: int = ORCHESTRATION_TIMEOUT, poll_interval: int = 2
+    ) -> dict[str, Any]:
+        """Wait for an orchestration to complete and have output available.
+
+        This is a specialized version of wait_for_orchestration that also
+        ensures the output field is present, handling timing race conditions.
+
+        Args:
+            status_url: URL to poll for orchestration status
+            max_wait: Maximum seconds to wait
+            poll_interval: Seconds between polls
+
+        Returns:
+            Final orchestration status with output
+
+        Raises:
+            TimeoutError: If orchestration doesn't complete with output in time
+        """
+        start_time = time.time()
+        while time.time() - start_time < max_wait:
+            response = requests.get(status_url, timeout=TIMEOUT)
+            response.raise_for_status()
+            status = response.json()
+
+            runtime_status = status.get("runtimeStatus", "")
+            if runtime_status in ["Failed", "Terminated"]:
+                return status
+            if runtime_status == "Completed" and status.get("output"):
+                return status
+            # If completed but no output, continue polling for a bit more to
+            # handle the race condition where output has not been persisted yet.
+
+            time.sleep(poll_interval)
+
+        # Provide detailed error message based on final status
+        final_response = requests.get(status_url, timeout=TIMEOUT)
+        final_response.raise_for_status()
+        final_status = final_response.json()
+        final_runtime_status = final_status.get("runtimeStatus", "Unknown")
+
+        if final_runtime_status == "Completed":
+            if "output" not in final_status:
+                raise TimeoutError(
+                    "Orchestration completed but 'output' field is missing after "
+                    f"{max_wait} seconds. Final status: {final_status}"
+                )
+            if not final_status["output"]:
+                raise TimeoutError(
+                    "Orchestration completed but output is empty after "
+                    f"{max_wait} seconds. Final status: {final_status}"
+                )
+            raise TimeoutError(
+                "Orchestration completed with output but validation failed after "
+                f"{max_wait} seconds. Final status: {final_status}"
+            )
+        raise TimeoutError(
+            "Orchestration did not complete within "
+            f"{max_wait} seconds. Final status: {final_runtime_status}, "
+            f"Full status: {final_status}"
+        )
+
+
+# =============================================================================
+# Function App Lifecycle Management
+# =============================================================================
+
+
+def _resolve_repo_root() -> Path:
+    """Resolve the repository root, preferring GITHUB_WORKSPACE when available."""
+    workspace = os.getenv("GITHUB_WORKSPACE")
+    if workspace:
+        candidate = Path(workspace).expanduser()
+        if not (candidate / "samples").exists() and (candidate / "python" / "samples").exists():
+            return (candidate / "python").resolve()
+        return candidate.resolve()
+
+    # If `GITHUB_WORKSPACE` is not set,
+    # go up from conftest.py -> integration_tests -> tests -> azurefunctions -> packages -> python
+    return Path(__file__).resolve().parents[4]
+
+
+def _get_sample_path_from_marker(request: pytest.FixtureRequest) -> tuple[Path | None, str | None]:
+    """Get sample path from @pytest.mark.sample() marker.
+
+    Returns a tuple of (sample_path, error_message).
+    If successful, error_message is None.
+    If failed, sample_path is None and error_message contains the reason.
+    """
+    marker = request.node.get_closest_marker("sample")
+
+    if not marker:
+        return (
+            None,
+            (
+                "No @pytest.mark.sample() marker found on test. Add pytestmark with "
+                "@pytest.mark.sample('sample_name') to the test module."
+            ),
+        )
+
+    if not marker.args:
+        return (
+            None,
+            "@pytest.mark.sample() marker found but no sample name provided. Use @pytest.mark.sample('sample_name').",
+        )
+
+    sample_name = marker.args[0]
+    repo_root = _resolve_repo_root()
+    sample_path = repo_root / "samples" / "04-hosting" / "azure_functions" / sample_name
+
+    if not sample_path.exists():
+        return None, f"Sample directory does not exist: {sample_path}"
+
+    return sample_path, None
+
+
+def _find_available_port(host: str = _DEFAULT_HOST) -> int:
+    """Find an available TCP port on the given host."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind((host, 0))
+        return sock.getsockname()[1]
+
+
+def _build_base_url(port: int, host: str = _DEFAULT_HOST) -> str:
+    """Construct a base URL for the Azure Functions host."""
+    return f"http://{host}:{port}"
+
+
+def _is_port_in_use(port: int, host: str = _DEFAULT_HOST) -> bool:
+    """Check if a port is already in use.
+
+    Returns True if the port is in use, False otherwise.
+    """
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        return sock.connect_ex((host, port)) == 0
+
+
+def _load_and_validate_env(sample_path: Path) -> None:
+    """Load .env file from current directory if it exists, then validate required environment variables.
+
+    Raises pytest.fail if required environment variables are missing.
+    """
+    _load_env_file_if_present()
+    # Required environment variables for Azure Functions samples
+    required_env_vars = [
+        "AzureWebJobsStorage",
+        "DURABLE_TASK_SCHEDULER_CONNECTION_STRING",
+        "FUNCTIONS_WORKER_RUNTIME",
+    ]
+    # Samples that host no AI agents need no model credentials (only the DTS emulator
+    # and Azurite). The suite-level gate still requires *some* LLM config to be present.
+    no_llm_samples = {"13_subworkflow_hitl"}
+    if sample_path.name in no_llm_samples:
+        pass
+    elif sample_path.name == "11_workflow_parallel":
+        required_env_vars.extend(["AZURE_OPENAI_ENDPOINT", "AZURE_OPENAI_MODEL"])
+    else:
+        required_env_vars.extend(["FOUNDRY_PROJECT_ENDPOINT", "FOUNDRY_MODEL"])
+
+    # Check if required env vars are set
+    missing_vars = [var for var in required_env_vars if not os.environ.get(var)]
+
+    if missing_vars:
+        pytest.fail(
+            f"Missing required environment variables: {', '.join(missing_vars)}. "
+            "Please create a .env file in tests/integration_tests/ based on .env.example or "
+            "set these variables in your environment."
+        )
+
+
+def _start_function_app(sample_path: Path, port: int) -> subprocess.Popen[Any]:
+    """Start a function app in the specified sample directory.
+
+    Returns the subprocess.Popen object for the running process.
+    """
+    env = os.environ.copy()
+    # Use a unique TASKHUB_NAME for each test run to ensure test isolation.
+    # This prevents conflicts between parallel or repeated test runs, as Durable Functions
+    # use the task hub name to separate orchestration state.
+    env["TASKHUB_NAME"] = f"test{uuid.uuid4().hex[:8]}"
+
+    # The Azure Functions Python worker's dependency isolation mechanism crashes
+    # on Python 3.13 with a SIGSEGV in the protobuf C extension (google._upb).
+    # Disabling isolation lets the worker load dependencies from the app's own
+    # environment, which avoids the crash.
+    # See: https://github.com/Azure/azure-functions-python-worker/issues/1797
+    if sys.version_info >= (3, 13):
+        env.setdefault("PYTHON_ISOLATE_WORKER_DEPENDENCIES", "0")
+
+    # On Windows, use CREATE_NEW_PROCESS_GROUP to allow proper termination
+    # shell=True only on Windows to handle PATH resolution
+    if sys.platform == "win32":
+        return subprocess.Popen(
+            ["func", "start", "--port", str(port)],
+            cwd=str(sample_path),
+            creationflags=subprocess.CREATE_NEW_PROCESS_GROUP,
+            shell=True,
+            env=env,
+        )
+    # On Unix, use start_new_session=True to isolate the process group from the
+    # pytest-xdist worker.  Without this, signals (e.g. from test-timeout) can
+    # propagate to the func host and vice-versa, potentially killing the worker.
+    return subprocess.Popen(
+        ["func", "start", "--port", str(port)],
+        cwd=str(sample_path),
+        env=env,
+        start_new_session=True,
+    )
+
+
+def _wait_for_function_app_ready(func_process: subprocess.Popen[Any], port: int, max_wait: int = 60) -> None:
+    """Block until the Azure Functions host responds healthy or fail fast."""
+    start_time = time.time()
+    health_url = f"{_build_base_url(port)}/api/health"
+    last_error: Exception | None = None
+
+    while time.time() - start_time < max_wait:
+        # If the process exited early, capture any previously seen error and fail fast.
+        if func_process.poll() is not None:
+            raise FunctionAppStartupError(
+                f"Function app process exited with code {func_process.returncode} before becoming healthy"
+            ) from last_error
+
+        if _is_port_in_use(port):
+            try:
+                response = requests.get(health_url, timeout=5)
+                if response.status_code == 200:
+                    return
+                last_error = RuntimeError(f"Health check returned {response.status_code}")
+            except requests.RequestException as exc:
+                last_error = exc
+
+        time.sleep(1)
+
+    raise FunctionAppStartupError(
+        f"Function app did not become healthy on port {port} within {max_wait} seconds"
+    ) from last_error
+
+
+def _cleanup_function_app(func_process: subprocess.Popen[Any]) -> None:
+    """Clean up the function app process and all its children.
+
+    Uses psutil if available for more thorough cleanup, falls back to basic termination.
+    """
+    try:
+        import psutil
+
+        if func_process.poll() is None:  # Process still running
+            # Get parent process
+            parent = psutil.Process(func_process.pid)
+
+            # Get all child processes recursively
+            children = parent.children(recursive=True)
+
+            # Kill children first
+            for child in children:
+                with suppress(psutil.NoSuchProcess, psutil.AccessDenied):
+                    child.kill()
+
+            # Kill parent
+            with suppress(psutil.NoSuchProcess, psutil.AccessDenied):
+                parent.kill()
+
+            # Wait for all to terminate
+            _gone, alive = psutil.wait_procs(children + [parent], timeout=3)
+
+            # Force kill any remaining
+            for proc in alive:
+                with suppress(psutil.NoSuchProcess, psutil.AccessDenied):
+                    proc.kill()
+    except ImportError:
+        # Fallback if psutil not available
+        try:
+            if func_process.poll() is None:
+                func_process.kill()
+                func_process.wait()
+        except Exception:
+            # Ignore all exceptions during fallback cleanup; best effort to terminate process.
+            pass
+    except Exception:
+        pass  # Best effort cleanup
+
+    # Give the port time to be released
+    time.sleep(2)
+
+
+# =============================================================================
+# Pytest Configuration
+# =============================================================================
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    """Register custom markers."""
+    config.addinivalue_line("markers", "orchestration: marks tests that use orchestrations (require Azurite)")
+    config.addinivalue_line(
+        "markers",
+        "sample(path): specify the sample directory path for the test (e.g., @pytest.mark.sample('01_single_agent'))",
+    )
+
+
+def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:
+    """Skip integration tests in this directory if prerequisites are not met."""
+    should_skip, reason = _should_skip_azure_functions_integration_tests()
+    if should_skip:
+        skip_marker = pytest.mark.skip(reason=reason)
+        for item in items:
+            # Only skip items that are in this integration_tests directory
+            if "integration_tests" in str(item.fspath):
+                item.add_marker(skip_marker)
+
+
+# =============================================================================
+# Pytest Fixtures
+# =============================================================================
+
+
+@pytest.fixture(scope="session")
+def function_app_running() -> bool:
+    """Check if the function app is running on localhost:7071.
+
+    This fixture can be used to skip tests if the function app is not available.
+    """
+    try:
+        response = requests.get("http://localhost:7071/api/health", timeout=2)
+        return response.status_code == 200
+    except requests.exceptions.RequestException:
+        return False
+
+
+@pytest.fixture(scope="session")
+def skip_if_no_function_app(function_app_running: bool) -> None:
+    """Skip test if function app is not running."""
+    if not function_app_running:
+        pytest.skip("Function app is not running on http://localhost:7071")
+
+
+@pytest.fixture(scope="module")
+def function_app_for_test(request: pytest.FixtureRequest) -> Iterator[dict[str, int | str]]:
+    """Start the function app for the corresponding sample based on marker.
+
+    This fixture:
+    1. Determines which sample to run from @pytest.mark.sample()
+    2. Validates environment variables
+    3. Starts the function app using 'func start'
+    4. Waits for the app to be ready
+    5. Tears down the app after tests complete
+
+    Usage:
+    @pytest.mark.sample("01_single_agent")
+    @pytest.mark.usefixtures("function_app_for_test")
+    class TestSample01SingleAgent:
+        ...
+    """
+    # Get sample path from marker
+    sample_path, error_message = _get_sample_path_from_marker(request)
+    if error_message:
+        pytest.fail(error_message)
+
+    assert sample_path is not None, "Sample path must be resolved before starting the function app"
+
+    # Load .env file if it exists and validate required env vars
+    _load_and_validate_env(sample_path)
+
+    max_attempts = 3
+    # The overall budget MUST be shorter than the pytest-timeout value
+    # (--timeout=120 by default) so that the fixture finishes cleanly instead
+    # of being killed by os._exit() which crashes the xdist worker.
+    overall_budget = 100  # seconds – leaves headroom below the 120 s test timeout
+    last_error: Exception | None = None
+    func_process: subprocess.Popen[Any] | None = None
+    base_url = ""
+    port = 0
+    overall_start = time.monotonic()
+    attempts_made = 0
+
+    for _ in range(max_attempts):
+        remaining = overall_budget - (time.monotonic() - overall_start)
+        if remaining < 10:
+            # Not enough time for another attempt; bail out.
+            break
+
+        attempts_made += 1
+        port = _find_available_port()
+        base_url = _build_base_url(port)
+        func_process = _start_function_app(sample_path, port)
+
+        try:
+            # Cap each attempt's wait to the remaining budget minus a small
+            # buffer for cleanup.
+            per_attempt_wait = min(60, int(remaining) - 5)
+            _wait_for_function_app_ready(func_process, port, max_wait=max(per_attempt_wait, 10))
+            last_error = None
+            break
+        except FunctionAppStartupError as exc:
+            last_error = exc
+            _cleanup_function_app(func_process)
+            func_process = None
+
+    if func_process is None:
+        elapsed = int(time.monotonic() - overall_start)
+        error_message = f"Function app failed to start after {attempts_made} attempt(s) ({elapsed}s elapsed)."
+        if last_error is not None:
+            error_message += f" Last error: {last_error}"
+        pytest.fail(error_message)
+
+    try:
+        yield {"base_url": base_url, "port": port}
+    finally:
+        if func_process is not None:
+            _cleanup_function_app(func_process)
+
+
+@pytest.fixture(scope="module")
+def base_url(function_app_for_test: Mapping[str, int | str]) -> str:
+    """Expose the function app's base URL to tests."""
+    return str(function_app_for_test["base_url"])
+
+
+@pytest.fixture(scope="session")
+def sample_helper() -> type[SampleTestHelper]:
+    """Provide the SampleTestHelper class for tests."""
+    return SampleTestHelper

--- a/python/packages/azurefunctions/tests/integration_tests/test_01_single_agent.py
+++ b/python/packages/azurefunctions/tests/integration_tests/test_01_single_agent.py
@@ -1,0 +1,115 @@
+# Copyright (c) Microsoft. All rights reserved.
+"""
+Integration Tests for Single Agent Sample
+
+Tests the single agent sample with various message formats and session management.
+
+The function app is automatically started by the test fixture.
+
+Prerequisites:
+- Azure OpenAI credentials configured (see packages/azurefunctions/tests/integration_tests/.env.example)
+- Azurite or Azure Storage account configured
+
+Usage:
+    uv run pytest packages/azurefunctions/tests/integration_tests/test_01_single_agent.py -v
+"""
+
+import pytest
+from agent_framework_durabletask import THREAD_ID_HEADER
+
+# Module-level markers - applied to all tests in this file
+pytestmark = [
+    pytest.mark.flaky,
+    pytest.mark.integration,
+    pytest.mark.sample("01_single_agent"),
+    pytest.mark.usefixtures("function_app_for_test"),
+]
+
+
+class TestSampleSingleAgent:
+    """Tests for 01_single_agent sample."""
+
+    @pytest.fixture(autouse=True)
+    def _setup(self, base_url: str, sample_helper) -> None:
+        """Provide agent-specific base URL and helper for the tests."""
+        self.base_url = f"{base_url}/api/agents/Joker"
+        self.helper = sample_helper
+
+    def test_health_check(self, base_url: str, sample_helper) -> None:
+        """Test health check endpoint."""
+        response = sample_helper.get(f"{base_url}/api/health")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "healthy"
+
+    def test_simple_message_json(self) -> None:
+        """Test sending a simple message with JSON payload."""
+        response = self.helper.post_json(
+            f"{self.base_url}/run",
+            {"message": "Tell me a short joke about cloud computing.", "thread_id": "test-simple-json"},
+        )
+        # Agent can return 200 (immediate) or 202 (async with wait_for_response=false)
+        assert response.status_code in [200, 202]
+        data = response.json()
+
+        if response.status_code == 200:
+            # Synchronous response - check result directly
+            assert data["status"] == "success"
+            assert "response" in data
+            assert data["message_count"] >= 1
+        else:
+            # Async response - check we got correlation info
+            assert "correlation_id" in data or "thread_id" in data
+
+    def test_simple_message_plain_text(self) -> None:
+        """Test sending a message with plain text payload."""
+        response = self.helper.post_text(f"{self.base_url}/run", "Tell me a short joke about networking.")
+        assert response.status_code in [200, 202]
+
+        # Agent responded with plain text when the request body was text/plain.
+        assert response.text.strip()
+        assert response.headers.get(THREAD_ID_HEADER) is not None
+
+    def test_thread_id_in_query(self) -> None:
+        """Test using thread_id in query parameter."""
+        response = self.helper.post_text(
+            f"{self.base_url}/run?thread_id=test-query-thread", "Tell me a short joke about weather in Texas."
+        )
+        assert response.status_code in [200, 202]
+
+        assert response.text.strip()
+        assert response.headers.get(THREAD_ID_HEADER) == "test-query-thread"
+
+    def test_conversation_continuity(self) -> None:
+        """Test conversation context is maintained across requests."""
+        thread_id = "test-continuity"
+
+        # First message
+        response1 = self.helper.post_json(
+            f"{self.base_url}/run",
+            {"message": "Tell me a short joke about weather in Seattle.", "thread_id": thread_id},
+        )
+        assert response1.status_code in [200, 202]
+
+        if response1.status_code == 200:
+            data1 = response1.json()
+            assert data1["message_count"] == 2  # Initial + reply
+
+            # Second message in same session
+            response2 = self.helper.post_json(
+                f"{self.base_url}/run", {"message": "What about San Francisco?", "thread_id": thread_id}
+            )
+            assert response2.status_code == 200
+            data2 = response2.json()
+            assert data2["message_count"] == 4
+        else:
+            # In async mode, we can't easily test message count
+            # Just verify we can make multiple calls
+            response2 = self.helper.post_json(
+                f"{self.base_url}/run", {"message": "What about Texas?", "thread_id": thread_id}
+            )
+            assert response2.status_code == 202
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/python/packages/azurefunctions/tests/integration_tests/test_02_multi_agent.py
+++ b/python/packages/azurefunctions/tests/integration_tests/test_02_multi_agent.py
@@ -1,0 +1,65 @@
+# Copyright (c) Microsoft. All rights reserved.
+"""
+Integration Tests for Multi-Agent Sample
+
+Tests the multi-agent sample with different agent endpoints.
+
+The function app is automatically started by the test fixture.
+
+Prerequisites:
+- Azure OpenAI credentials configured (see packages/azurefunctions/tests/integration_tests/.env.example)
+- Azurite or Azure Storage account configured
+
+Usage:
+    uv run pytest packages/azurefunctions/tests/integration_tests/test_02_multi_agent.py -v
+"""
+
+import pytest
+
+# Module-level markers - applied to all tests in this file
+pytestmark = [
+    pytest.mark.flaky,
+    pytest.mark.integration,
+    pytest.mark.sample("02_multi_agent"),
+    pytest.mark.usefixtures("function_app_for_test"),
+]
+
+
+class TestSampleMultiAgent:
+    """Tests for 02_multi_agent sample."""
+
+    @pytest.fixture(autouse=True)
+    def _setup(self, base_url: str, sample_helper) -> None:
+        """Configure base URLs for Weather and Math agents."""
+        self.weather_base_url = f"{base_url}/api/agents/WeatherAgent"
+        self.math_base_url = f"{base_url}/api/agents/MathAgent"
+        self.helper = sample_helper
+
+    @pytest.mark.skip(reason="Flaky in CI: times out / crashes the xdist runner; temporarily disabled.")
+    def test_weather_agent(self) -> None:
+        """Test WeatherAgent endpoint."""
+        response = self.helper.post_json(
+            f"{self.weather_base_url}/run",
+            {"message": "What is the weather in Seattle?"},
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "success"
+        assert "response" in data
+
+    def test_math_agent(self) -> None:
+        """Test MathAgent endpoint."""
+        response = self.helper.post_json(
+            f"{self.math_base_url}/run",
+            {"message": "Calculate a 20% tip on a $50 bill", "wait_for_response": False},
+        )
+        assert response.status_code == 202
+        data = response.json()
+
+        assert data["status"] == "accepted"
+        assert "correlation_id" in data
+        assert "thread_id" in data
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/python/packages/azurefunctions/tests/integration_tests/test_03_reliable_streaming.py
+++ b/python/packages/azurefunctions/tests/integration_tests/test_03_reliable_streaming.py
@@ -1,0 +1,121 @@
+# Copyright (c) Microsoft. All rights reserved.
+"""
+Integration Tests for Reliable Streaming Sample
+
+Tests the reliable streaming sample using Redis Streams for persistent message delivery.
+
+The function app is automatically started by the test fixture.
+
+Prerequisites:
+- Azure OpenAI credentials configured (see packages/azurefunctions/tests/integration_tests/.env.example)
+- Azurite or Azure Storage account configured
+- Redis running (docker run -d --name redis -p 6379:6379 redis:latest)
+
+Usage:
+    uv run pytest packages/azurefunctions/tests/integration_tests/test_03_reliable_streaming.py -v
+"""
+
+import time
+
+import pytest
+import requests
+
+# Module-level markers - applied to all tests in this file
+pytestmark = [
+    pytest.mark.flaky,
+    pytest.mark.integration,
+    pytest.mark.sample("03_reliable_streaming"),
+    pytest.mark.usefixtures("function_app_for_test"),
+]
+
+
+class TestSampleReliableStreaming:
+    """Tests for 03_reliable_streaming sample."""
+
+    @pytest.fixture(autouse=True)
+    def _setup(self, base_url: str, sample_helper) -> None:
+        """Provide the base URL and helper for each test."""
+        self.base_url = base_url
+        self.agent_url = f"{base_url}/api/agents/TravelPlanner"
+        self.stream_url = f"{base_url}/api/agent/stream"
+        self.helper = sample_helper
+
+    def test_agent_run_and_stream(self) -> None:
+        """Test agent execution with Redis streaming."""
+        # Start agent run
+        response = self.helper.post_json(
+            f"{self.agent_url}/run",
+            {"message": "Plan a 1-day trip to Seattle in 1 sentence", "wait_for_response": False},
+        )
+        assert response.status_code == 202
+        data = response.json()
+
+        thread_id = data.get("thread_id")
+
+        # Wait a moment for the agent to start writing to Redis
+        time.sleep(2)
+
+        # Stream response from Redis with longer timeout to account for LLM latency
+        stream_response = requests.get(
+            f"{self.stream_url}/{thread_id}",
+            headers={"Accept": "text/plain"},
+            timeout=60,
+        )
+        assert stream_response.status_code == 200
+
+    def test_stream_with_sse_format(self) -> None:
+        """Test streaming with Server-Sent Events format."""
+        # Start agent run
+        response = self.helper.post_json(
+            f"{self.agent_url}/run",
+            {"message": "What's the weather like?", "wait_for_response": False},
+        )
+        assert response.status_code == 202
+        data = response.json()
+        thread_id = data.get("thread_id")
+
+        # Wait for agent to start writing
+        time.sleep(2)
+
+        # Stream with SSE format
+        stream_response = requests.get(
+            f"{self.stream_url}/{thread_id}",
+            headers={"Accept": "text/event-stream"},
+            timeout=60,
+        )
+        assert stream_response.status_code == 200
+        content_type = stream_response.headers.get("content-type", "")
+        assert "text/event-stream" in content_type
+
+        # Check for SSE event markers if we got content
+        content = stream_response.text
+        if content:
+            assert "event:" in content or "data:" in content
+
+    def test_stream_nonexistent_conversation(self) -> None:
+        """Test streaming from a non-existent conversation.
+
+        The endpoint will wait for data in Redis, but since the conversation
+        doesn't exist, it will timeout. This is expected behavior.
+        """
+        fake_id = "nonexistent-conversation-12345"
+
+        # Should timeout since the conversation doesn't exist
+        with pytest.raises(requests.exceptions.ReadTimeout):
+            requests.get(
+                f"{self.stream_url}/{fake_id}",
+                headers={"Accept": "text/plain"},
+                timeout=10,  # Short timeout for non-existent ID
+            )
+
+    def test_health_endpoint(self) -> None:
+        """Test health check endpoint."""
+        response = self.helper.get(f"{self.base_url}/api/health")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "healthy"
+        assert "agents" in data
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/python/packages/azurefunctions/tests/integration_tests/test_04_single_agent_orchestration_chaining.py
+++ b/python/packages/azurefunctions/tests/integration_tests/test_04_single_agent_orchestration_chaining.py
@@ -1,0 +1,57 @@
+# Copyright (c) Microsoft. All rights reserved.
+"""
+Integration Tests for Orchestration Chaining Sample
+
+Tests the orchestration chaining sample for sequential agent execution.
+
+The function app is automatically started by the test fixture.
+
+Prerequisites:
+- Azure OpenAI credentials configured (see packages/azurefunctions/tests/integration_tests/.env.example)
+- Azurite running for durable orchestrations (or Azure Storage account configured)
+
+Usage:
+    # Start Azurite (if not already running)
+    azurite &
+
+    # Run tests
+    uv run pytest packages/azurefunctions/tests/integration_tests/test_04_single_agent_orchestration_chaining.py -v
+"""
+
+import pytest
+
+# Module-level markers - applied to all tests in this file
+pytestmark = [
+    pytest.mark.flaky,
+    pytest.mark.integration,
+    pytest.mark.sample("04_single_agent_orchestration_chaining"),
+    pytest.mark.usefixtures("function_app_for_test"),
+]
+
+
+@pytest.mark.orchestration
+class TestSampleOrchestrationChaining:
+    """Tests for 04_single_agent_orchestration_chaining sample."""
+
+    @pytest.fixture(autouse=True)
+    def _setup(self, sample_helper) -> None:
+        """Provide the helper for each test."""
+        self.helper = sample_helper
+
+    def test_orchestration_chaining(self, base_url: str) -> None:
+        """Test sequential agent calls in orchestration."""
+        # Start orchestration
+        response = self.helper.post_json(f"{base_url}/api/singleagent/run", {})
+        assert response.status_code == 202
+        data = response.json()
+        assert "instanceId" in data
+        assert "statusQueryGetUri" in data
+
+        # Wait for completion with output available
+        status = self.helper.wait_for_orchestration_with_output(data["statusQueryGetUri"])
+        assert status["runtimeStatus"] == "Completed"
+        assert "output" in status
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/python/packages/azurefunctions/tests/integration_tests/test_05_multi_agent_orchestration_concurrency.py
+++ b/python/packages/azurefunctions/tests/integration_tests/test_05_multi_agent_orchestration_concurrency.py
@@ -1,0 +1,59 @@
+# Copyright (c) Microsoft. All rights reserved.
+"""
+Integration Tests for MultiAgent Concurrency Sample
+
+Tests the multi-agent concurrency sample for parallel agent execution.
+
+The function app is automatically started by the test fixture.
+
+Prerequisites:
+- Azure OpenAI credentials configured (see packages/azurefunctions/tests/integration_tests/.env.example)
+- Azurite running for durable orchestrations (or Azure Storage account configured)
+
+Usage:
+    # Start Azurite (if not already running)
+    azurite &
+
+    # Run tests
+    uv run pytest packages/azurefunctions/tests/integration_tests/test_05_multi_agent_orchestration_concurrency.py -v
+"""
+
+import pytest
+
+# Module-level markers - applied to all tests in this file
+pytestmark = [
+    pytest.mark.flaky,
+    pytest.mark.integration,
+    pytest.mark.orchestration,
+    pytest.mark.sample("05_multi_agent_orchestration_concurrency"),
+    pytest.mark.usefixtures("function_app_for_test"),
+]
+
+
+class TestSampleMultiAgentConcurrency:
+    """Tests for 05_multi_agent_orchestration_concurrency sample."""
+
+    @pytest.fixture(autouse=True)
+    def _setup(self, sample_helper) -> None:
+        """Provide the helper for each test."""
+        self.helper = sample_helper
+
+    def test_concurrent_agents(self, base_url: str) -> None:
+        """Test multiple agents running concurrently."""
+        # Start orchestration
+        response = self.helper.post_text(f"{base_url}/api/multiagent/run", "What is temperature?")
+        assert response.status_code == 202
+        data = response.json()
+        assert "instanceId" in data
+        assert "statusQueryGetUri" in data
+
+        # Wait for completion
+        status = self.helper.wait_for_orchestration(data["statusQueryGetUri"])
+        assert status["runtimeStatus"] == "Completed"
+        output = status["output"]
+        assert "physicist" in output
+        assert "chemist" in output
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/python/packages/azurefunctions/tests/integration_tests/test_06_multi_agent_orchestration_conditionals.py
+++ b/python/packages/azurefunctions/tests/integration_tests/test_06_multi_agent_orchestration_conditionals.py
@@ -1,0 +1,77 @@
+# Copyright (c) Microsoft. All rights reserved.
+"""
+Integration Tests for MultiAgent Conditionals Sample
+
+Tests the multi-agent conditionals sample for conditional orchestration logic.
+
+The function app is automatically started by the test fixture.
+
+Prerequisites:
+- Azure OpenAI credentials configured (see packages/azurefunctions/tests/integration_tests/.env.example)
+- Azurite running for durable orchestrations (or Azure Storage account configured)
+
+Usage:
+    # Start Azurite (if not already running)
+    azurite &
+
+    # Run tests
+    uv run pytest packages/azurefunctions/tests/integration_tests/test_06_multi_agent_orchestration_conditionals.py -v
+"""
+
+import pytest
+
+# Module-level markers - applied to all tests in this file
+pytestmark = [
+    pytest.mark.flaky,
+    pytest.mark.integration,
+    pytest.mark.orchestration,
+    pytest.mark.sample("06_multi_agent_orchestration_conditionals"),
+    pytest.mark.usefixtures("function_app_for_test"),
+]
+
+
+class TestSampleMultiAgentConditionals:
+    """Tests for 06_multi_agent_orchestration_conditionals sample."""
+
+    @pytest.fixture(autouse=True)
+    def _setup(self, sample_helper) -> None:
+        """Provide the helper for each test."""
+        self.helper = sample_helper
+
+    def test_legitimate_email(self, base_url: str) -> None:
+        """Test conditional logic with legitimate email."""
+        response = self.helper.post_json(
+            f"{base_url}/api/spamdetection/run",
+            {
+                "email_id": "email-test-001",
+                "email_content": "Hi John, I hope you are doing well. Can you send me the report?",
+            },
+        )
+        assert response.status_code == 202
+        data = response.json()
+        assert "instanceId" in data
+        assert "statusQueryGetUri" in data
+
+        # Wait for completion
+        status = self.helper.wait_for_orchestration(data["statusQueryGetUri"])
+        assert status["runtimeStatus"] == "Completed"
+        assert "Email sent:" in status["output"]
+
+    def test_spam_email(self, base_url: str) -> None:
+        """Test conditional logic with spam email."""
+        response = self.helper.post_json(
+            f"{base_url}/api/spamdetection/run",
+            {"email_id": "email-test-002", "email_content": "URGENT! You have won $1,000,000! Click here now!"},
+        )
+        assert response.status_code == 202
+        data = response.json()
+        assert "instanceId" in data
+
+        # Wait for completion
+        status = self.helper.wait_for_orchestration(data["statusQueryGetUri"])
+        assert status["runtimeStatus"] == "Completed"
+        assert "Email marked as spam:" in status["output"]
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/python/packages/azurefunctions/tests/integration_tests/test_07_single_agent_orchestration_hitl.py
+++ b/python/packages/azurefunctions/tests/integration_tests/test_07_single_agent_orchestration_hitl.py
@@ -1,0 +1,185 @@
+# Copyright (c) Microsoft. All rights reserved.
+"""
+Integration Tests for Human-in-the-Loop (HITL) Orchestration Sample
+
+Tests the HITL orchestration sample for content generation with human approval workflow.
+
+The function app is automatically started by the test fixture.
+
+Prerequisites:
+- Azure OpenAI credentials configured (see packages/azurefunctions/tests/integration_tests/.env.example)
+- Azurite running for durable orchestrations (or Azure Storage account configured)
+
+Usage:
+    # Start Azurite (if not already running)
+    azurite &
+
+    # Run tests
+    uv run pytest packages/azurefunctions/tests/integration_tests/test_07_single_agent_orchestration_hitl.py -v
+"""
+
+import time
+
+import pytest
+
+# Module-level markers - applied to all tests in this file
+pytestmark = [
+    pytest.mark.flaky,
+    pytest.mark.integration,
+    pytest.mark.sample("07_single_agent_orchestration_hitl"),
+    pytest.mark.usefixtures("function_app_for_test"),
+]
+
+
+@pytest.mark.orchestration
+class TestSampleHITLOrchestration:
+    """Tests for 07_single_agent_orchestration_hitl sample."""
+
+    @pytest.fixture(autouse=True)
+    def _setup(self, base_url: str, sample_helper) -> None:
+        """Provide the helper and base URL for each test."""
+        self.hitl_base_url = f"{base_url}/api/hitl"
+        self.helper = sample_helper
+
+    def test_hitl_orchestration_approval(self) -> None:
+        """Test HITL orchestration with human approval."""
+        # Start orchestration
+        response = self.helper.post_json(
+            f"{self.hitl_base_url}/run",
+            {"topic": "artificial intelligence", "max_review_attempts": 3, "approval_timeout_hours": 1.0},
+        )
+        assert response.status_code == 202
+        data = response.json()
+        assert "instanceId" in data
+        assert "statusQueryGetUri" in data
+        assert data["topic"] == "artificial intelligence"
+        instance_id = data["instanceId"]
+
+        # Wait a bit for the orchestration to generate initial content
+        time.sleep(5)
+
+        # Check status to ensure it's waiting for approval
+        status_response = self.helper.get(data["statusQueryGetUri"])
+        assert status_response.status_code == 200
+        status = status_response.json()
+        assert status["runtimeStatus"] in ["Running", "Pending"]
+
+        # Send approval
+        approval_response = self.helper.post_json(
+            f"{self.hitl_base_url}/approve/{instance_id}", {"approved": True, "feedback": ""}
+        )
+        assert approval_response.status_code == 200
+        approval_data = approval_response.json()
+        assert approval_data["approved"] is True
+
+        # Wait for orchestration to complete
+        status = self.helper.wait_for_orchestration(data["statusQueryGetUri"])
+        assert status["runtimeStatus"] == "Completed"
+        assert "output" in status
+        assert "content" in status["output"]
+
+    def test_hitl_orchestration_rejection_with_feedback(self) -> None:
+        """Test HITL orchestration with rejection and subsequent approval."""
+        # Start orchestration
+        response = self.helper.post_json(
+            f"{self.hitl_base_url}/run",
+            {"topic": "machine learning", "max_review_attempts": 3, "approval_timeout_hours": 1.0},
+        )
+        assert response.status_code == 202
+        data = response.json()
+        instance_id = data["instanceId"]
+
+        # Wait for initial content generation
+        time.sleep(5)
+
+        # Send rejection with feedback
+        rejection_response = self.helper.post_json(
+            f"{self.hitl_base_url}/approve/{instance_id}",
+            {"approved": False, "feedback": "Please make it more concise and focus on practical applications."},
+        )
+        assert rejection_response.status_code == 200
+
+        # Wait for regeneration
+        time.sleep(5)
+
+        # Check status - should still be running
+        status_response = self.helper.get(data["statusQueryGetUri"])
+        assert status_response.status_code == 200
+        status = status_response.json()
+        assert status["runtimeStatus"] in ["Running", "Pending"]
+
+        # Now approve the revised content
+        approval_response = self.helper.post_json(
+            f"{self.hitl_base_url}/approve/{instance_id}", {"approved": True, "feedback": ""}
+        )
+        assert approval_response.status_code == 200
+
+        # Wait for completion
+        status = self.helper.wait_for_orchestration(data["statusQueryGetUri"])
+        assert status["runtimeStatus"] == "Completed"
+        assert "output" in status
+
+    def test_hitl_orchestration_missing_topic(self) -> None:
+        """Test HITL orchestration with missing topic."""
+        response = self.helper.post_json(f"{self.hitl_base_url}/run", {"max_review_attempts": 3})
+        assert response.status_code == 400
+        data = response.json()
+        assert "error" in data
+
+    def test_hitl_get_status(self) -> None:
+        """Test getting orchestration status."""
+        # Start orchestration
+        response = self.helper.post_json(
+            f"{self.hitl_base_url}/run",
+            {"topic": "quantum computing", "max_review_attempts": 2, "approval_timeout_hours": 1.0},
+        )
+        assert response.status_code == 202
+        data = response.json()
+        instance_id = data["instanceId"]
+
+        # Get status
+        status_response = self.helper.get(f"{self.hitl_base_url}/status/{instance_id}")
+        assert status_response.status_code == 200
+        status = status_response.json()
+        assert "instanceId" in status
+        assert "runtimeStatus" in status
+        assert status["instanceId"] == instance_id
+
+        # Cleanup: approve to complete orchestration
+        time.sleep(5)
+        self.helper.post_json(f"{self.hitl_base_url}/approve/{instance_id}", {"approved": True, "feedback": ""})
+
+    def test_hitl_approval_invalid_payload(self) -> None:
+        """Test sending approval with invalid payload."""
+        # Start orchestration first
+        response = self.helper.post_json(
+            f"{self.hitl_base_url}/run",
+            {"topic": "test topic", "max_review_attempts": 1, "approval_timeout_hours": 1.0},
+        )
+        assert response.status_code == 202
+        data = response.json()
+        instance_id = data["instanceId"]
+
+        time.sleep(3)
+
+        # Send approval without 'approved' field
+        approval_response = self.helper.post_json(
+            f"{self.hitl_base_url}/approve/{instance_id}", {"feedback": "Some feedback"}
+        )
+        assert approval_response.status_code == 400
+        error_data = approval_response.json()
+        assert "error" in error_data
+
+        # Cleanup
+        self.helper.post_json(f"{self.hitl_base_url}/approve/{instance_id}", {"approved": True, "feedback": ""})
+
+    def test_hitl_status_invalid_instance(self) -> None:
+        """Test getting status for non-existent instance."""
+        response = self.helper.get(f"{self.hitl_base_url}/status/invalid-instance-id")
+        assert response.status_code == 404
+        data = response.json()
+        assert "error" in data
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/python/packages/azurefunctions/tests/integration_tests/test_09_workflow_shared_state.py
+++ b/python/packages/azurefunctions/tests/integration_tests/test_09_workflow_shared_state.py
@@ -1,0 +1,100 @@
+# Copyright (c) Microsoft. All rights reserved.
+"""
+Integration Tests for Workflow Shared State Sample
+
+Tests the workflow shared state sample for conditional email processing
+with shared state management.
+
+The function app is automatically started by the test fixture.
+
+Prerequisites:
+- Azure OpenAI credentials configured (see packages/azurefunctions/tests/integration_tests/.env.example)
+- Azurite running for durable orchestrations (or Azure Storage account configured)
+
+Usage:
+    # Start Azurite (if not already running)
+    azurite &
+
+    # Run tests
+    uv run pytest packages/azurefunctions/tests/integration_tests/test_09_workflow_shared_state.py -v
+"""
+
+import pytest
+
+# Must match the workflow name in samples/04-hosting/azure_functions/09_workflow_shared_state/function_app.py
+WORKFLOW_NAME = "email_triage_shared_state"
+
+# Module-level markers - applied to all tests in this file
+pytestmark = [
+    pytest.mark.flaky,
+    pytest.mark.integration,
+    pytest.mark.sample("09_workflow_shared_state"),
+    pytest.mark.usefixtures("function_app_for_test"),
+]
+
+
+@pytest.mark.orchestration
+class TestWorkflowSharedState:
+    """Tests for 09_workflow_shared_state sample."""
+
+    @pytest.fixture(autouse=True)
+    def _setup(self, base_url: str, sample_helper) -> None:
+        """Provide the helper and base URL for each test."""
+        self.base_url = base_url
+        self.helper = sample_helper
+
+    def test_workflow_with_spam_email(self) -> None:
+        """Test workflow with spam email content - should be detected and handled as spam."""
+        spam_content = "URGENT! You have won $1,000,000! Click here to claim your prize now before it expires!"
+
+        # Start orchestration with spam email
+        response = self.helper.post_text(f"{self.base_url}/api/workflow/{WORKFLOW_NAME}/run", spam_content)
+        assert response.status_code == 202
+        data = response.json()
+        assert "instanceId" in data
+        assert "statusQueryGetUri" in data
+
+        # Wait for completion
+        status = self.helper.wait_for_orchestration_with_output(data["statusQueryGetUri"])
+        assert status["runtimeStatus"] == "Completed"
+        assert "output" in status
+
+    def test_workflow_with_legitimate_email(self) -> None:
+        """Test workflow with legitimate email content - should generate response."""
+        legitimate_content = (
+            "Hi team, just a reminder about the sprint planning meeting tomorrow at 10 AM. "
+            "Please review the agenda items in Jira before the call."
+        )
+
+        # Start orchestration with legitimate email
+        response = self.helper.post_text(f"{self.base_url}/api/workflow/{WORKFLOW_NAME}/run", legitimate_content)
+        assert response.status_code == 202
+        data = response.json()
+        assert "instanceId" in data
+        assert "statusQueryGetUri" in data
+
+        # Wait for completion
+        status = self.helper.wait_for_orchestration_with_output(data["statusQueryGetUri"])
+        assert status["runtimeStatus"] == "Completed"
+        assert "output" in status
+
+    def test_workflow_with_phishing_email(self) -> None:
+        """Test workflow with phishing email - should be detected as spam."""
+        phishing_content = (
+            "Dear Customer, Your account has been compromised! "
+            "Click this link immediately to secure your account: http://totallylegit.suspicious.com/secure"
+        )
+
+        # Start orchestration with phishing email
+        response = self.helper.post_text(f"{self.base_url}/api/workflow/{WORKFLOW_NAME}/run", phishing_content)
+        assert response.status_code == 202
+        data = response.json()
+        assert "instanceId" in data
+
+        # Wait for completion
+        status = self.helper.wait_for_orchestration_with_output(data["statusQueryGetUri"])
+        assert status["runtimeStatus"] == "Completed"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/python/packages/azurefunctions/tests/integration_tests/test_10_workflow_no_shared_state.py
+++ b/python/packages/azurefunctions/tests/integration_tests/test_10_workflow_no_shared_state.py
@@ -1,0 +1,116 @@
+# Copyright (c) Microsoft. All rights reserved.
+"""
+Integration Tests for Workflow No Shared State Sample
+
+Tests the workflow sample that runs without shared state,
+demonstrating conditional routing with spam detection and email response.
+
+The function app is automatically started by the test fixture.
+
+Prerequisites:
+- Azure OpenAI credentials configured (see packages/azurefunctions/tests/integration_tests/.env.example)
+- Azurite running for durable orchestrations (or Azure Storage account configured)
+
+Usage:
+    # Start Azurite (if not already running)
+    azurite &
+
+    # Run tests
+    uv run pytest packages/azurefunctions/tests/integration_tests/test_10_workflow_no_shared_state.py -v
+"""
+
+import pytest
+
+# Must match the workflow name in samples/04-hosting/azure_functions/10_workflow_no_shared_state/function_app.py
+WORKFLOW_NAME = "email_triage"
+
+# Module-level markers - applied to all tests in this file
+pytestmark = [
+    pytest.mark.flaky,
+    pytest.mark.integration,
+    pytest.mark.sample("10_workflow_no_shared_state"),
+    pytest.mark.usefixtures("function_app_for_test"),
+]
+
+
+@pytest.mark.orchestration
+class TestWorkflowNoSharedState:
+    """Tests for 10_workflow_no_shared_state sample."""
+
+    @pytest.fixture(autouse=True)
+    def _setup(self, base_url: str, sample_helper) -> None:
+        """Provide the helper and base URL for each test."""
+        self.base_url = base_url
+        self.helper = sample_helper
+
+    def test_workflow_with_spam_email(self) -> None:
+        """Test workflow with spam email - should detect and handle as spam."""
+        payload = {
+            "email_id": "email-test-001",
+            "email_content": (
+                "URGENT! You've won $1,000,000! Click here immediately to claim your prize! "
+                "Limited time offer - act now!"
+            ),
+        }
+
+        # Start orchestration
+        response = self.helper.post_json(f"{self.base_url}/api/workflow/{WORKFLOW_NAME}/run", payload)
+        assert response.status_code == 202
+        data = response.json()
+        assert "instanceId" in data
+        assert "statusQueryGetUri" in data
+
+        # Wait for completion
+        status = self.helper.wait_for_orchestration_with_output(data["statusQueryGetUri"])
+        assert status["runtimeStatus"] == "Completed"
+        assert "output" in status
+
+    def test_workflow_with_legitimate_email(self) -> None:
+        """Test workflow with legitimate email - should draft a response."""
+        payload = {
+            "email_id": "email-test-002",
+            "email_content": (
+                "Hi team, just a reminder about our sprint planning meeting tomorrow at 10 AM. "
+                "Please review the agenda in Jira."
+            ),
+        }
+
+        # Start orchestration
+        response = self.helper.post_json(f"{self.base_url}/api/workflow/{WORKFLOW_NAME}/run", payload)
+        assert response.status_code == 202
+        data = response.json()
+        assert "instanceId" in data
+        assert "statusQueryGetUri" in data
+
+        # Wait for completion
+        status = self.helper.wait_for_orchestration_with_output(data["statusQueryGetUri"])
+        assert status["runtimeStatus"] == "Completed"
+        assert "output" in status
+
+    def test_workflow_status_endpoint(self) -> None:
+        """Test that the status endpoint works correctly."""
+        payload = {
+            "email_id": "email-test-003",
+            "email_content": "Quick question: When is the next team meeting scheduled?",
+        }
+
+        # Start orchestration
+        response = self.helper.post_json(f"{self.base_url}/api/workflow/{WORKFLOW_NAME}/run", payload)
+        assert response.status_code == 202
+        data = response.json()
+        instance_id = data["instanceId"]
+
+        # Check status using the workflow status endpoint
+        status_response = self.helper.get(f"{self.base_url}/api/workflow/{WORKFLOW_NAME}/status/{instance_id}")
+        assert status_response.status_code == 200
+        status = status_response.json()
+        assert "instanceId" in status
+        assert status["instanceId"] == instance_id
+        assert "runtimeStatus" in status
+
+        # Wait for completion to clean up
+        self.helper.wait_for_orchestration(data["statusQueryGetUri"])
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/python/packages/azurefunctions/tests/integration_tests/test_11_workflow_parallel.py
+++ b/python/packages/azurefunctions/tests/integration_tests/test_11_workflow_parallel.py
@@ -1,0 +1,87 @@
+# Copyright (c) Microsoft. All rights reserved.
+"""
+Integration Tests for Parallel Workflow Sample
+
+Tests the parallel workflow execution sample demonstrating:
+- Two executors running concurrently (fan-out to activities)
+- Two agents running concurrently (fan-out to entities)
+- Mixed agent + executor running concurrently
+
+The function app is automatically started by the test fixture.
+
+Prerequisites:
+- Azure OpenAI credentials configured (see packages/azurefunctions/tests/integration_tests/.env.example)
+- Azurite running for durable orchestrations (or Azure Storage account configured)
+
+Usage:
+    # Start Azurite (if not already running)
+    azurite &
+
+    # Run tests
+    uv run pytest packages/azurefunctions/tests/integration_tests/test_11_workflow_parallel.py -v
+"""
+
+import pytest
+
+# Must match the workflow name in samples/04-hosting/azure_functions/11_workflow_parallel/function_app.py
+WORKFLOW_NAME = "parallel_review"
+
+# Module-level markers - applied to all tests in this file
+pytestmark = [
+    pytest.mark.flaky,
+    pytest.mark.integration,
+    pytest.mark.sample("11_workflow_parallel"),
+    pytest.mark.usefixtures("function_app_for_test"),
+]
+
+
+@pytest.mark.orchestration
+class TestWorkflowParallel:
+    """Tests for 11_workflow_parallel sample."""
+
+    @pytest.fixture(autouse=True)
+    def _setup(self, base_url: str, sample_helper) -> None:
+        """Provide the helper and base URL for each test."""
+        self.base_url = base_url
+        self.helper = sample_helper
+
+    @pytest.mark.skip(reason="Flaky in CI: times out / crashes the xdist runner; temporarily disabled.")
+    def test_parallel_workflow_end_to_end(self) -> None:
+        """Run the parallel workflow end-to-end: start, check status, verify completion.
+
+        Consolidated into a single test on purpose: the work-stealing xdist scheduler
+        distributes tests (not modules) across workers, and the module-scoped
+        ``function_app_for_test`` fixture is created per worker -- so multiple tests in
+        this module would each spawn a separate ``func`` host for this resource-heavy
+        parallel sample. One test keeps it to a single host while still covering the
+        fan-out path end-to-end.
+        """
+        payload = {
+            "document_id": "doc-test-001",
+            "content": (
+                "The quarterly earnings report shows strong growth in our cloud services division. "
+                "Revenue increased by 25% compared to last year, driven by enterprise adoption. "
+                "Customer satisfaction remains high at 92%."
+            ),
+        }
+
+        # Start the orchestration.
+        response = self.helper.post_json(f"{self.base_url}/api/workflow/{WORKFLOW_NAME}/run", payload)
+        assert response.status_code == 202
+        data = response.json()
+        instance_id = data["instanceId"]
+        assert "statusQueryGetUri" in data
+
+        # The status endpoint reflects the started instance.
+        status_response = self.helper.get(f"{self.base_url}/api/workflow/{WORKFLOW_NAME}/status/{instance_id}")
+        assert status_response.status_code == 200
+        assert status_response.json()["instanceId"] == instance_id
+
+        # Fan-out to parallel processors and agents completes with an aggregated output.
+        status = self.helper.wait_for_orchestration_with_output(data["statusQueryGetUri"], max_wait=300)
+        assert status["runtimeStatus"] == "Completed"
+        assert "output" in status
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/python/packages/azurefunctions/tests/integration_tests/test_12_workflow_hitl.py
+++ b/python/packages/azurefunctions/tests/integration_tests/test_12_workflow_hitl.py
@@ -1,0 +1,284 @@
+# Copyright (c) Microsoft. All rights reserved.
+"""
+Integration Tests for Workflow Human-in-the-Loop (HITL) Sample
+
+Tests the workflow HITL sample demonstrating content moderation with human approval
+using the MAF request_info / @response_handler pattern.
+
+The function app is automatically started by the test fixture.
+
+Prerequisites:
+- Azure OpenAI credentials configured (see packages/azurefunctions/tests/integration_tests/.env.example)
+- Azurite running for durable orchestrations (or Azure Storage account configured)
+
+Usage:
+    # Start Azurite (if not already running)
+    azurite &
+
+    # Run tests
+    uv run pytest packages/azurefunctions/tests/integration_tests/test_12_workflow_hitl.py -v
+"""
+
+import time
+import uuid
+
+import pytest
+
+from agent_framework_azurefunctions import WorkflowHitlContext
+
+# Module-level markers - applied to all tests in this file
+pytestmark = [
+    pytest.mark.flaky,
+    pytest.mark.integration,
+    pytest.mark.sample("12_workflow_hitl"),
+    pytest.mark.usefixtures("function_app_for_test"),
+]
+
+# Must match the workflow name in samples/04-hosting/azure_functions/12_workflow_hitl/function_app.py
+WORKFLOW_NAME = "content_moderation"
+
+
+@pytest.mark.orchestration
+class TestWorkflowHITL:
+    """Tests for 12_workflow_hitl sample."""
+
+    @pytest.fixture(autouse=True)
+    def _setup(self, base_url: str, sample_helper) -> None:
+        """Provide the helper and base URL for each test."""
+        self.base_url = base_url
+        self.helper = sample_helper
+
+    def _wait_for_hitl_request(self, instance_id: str, timeout: int = 40) -> dict:
+        """Polls for a pending HITL request."""
+        start_time = time.time()
+        while time.time() - start_time < timeout:
+            status_response = self.helper.get(f"{self.base_url}/api/workflow/{WORKFLOW_NAME}/status/{instance_id}")
+            if status_response.status_code == 200:
+                status = status_response.json()
+                pending_requests = status.get("pendingHumanInputRequests", [])
+                if pending_requests:
+                    return status
+            time.sleep(2)
+        raise AssertionError(f"Timed out waiting for HITL request for instance {instance_id}")
+
+    def test_hitl_workflow_approval(self) -> None:
+        """Test HITL workflow with human approval."""
+        payload = {
+            "content_id": "article-test-001",
+            "title": "Introduction to AI in Healthcare",
+            "body": (
+                "Artificial intelligence is revolutionizing healthcare by enabling faster diagnosis, "
+                "personalized treatment plans, and improved patient outcomes. Machine learning algorithms "
+                "can analyze medical images with remarkable accuracy."
+            ),
+            "author": "Dr. Jane Smith",
+        }
+
+        # Start orchestration
+        response = self.helper.post_json(f"{self.base_url}/api/workflow/{WORKFLOW_NAME}/run", payload)
+        assert response.status_code == 202
+        data = response.json()
+        assert "instanceId" in data
+        assert "statusQueryGetUri" in data
+        instance_id = data["instanceId"]
+
+        # Wait for the workflow to reach the HITL pause point
+        status = self._wait_for_hitl_request(instance_id)
+
+        # Confirm status is valid
+        assert status["runtimeStatus"] in ["Running", "Pending"]
+
+        # Get the request ID from pending requests
+        pending_requests = status.get("pendingHumanInputRequests", [])
+        assert len(pending_requests) > 0, "Expected pending HITL request"
+        request_id = pending_requests[0]["requestId"]
+
+        # Send approval
+        approval_response = self.helper.post_json(
+            f"{self.base_url}/api/workflow/{WORKFLOW_NAME}/respond/{instance_id}/{request_id}",
+            {"approved": True, "reviewer_notes": "Content is appropriate and well-written."},
+        )
+        assert approval_response.status_code == 200
+
+        # Wait for orchestration to complete
+        final_status = self.helper.wait_for_orchestration(data["statusQueryGetUri"])
+        assert final_status["runtimeStatus"] == "Completed"
+        assert "output" in final_status
+
+    def test_hitl_workflow_rejection(self) -> None:
+        """Test HITL workflow with human rejection."""
+        payload = {
+            "content_id": "article-test-002",
+            "title": "Get Rich Quick Scheme",
+            "body": (
+                "Click here NOW to make $10,000 overnight! This SECRET method is GUARANTEED to work! "
+                "Limited time offer - act NOW before it's too late!"
+            ),
+            "author": "Definitely Not Spam",
+        }
+
+        # Start orchestration
+        response = self.helper.post_json(f"{self.base_url}/api/workflow/{WORKFLOW_NAME}/run", payload)
+        assert response.status_code == 202
+        data = response.json()
+        instance_id = data["instanceId"]
+
+        # Wait for the workflow to reach the HITL pause point
+        status = self._wait_for_hitl_request(instance_id)
+
+        # Get the request ID from pending requests
+        pending_requests = status.get("pendingHumanInputRequests", [])
+        assert len(pending_requests) > 0, "Expected pending HITL request"
+        request_id = pending_requests[0]["requestId"]
+
+        # Send rejection
+        rejection_response = self.helper.post_json(
+            f"{self.base_url}/api/workflow/{WORKFLOW_NAME}/respond/{instance_id}/{request_id}",
+            {"approved": False, "reviewer_notes": "Content appears to be spam/scam material."},
+        )
+        assert rejection_response.status_code == 200
+
+        # Wait for orchestration to complete
+        final_status = self.helper.wait_for_orchestration(data["statusQueryGetUri"])
+        assert final_status["runtimeStatus"] == "Completed"
+        assert "output" in final_status
+        # The output should indicate rejection
+        output = final_status["output"]
+        assert "rejected" in str(output).lower()
+
+    def test_hitl_workflow_status_endpoint(self) -> None:
+        """Test that the workflow status endpoint shows pending HITL requests."""
+        payload = {
+            "content_id": "article-test-003",
+            "title": "Test Article",
+            "body": "This is a test article for checking status endpoint functionality.",
+            "author": "Test Author",
+        }
+
+        # Start orchestration
+        response = self.helper.post_json(f"{self.base_url}/api/workflow/{WORKFLOW_NAME}/run", payload)
+        assert response.status_code == 202
+        data = response.json()
+        instance_id = data["instanceId"]
+
+        # Wait for HITL pause
+        status = self._wait_for_hitl_request(instance_id)
+
+        # Check status
+        assert "instanceId" in status
+        assert status["instanceId"] == instance_id
+        assert "runtimeStatus" in status
+        assert "pendingHumanInputRequests" in status
+
+        # Clean up: approve to complete
+        pending_requests = status.get("pendingHumanInputRequests", [])
+        if pending_requests:
+            request_id = pending_requests[0]["requestId"]
+            self.helper.post_json(
+                f"{self.base_url}/api/workflow/{WORKFLOW_NAME}/respond/{instance_id}/{request_id}",
+                {"approved": True, "reviewer_notes": ""},
+            )
+
+        # Wait for completion
+        self.helper.wait_for_orchestration(data["statusQueryGetUri"])
+
+    def test_hitl_workflow_with_neutral_content(self) -> None:
+        """Test HITL workflow with neutral content that should get medium risk."""
+        payload = {
+            "content_id": "article-test-004",
+            "title": "Product Review",
+            "body": (
+                "This product works as advertised. The build quality is average and the price "
+                "is reasonable. I would recommend it for basic use cases but not for professional work."
+            ),
+            "author": "Regular User",
+        }
+
+        # Start orchestration
+        response = self.helper.post_json(f"{self.base_url}/api/workflow/{WORKFLOW_NAME}/run", payload)
+        assert response.status_code == 202
+        data = response.json()
+        instance_id = data["instanceId"]
+
+        # Wait for HITL pause
+        status = self._wait_for_hitl_request(instance_id)
+
+        pending_requests = status.get("pendingHumanInputRequests", [])
+        assert len(pending_requests) > 0
+        request_id = pending_requests[0]["requestId"]
+
+        # Approve
+        self.helper.post_json(
+            f"{self.base_url}/api/workflow/{WORKFLOW_NAME}/respond/{instance_id}/{request_id}",
+            {"approved": True, "reviewer_notes": "Approved after review."},
+        )
+
+        # Wait for completion
+        final_status = self.helper.wait_for_orchestration(data["statusQueryGetUri"])
+        assert final_status["runtimeStatus"] == "Completed"
+
+    def test_hitl_notify_respond_url_matches_helper(self) -> None:
+        """The respond URL WorkflowHitlContext builds equals the one the server accepts.
+
+        This is the core guarantee of the in-workflow notify pattern: the URL an
+        executor builds (via ``WorkflowHitlContext`` -- the same one ``NotifyExecutor``
+        would email a reviewer) is byte-for-byte the canonical respond URL the status
+        endpoint exposes, and POSTing to it actually resumes the run.
+        """
+        payload = {
+            "content_id": "article-test-005",
+            "title": "Sustainable Gardening Basics",
+            "body": (
+                "Composting kitchen scraps enriches soil naturally and reduces waste. "
+                "Rotating crops each season helps prevent nutrient depletion."
+            ),
+            "author": "Green Thumb",
+        }
+
+        # Start orchestration
+        response = self.helper.post_json(f"{self.base_url}/api/workflow/{WORKFLOW_NAME}/run", payload)
+        assert response.status_code == 202
+        data = response.json()
+        instance_id = data["instanceId"]
+
+        # Wait for the workflow to reach the HITL pause point
+        status = self._wait_for_hitl_request(instance_id)
+        pending_requests = status.get("pendingHumanInputRequests", [])
+        assert len(pending_requests) > 0, "Expected pending HITL request"
+        pending = pending_requests[0]
+        request_id = pending["requestId"]
+
+        # request_info generates the request id internally as a uuid4 when the caller
+        # does not pass one, so the pending id round-trips as a valid UUID (not an
+        # opaque framework default).
+        uuid.UUID(request_id)  # raises ValueError if not a valid UUID
+
+        # The request originates in the executor that called request_info.
+        assert pending.get("sourceExecutor") == "human_review_executor"
+
+        # Build the respond URL the same way an in-workflow executor would, via the
+        # public helper, pointing it at this app's base URL. It must equal the
+        # server-exposed respondUrl exactly -- i.e. the link NotifyExecutor emails is
+        # the one the /respond endpoint honors.
+        hitl = WorkflowHitlContext(
+            instance_id=instance_id,
+            workflow_name=WORKFLOW_NAME,
+            base_url_override=self.base_url,
+        )
+        helper_url = hitl.build_respond_url(request_id)
+        assert helper_url == pending["respondUrl"]
+
+        # Responding via the helper-built URL resumes the workflow to completion.
+        approval_response = self.helper.post_json(
+            helper_url,
+            {"approved": True, "reviewer_notes": "Looks good."},
+        )
+        assert approval_response.status_code == 200
+
+        final_status = self.helper.wait_for_orchestration(data["statusQueryGetUri"])
+        assert final_status["runtimeStatus"] == "Completed"
+        assert "output" in final_status
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/python/packages/azurefunctions/tests/integration_tests/test_13_workflow_subworkflow_hitl.py
+++ b/python/packages/azurefunctions/tests/integration_tests/test_13_workflow_subworkflow_hitl.py
@@ -1,0 +1,199 @@
+# Copyright (c) Microsoft. All rights reserved.
+"""
+Integration Tests for the Sub-workflow HITL Sample (13_subworkflow_hitl)
+
+Tests nested human-in-the-loop through the Azure Functions host: the HITL pause
+lives inside an inner workflow embedded via ``WorkflowExecutor``, so the pending
+request surfaces at the top-level instance with a **qualified** request id
+(``review_sub~0~{requestId}``). The caller responds against the top-level instance
+and the host routes it to the owning child orchestration.
+
+This sample hosts no AI agents, so it exercises the AF nested-HITL plumbing
+deterministically (no model latency / variability).
+
+The function app is automatically started by the test fixture.
+
+Prerequisites:
+- Azurite running for durable orchestrations
+- Durable Task Scheduler emulator running on localhost:8080
+
+Usage:
+    uv run pytest packages/azurefunctions/tests/integration_tests/test_13_workflow_subworkflow_hitl.py -v
+"""
+
+import time
+import uuid
+
+import pytest
+
+from agent_framework_azurefunctions import WorkflowHitlContext
+
+# Module-level markers - applied to all tests in this file
+pytestmark = [
+    pytest.mark.flaky,
+    pytest.mark.integration,
+    pytest.mark.sample("13_subworkflow_hitl"),
+    pytest.mark.usefixtures("function_app_for_test"),
+]
+
+# Must match the outer workflow name in samples/.../13_subworkflow_hitl/function_app.py
+WORKFLOW_NAME = "moderation_pipeline"
+# The WorkflowExecutor node id that embeds the inner HITL workflow.
+SUBWORKFLOW_NODE_ID = "review_sub"
+
+
+@pytest.mark.orchestration
+class TestSubworkflowHITL:
+    """Tests for the 13_subworkflow_hitl sample (nested HITL behind one surface)."""
+
+    @pytest.fixture(autouse=True)
+    def _setup(self, base_url: str, sample_helper) -> None:
+        """Provide the helper and base URL for each test."""
+        self.base_url = base_url
+        self.helper = sample_helper
+
+    def _wait_for_hitl_request(self, instance_id: str, timeout: int = 40) -> dict:
+        """Poll the top-level status endpoint until a (nested) HITL request appears."""
+        start_time = time.time()
+        while time.time() - start_time < timeout:
+            status_response = self.helper.get(f"{self.base_url}/api/workflow/{WORKFLOW_NAME}/status/{instance_id}")
+            if status_response.status_code == 200:
+                status = status_response.json()
+                if status.get("pendingHumanInputRequests"):
+                    return status
+            time.sleep(2)
+        raise AssertionError(f"Timed out waiting for a nested HITL request for instance {instance_id}")
+
+    def _start(self, payload: dict) -> dict:
+        """Start the outer workflow and return the run response JSON."""
+        response = self.helper.post_json(f"{self.base_url}/api/workflow/{WORKFLOW_NAME}/run", payload)
+        assert response.status_code == 202
+        return response.json()
+
+    def test_nested_request_surfaces_with_qualified_id(self) -> None:
+        """The nested pending request is surfaced with a ``review_sub~0~{id}`` qualified id."""
+        data = self._start({
+            "content_id": "article-100",
+            "title": "Quarterly Roadmap",
+            "body": "A summary of the upcoming features planned for the next quarter.",
+        })
+        instance_id = data["instanceId"]
+
+        status = self._wait_for_hitl_request(instance_id)
+        pending = status.get("pendingHumanInputRequests", [])
+        assert len(pending) == 1
+        request_id = pending[0]["requestId"]
+
+        # The qualifier carries the node id and the child's ordinal (0 for the single
+        # dispatch), then the inner bare request id: ``review_sub~0~{requestId}``.
+        expected_prefix = f"{SUBWORKFLOW_NODE_ID}~0~"
+        assert request_id.startswith(expected_prefix), request_id
+        assert request_id[len(expected_prefix) :]  # non-empty inner id
+
+        # The respondUrl always targets the top-level instance.
+        assert f"/api/workflow/{WORKFLOW_NAME}/respond/{instance_id}/" in pending[0]["respondUrl"]
+
+        # Drain the pause so the instance does not hang.
+        approve = self.helper.post_json(
+            f"{self.base_url}/api/workflow/{WORKFLOW_NAME}/respond/{instance_id}/{request_id}",
+            {"approved": True, "reviewer_notes": "ok"},
+        )
+        assert approve.status_code == 200
+        self.helper.wait_for_orchestration(data["statusQueryGetUri"])
+
+    def test_nested_hitl_approval(self) -> None:
+        """Responding 'approved' to the nested request resumes the outer workflow to APPROVED."""
+        data = self._start({
+            "content_id": "article-001",
+            "title": "Introduction to AI in Healthcare",
+            "body": (
+                "Artificial intelligence is improving healthcare by enabling faster diagnosis, "
+                "personalized treatment plans, and better patient outcomes."
+            ),
+        })
+        instance_id = data["instanceId"]
+
+        status = self._wait_for_hitl_request(instance_id)
+        request_id = status["pendingHumanInputRequests"][0]["requestId"]
+
+        approval = self.helper.post_json(
+            f"{self.base_url}/api/workflow/{WORKFLOW_NAME}/respond/{instance_id}/{request_id}",
+            {"approved": True, "reviewer_notes": "Looks good."},
+        )
+        assert approval.status_code == 200
+
+        final_status = self.helper.wait_for_orchestration(data["statusQueryGetUri"])
+        assert final_status["runtimeStatus"] == "Completed"
+        assert "APPROVED" in str(final_status.get("output")).upper()
+
+    def test_nested_hitl_rejection(self) -> None:
+        """Responding 'rejected' to the nested request resumes the outer workflow to REJECTED."""
+        data = self._start({
+            "content_id": "article-002",
+            "title": "Get Rich Quick",
+            "body": "Click here NOW to make $10,000 overnight! GUARANTEED! Limited time offer!",
+        })
+        instance_id = data["instanceId"]
+
+        status = self._wait_for_hitl_request(instance_id)
+        request_id = status["pendingHumanInputRequests"][0]["requestId"]
+
+        rejection = self.helper.post_json(
+            f"{self.base_url}/api/workflow/{WORKFLOW_NAME}/respond/{instance_id}/{request_id}",
+            {"approved": False, "reviewer_notes": "Violates content policy."},
+        )
+        assert rejection.status_code == 200
+
+        final_status = self.helper.wait_for_orchestration(data["statusQueryGetUri"])
+        assert final_status["runtimeStatus"] == "Completed"
+        assert "REJECTED" in str(final_status.get("output")).upper()
+
+    def test_nested_notify_respond_url_matches_helper(self) -> None:
+        """The URL the nested NotifyExecutor builds equals the server's qualified respondUrl.
+
+        Proves the address-propagation path end-to-end: the inner ``notify`` executor
+        (running in the child orchestration) builds a respond URL from the propagated
+        root instance + ``review_sub~0~`` prefix, given only the inner bare request id,
+        and that URL is byte-for-byte the qualified ``respondUrl`` the top-level status
+        endpoint exposes -- and POSTing to it resumes the nested run.
+        """
+        data = self._start({
+            "content_id": "article-200",
+            "title": "Tide Pool Ecology",
+            "body": "Intertidal zones host a surprising diversity of resilient marine life.",
+        })
+        instance_id = data["instanceId"]
+
+        status = self._wait_for_hitl_request(instance_id)
+        pending = status.get("pendingHumanInputRequests", [])
+        assert len(pending) == 1
+        qualified_id = pending[0]["requestId"]
+
+        # The qualified id is ``review_sub~0~{bare}``; request_info generates the bare
+        # inner id internally as a uuid4 when the review gate does not pass one.
+        prefix = f"{SUBWORKFLOW_NODE_ID}~0~"
+        assert qualified_id.startswith(prefix), qualified_id
+        bare_id = qualified_id[len(prefix) :]
+        uuid.UUID(bare_id)  # raises if the inner id is not a valid uuid4
+
+        # Rebuild the URL exactly as the nested NotifyExecutor does: the root instance
+        # and root workflow name, the propagated path prefix, and only the bare id.
+        hitl = WorkflowHitlContext(
+            instance_id=instance_id,
+            workflow_name=WORKFLOW_NAME,
+            base_url_override=self.base_url,
+            request_path_prefix=prefix,
+        )
+        helper_url = hitl.build_respond_url(bare_id)
+        assert helper_url == pending[0]["respondUrl"]
+
+        # Responding via the helper-built URL resumes the nested run to completion.
+        approve = self.helper.post_json(helper_url, {"approved": True, "reviewer_notes": "ok"})
+        assert approve.status_code == 200
+        final_status = self.helper.wait_for_orchestration(data["statusQueryGetUri"])
+        assert final_status["runtimeStatus"] == "Completed"
+        assert "APPROVED" in str(final_status.get("output")).upper()
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/python/packages/azurefunctions/tests/test_app.py
+++ b/python/packages/azurefunctions/tests/test_app.py
@@ -1,0 +1,1966 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+"""Unit tests for AgentFunctionApp."""
+
+# pyright: reportPrivateUsage=false
+
+import json
+from collections.abc import Awaitable, Callable
+from typing import Any, TypeVar
+from unittest.mock import ANY, AsyncMock, Mock, patch
+
+import azure.durable_functions as df
+import azure.functions as func
+import pytest
+from agent_framework import AgentResponse, Message
+from agent_framework_durabletask import (
+    MIMETYPE_APPLICATION_JSON,
+    MIMETYPE_TEXT_PLAIN,
+    THREAD_ID_HEADER,
+    WAIT_FOR_RESPONSE_FIELD,
+    WAIT_FOR_RESPONSE_HEADER,
+    AgentEntity,
+    AgentEntityStateProviderMixin,
+    DurableAgentState,
+    workflow_orchestrator_name,
+)
+
+from agent_framework_azurefunctions import AgentFunctionApp
+from agent_framework_azurefunctions._entities import create_agent_entity
+
+FuncT = TypeVar("FuncT", bound=Callable[..., Any])
+
+
+def _identity_decorator(func: FuncT) -> FuncT:
+    return func
+
+
+class _InMemoryStateProvider(AgentEntityStateProviderMixin):
+    def __init__(self, *, thread_id: str = "test-thread", initial_state: dict[str, Any] | None = None) -> None:
+        self._thread_id = thread_id
+        self._state_dict: dict[str, Any] = initial_state or {}
+
+    def _get_state_dict(self) -> dict[str, Any]:
+        return self._state_dict
+
+    def _set_state_dict(self, state: dict[str, Any]) -> None:
+        self._state_dict = state
+
+    def _get_thread_id_from_entity(self) -> str:
+        return self._thread_id
+
+
+class TestAgentFunctionAppInit:
+    """Test suite for AgentFunctionApp initialization."""
+
+    def test_init_with_defaults(self) -> None:
+        """Test initialization with default parameters."""
+        mock_agent = Mock()
+        mock_agent.name = "TestAgent"
+
+        app = AgentFunctionApp(agents=[mock_agent])
+
+        assert len(app.agents) == 1
+        assert "TestAgent" in app.agents
+        assert app.enable_health_check is True
+
+    def test_init_with_custom_auth_level(self) -> None:
+        """Test initialization with custom auth level."""
+        mock_agent = Mock()
+        mock_agent.name = "TestAgent"
+
+        app = AgentFunctionApp(agents=[mock_agent], http_auth_level=func.AuthLevel.FUNCTION)
+
+        # App should be created successfully
+        assert "TestAgent" in app.agents
+
+    def test_init_with_health_check_disabled(self) -> None:
+        """Test initialization with health check disabled."""
+        mock_agent = Mock()
+        mock_agent.name = "TestAgent"
+
+        app = AgentFunctionApp(agents=[mock_agent], enable_health_check=False)
+
+        assert app.enable_health_check is False
+
+    def test_init_with_http_endpoints_disabled(self) -> None:
+        """Test initialization with HTTP endpoints disabled."""
+        mock_agent = Mock()
+        mock_agent.name = "TestAgent"
+
+        app = AgentFunctionApp(agents=[mock_agent], enable_http_endpoints=False)
+
+        assert app.enable_http_endpoints is False
+
+    def test_init_stores_agent_reference(self) -> None:
+        """Test that agent reference is stored correctly."""
+        mock_agent = Mock()
+        mock_agent.name = "TestAgent"
+
+        app = AgentFunctionApp(agents=[mock_agent])
+
+        assert app.agents["TestAgent"].name == "TestAgent"
+
+    def test_add_agent_uses_specific_callback(self) -> None:
+        """Verify that a per-agent callback overrides the default."""
+
+        mock_agent = Mock()
+        mock_agent.name = "CallbackAgent"
+        specific_callback = Mock()
+
+        with patch.object(AgentFunctionApp, "_setup_agent_functions") as setup_mock:
+            app = AgentFunctionApp(default_callback=Mock())
+            app.add_agent(mock_agent, callback=specific_callback)
+
+        setup_mock.assert_called_once()
+        _, _, passed_callback, enable_http_endpoint, _enable_mcp_tool_trigger = setup_mock.call_args[0]
+        assert passed_callback is specific_callback
+        assert enable_http_endpoint is True
+
+    def test_default_callback_applied_when_no_specific(self) -> None:
+        """Ensure the default callback is supplied when add_agent lacks override."""
+
+        mock_agent = Mock()
+        mock_agent.name = "DefaultAgent"
+        default_callback = Mock()
+
+        with patch.object(AgentFunctionApp, "_setup_agent_functions") as setup_mock:
+            app = AgentFunctionApp(default_callback=default_callback)
+            app.add_agent(mock_agent)
+
+        setup_mock.assert_called_once()
+        _, _, passed_callback, enable_http_endpoint, _enable_mcp_tool_trigger = setup_mock.call_args[0]
+        assert passed_callback is default_callback
+        assert enable_http_endpoint is True
+
+    def test_init_with_agents_uses_default_callback(self) -> None:
+        """Agents provided in __init__ should receive the default callback."""
+
+        mock_agent = Mock()
+        mock_agent.name = "InitAgent"
+        default_callback = Mock()
+
+        with patch.object(AgentFunctionApp, "_setup_agent_functions") as setup_mock:
+            AgentFunctionApp(agents=[mock_agent], default_callback=default_callback)
+
+        setup_mock.assert_called_once()
+        _, _, passed_callback, enable_http_endpoint, _enable_mcp_tool_trigger = setup_mock.call_args[0]
+        assert passed_callback is default_callback
+        assert enable_http_endpoint is True
+
+
+class TestAgentFunctionAppSetup:
+    """Test suite for AgentFunctionApp setup and configuration."""
+
+    def test_app_is_dfapp_instance(self) -> None:
+        """Test that AgentFunctionApp is a DFApp instance."""
+        mock_agent = Mock()
+        mock_agent.name = "TestAgent"
+
+        app = AgentFunctionApp(agents=[mock_agent])
+
+        assert isinstance(app, df.DFApp)
+
+    def test_setup_creates_http_trigger(self) -> None:
+        """Test that setup creates an HTTP trigger."""
+        mock_agent = Mock()
+        mock_agent.name = "TestAgent"
+
+        def passthrough_decorator(*args: Any, **kwargs: Any) -> Callable[[FuncT], FuncT]:
+            def decorator(func: FuncT) -> FuncT:
+                return func
+
+            return decorator
+
+        with (
+            patch.object(AgentFunctionApp, "route", new=passthrough_decorator),
+            patch.object(AgentFunctionApp, "durable_client_input", new=passthrough_decorator),
+            patch.object(AgentFunctionApp, "entity_trigger", new=passthrough_decorator),
+        ):
+            app = AgentFunctionApp(agents=[mock_agent])
+
+        # Verify agent is registered
+        assert "TestAgent" in app.agents
+
+    def test_http_function_name_uses_prefix_format(self) -> None:
+        """Ensure function names follow the prefix-agent naming convention."""
+        mock_agent = Mock()
+        mock_agent.name = "Agent 42"
+
+        captured_names: list[str] = []
+
+        def capture_function_name(
+            self: AgentFunctionApp, name: str, *args: Any, **kwargs: Any
+        ) -> Callable[[FuncT], FuncT]:
+            def decorator(func: FuncT) -> FuncT:
+                captured_names.append(name)
+                return func
+
+            return decorator
+
+        def passthrough_decorator(*args: Any, **kwargs: Any) -> Callable[[FuncT], FuncT]:
+            def decorator(func: FuncT) -> FuncT:
+                return func
+
+            return decorator
+
+        with (
+            patch.object(AgentFunctionApp, "function_name", new=capture_function_name),
+            patch.object(AgentFunctionApp, "route", new=passthrough_decorator),
+            patch.object(AgentFunctionApp, "durable_client_input", new=passthrough_decorator),
+            patch.object(AgentFunctionApp, "entity_trigger", new=passthrough_decorator),
+        ):
+            AgentFunctionApp(agents=[mock_agent])
+
+        assert captured_names == ["http-Agent_42"]
+
+    def test_setup_skips_http_trigger_when_disabled(self) -> None:
+        """Test that HTTP trigger is not created when disabled."""
+        mock_agent = Mock()
+        mock_agent.name = "TestAgent"
+
+        captured_routes: list[str | None] = []
+
+        def capture_route(*args: Any, **kwargs: Any) -> Callable[[FuncT], FuncT]:
+            def decorator(func: FuncT) -> FuncT:
+                route_key = kwargs.get("route") if kwargs else None
+                captured_routes.append(route_key)
+                return func
+
+            return decorator
+
+        def passthrough_decorator(*args: Any, **kwargs: Any) -> Callable[[FuncT], FuncT]:
+            def decorator(func: FuncT) -> FuncT:
+                return func
+
+            return decorator
+
+        with (
+            patch.object(AgentFunctionApp, "function_name", new=passthrough_decorator),
+            patch.object(AgentFunctionApp, "route", new=capture_route),
+            patch.object(AgentFunctionApp, "durable_client_input", new=passthrough_decorator),
+            patch.object(AgentFunctionApp, "entity_trigger", new=passthrough_decorator),
+        ):
+            app = AgentFunctionApp(agents=[mock_agent], enable_http_endpoints=False)
+
+        # Verify agent is registered
+        assert "TestAgent" in app.agents
+
+        # Verify that no HTTP run route was created
+        run_route = f"agents/{mock_agent.name}/run"
+        assert run_route not in captured_routes
+
+    def test_agent_override_enables_http_route_when_app_disabled(self) -> None:
+        """Agent-level override should enable HTTP route even when app disables it."""
+
+        mock_agent = Mock()
+        mock_agent.name = "OverrideAgent"
+
+        with (
+            patch.object(AgentFunctionApp, "_setup_http_run_route") as http_route_mock,
+            patch.object(AgentFunctionApp, "_setup_agent_entity") as agent_entity_mock,
+        ):
+            app = AgentFunctionApp(enable_health_check=False, enable_http_endpoints=False)
+            app.add_agent(mock_agent, enable_http_endpoint=True)
+
+        http_route_mock.assert_called_once_with("OverrideAgent")
+        agent_entity_mock.assert_called_once_with(mock_agent, "OverrideAgent", ANY)
+        assert app._agent_metadata["OverrideAgent"].http_endpoint_enabled is True
+
+    def test_agent_override_disables_http_route_when_app_enabled(self) -> None:
+        """Agent-level override should disable HTTP route even when app enables it."""
+
+        mock_agent = Mock()
+        mock_agent.name = "DisabledOverride"
+
+        with (
+            patch.object(AgentFunctionApp, "_setup_http_run_route") as http_route_mock,
+            patch.object(AgentFunctionApp, "_setup_agent_entity") as agent_entity_mock,
+        ):
+            app = AgentFunctionApp(enable_health_check=False, enable_http_endpoints=True)
+            app.add_agent(mock_agent, enable_http_endpoint=False)
+
+        http_route_mock.assert_not_called()
+        agent_entity_mock.assert_called_once_with(mock_agent, "DisabledOverride", ANY)
+        assert app._agent_metadata["DisabledOverride"].http_endpoint_enabled is False
+
+    def test_multiple_apps_independent(self) -> None:
+        """Test that multiple AgentFunctionApp instances are independent."""
+        agent1 = Mock()
+        agent1.name = "Agent1"
+        agent2 = Mock()
+        agent2.name = "Agent2"
+
+        app1 = AgentFunctionApp(agents=[agent1])
+        app2 = AgentFunctionApp(agents=[agent2])
+
+        assert app1.agents["Agent1"].name == "Agent1"
+        assert app2.agents["Agent2"].name == "Agent2"
+        assert "Agent1" in app1.agents
+        assert "Agent2" in app2.agents
+
+
+class TestWaitForResponseAndCorrelationId:
+    """Tests for wait_for_response flag and correlation ID handling."""
+
+    def _create_app(self) -> AgentFunctionApp:
+        mock_agent = Mock()
+        mock_agent.__class__.__name__ = "MockAgent"
+        mock_agent.name = "MockAgent"
+        return AgentFunctionApp(agents=[mock_agent], enable_health_check=False)
+
+    def _make_request(
+        self,
+        headers: dict[str, str] | None = None,
+        params: dict[str, str] | None = None,
+    ) -> Mock:
+        request = Mock()
+        request.headers = headers or {}
+        request.params = params or {}
+        return request
+
+    def test_wait_for_response_header_true(self) -> None:
+        """Test that the wait-for-response header is honored."""
+        app = self._create_app()
+        request = self._make_request(headers={WAIT_FOR_RESPONSE_HEADER: "true"})
+
+        assert app._should_wait_for_response(request, {}) is True
+
+    def test_wait_for_response_body_snake_case(self) -> None:
+        """Test that payload controls wait_for_response."""
+        app = self._create_app()
+        request = self._make_request()
+
+        assert app._should_wait_for_response(request, {WAIT_FOR_RESPONSE_FIELD: "true"}) is True
+        assert app._should_wait_for_response(request, {WAIT_FOR_RESPONSE_FIELD: "false"}) is False
+        assert app._should_wait_for_response(request, {WAIT_FOR_RESPONSE_FIELD: "0"}) is False
+
+    def test_wait_for_response_query_parameter(self) -> None:
+        """Test that query parameter controls wait_for_response."""
+        app = self._create_app()
+        request = self._make_request(params={WAIT_FOR_RESPONSE_FIELD: "true"})
+
+        assert app._should_wait_for_response(request, {}) is True
+
+    def test_wait_for_response_query_precedence(self) -> None:
+        """Test that query parameter overrides body value."""
+        app = self._create_app()
+        request = self._make_request(params={WAIT_FOR_RESPONSE_FIELD: "false"})
+
+        assert app._should_wait_for_response(request, {WAIT_FOR_RESPONSE_FIELD: "true"}) is False
+
+
+class TestAgentEntityOperations:
+    """Test suite for entity operations."""
+
+    async def test_entity_run_agent_operation(self) -> None:
+        """Test that entity can run agent operation."""
+        mock_agent = Mock()
+        mock_agent.run = AsyncMock(
+            return_value=AgentResponse(messages=[Message(role="assistant", contents=["Test response"])])
+        )
+
+        entity = AgentEntity(mock_agent, state_provider=_InMemoryStateProvider(thread_id="test-conv-123"))
+
+        result = await entity.run({
+            "message": "Test message",
+            "correlationId": "corr-app-entity-1",
+        })
+
+        assert isinstance(result, AgentResponse)
+        assert result.text == "Test response"
+        assert entity.state.message_count == 2
+
+    async def test_entity_stores_conversation_history(self) -> None:
+        """Test that the entity stores conversation history."""
+        mock_agent = Mock()
+        mock_agent.run = AsyncMock(
+            return_value=AgentResponse(messages=[Message(role="assistant", contents=["Response 1"])])
+        )
+
+        entity = AgentEntity(mock_agent, state_provider=_InMemoryStateProvider(thread_id="conv-1"))
+
+        # Send first message
+        await entity.run({"message": "Message 1", "correlationId": "corr-app-entity-2"})
+
+        # Each conversation turn creates 2 entries: request and response
+        history = entity.state.data.conversation_history[0].messages  # Request entry
+        assert len(history) == 1  # Just the user message
+
+        # Send second message
+        await entity.run({"message": "Message 2", "correlationId": "corr-app-entity-2b"})
+
+        # Now we have 4 entries total (2 requests + 2 responses)
+        # Access the first request entry
+        history2 = entity.state.data.conversation_history[2].messages  # Second request entry
+        assert len(history2) == 1  # Just the user message
+
+        user_msg = history[0]
+        user_role = getattr(user_msg.role, "value", user_msg.role)
+        assert user_role == "user"
+        assert user_msg.text == "Message 1"
+
+        assistant_msg = entity.state.data.conversation_history[1].messages[0]
+        assistant_role = getattr(assistant_msg.role, "value", assistant_msg.role)
+        assert assistant_role == "assistant"
+        assert assistant_msg.text == "Response 1"
+
+    async def test_entity_increments_message_count(self) -> None:
+        """Test that the entity increments the message count."""
+        mock_agent = Mock()
+        mock_agent.run = AsyncMock(
+            return_value=AgentResponse(messages=[Message(role="assistant", contents=["Response"])])
+        )
+
+        entity = AgentEntity(mock_agent, state_provider=_InMemoryStateProvider(thread_id="conv-1"))
+
+        assert len(entity.state.data.conversation_history) == 0
+
+        await entity.run({"message": "Message 1", "correlationId": "corr-app-entity-3a"})
+        assert len(entity.state.data.conversation_history) == 2
+
+        await entity.run({"message": "Message 2", "correlationId": "corr-app-entity-3b"})
+        assert len(entity.state.data.conversation_history) == 4
+
+    def test_entity_reset(self) -> None:
+        """Test that entity reset clears state."""
+        mock_agent = Mock()
+        entity = AgentEntity(mock_agent, state_provider=_InMemoryStateProvider())
+
+        # Set some state
+        entity.state = DurableAgentState()
+
+        # Reset
+        entity.reset()
+
+        assert len(entity.state.data.conversation_history) == 0
+
+
+class TestAgentEntityFactory:
+    """Test suite for the entity factory function."""
+
+    def test_create_agent_entity_returns_function(self) -> None:
+        """Test that create_agent_entity returns a function."""
+        mock_agent = Mock()
+        entity_function = create_agent_entity(mock_agent)
+
+        assert callable(entity_function)
+
+    def test_entity_function_handles_run_operation(self) -> None:
+        """Test that the entity function handles the run operation."""
+        mock_agent = Mock()
+        mock_agent.run = AsyncMock(
+            return_value=AgentResponse(messages=[Message(role="assistant", contents=["Response"])])
+        )
+
+        entity_function = create_agent_entity(mock_agent)
+
+        # Mock context
+        mock_context = Mock()
+        mock_context.operation_name = "run"
+        mock_context.get_input.return_value = {
+            "message": "Test message",
+            "correlationId": "corr-app-factory-1",
+        }
+        mock_context.get_state.return_value = None
+
+        # Execute entity function
+        entity_function(mock_context)
+
+        # Verify result was set
+        assert mock_context.set_result.called
+        assert mock_context.set_state.called
+        result_call = mock_context.set_result.call_args[0][0]
+        assert "error" not in result_call
+
+    def test_entity_function_handles_run_agent_operation(self) -> None:
+        """Test that the entity function handles the deprecated run_agent operation for backward compatibility."""
+        mock_agent = Mock()
+        mock_agent.run = AsyncMock(
+            return_value=AgentResponse(messages=[Message(role="assistant", contents=["Response"])])
+        )
+
+        entity_function = create_agent_entity(mock_agent)
+
+        # Mock context
+        mock_context = Mock()
+        mock_context.operation_name = "run_agent"
+        mock_context.get_input.return_value = {
+            "message": "Test message",
+            "correlationId": "corr-app-factory-1",
+        }
+        mock_context.get_state.return_value = None
+
+        # Execute entity function
+        entity_function(mock_context)
+
+        # Verify result was set
+        assert mock_context.set_result.called
+        assert mock_context.set_state.called
+        result_call = mock_context.set_result.call_args[0][0]
+        assert "error" not in result_call
+
+    def test_entity_function_handles_reset_operation(self) -> None:
+        """Test that the entity function handles the reset operation."""
+        mock_agent = Mock()
+        entity_function = create_agent_entity(mock_agent)
+
+        # Mock context
+        mock_context = Mock()
+        mock_context.operation_name = "reset"
+        mock_context.get_state.return_value = {
+            "schemaVersion": "1.0.0",
+            "data": {
+                "conversationHistory": [
+                    {
+                        "$type": "request",
+                        "correlationId": "corr-reset-test",
+                        "createdAt": "2024-01-01T00:00:00Z",
+                        "messages": [
+                            {
+                                "role": "user",
+                                "contents": [
+                                    {
+                                        "$type": "text",
+                                        "text": "test",
+                                    }
+                                ],
+                            }
+                        ],
+                    }
+                ],
+            },
+        }
+
+        # Execute entity function
+        entity_function(mock_context)
+
+        # Verify result was set
+        assert mock_context.set_result.called
+        result_call = mock_context.set_result.call_args[0][0]
+        assert result_call["status"] == "reset"
+
+    def test_entity_function_handles_unknown_operation(self) -> None:
+        """Test that the entity function handles an unknown operation."""
+        mock_agent = Mock()
+        entity_function = create_agent_entity(mock_agent)
+
+        # Mock context with unknown operation
+        mock_context = Mock()
+        mock_context.operation_name = "unknown_operation"
+        mock_context.get_state.return_value = None
+
+        # Execute entity function
+        entity_function(mock_context)
+
+        # Verify error result was set
+        assert mock_context.set_result.called
+        result_call = mock_context.set_result.call_args[0][0]
+        assert "error" in result_call
+        assert "unknown_operation" in result_call["error"]
+
+    def test_entity_function_restores_state(self) -> None:
+        """Test that the entity function restores state from the context."""
+        mock_agent = Mock()
+        entity_function = create_agent_entity(mock_agent)
+
+        # Mock context with existing state
+        existing_state = {
+            "schemaVersion": "1.0.0",
+            "data": {
+                "conversationHistory": [
+                    {
+                        "$type": "request",
+                        "correlationId": "corr-existing-1",
+                        "createdAt": "2024-01-01T00:00:00Z",
+                        "messages": [
+                            {
+                                "role": "user",
+                                "contents": [
+                                    {
+                                        "$type": "text",
+                                        "text": "msg1",
+                                    }
+                                ],
+                            }
+                        ],
+                    },
+                    {
+                        "$type": "response",
+                        "correlationId": "corr-existing-1",
+                        "createdAt": "2024-01-01T00:05:00Z",
+                        "messages": [
+                            {
+                                "role": "assistant",
+                                "contents": [
+                                    {
+                                        "$type": "text",
+                                        "text": "resp1",
+                                    }
+                                ],
+                            }
+                        ],
+                    },
+                ],
+            },
+        }
+
+        mock_context = Mock()
+        mock_context.operation_name = "run"
+        mock_context.get_input.return_value = {
+            "message": "Test message",
+            "correlationId": "corr-restore-1",
+        }
+        mock_context.get_state.return_value = existing_state
+
+        with patch.object(DurableAgentState, "from_dict", wraps=DurableAgentState.from_dict) as from_dict_mock:
+            entity_function(mock_context)
+
+        from_dict_mock.assert_called_once_with(existing_state)
+
+
+class TestErrorHandling:
+    """Test suite for error handling."""
+
+    async def test_entity_handles_agent_error(self) -> None:
+        """Test that the entity handles agent execution errors."""
+        mock_agent = Mock()
+        mock_agent.run = AsyncMock(side_effect=Exception("Agent error"))
+
+        entity = AgentEntity(mock_agent, state_provider=_InMemoryStateProvider(thread_id="conv-1"))
+
+        result = await entity.run({
+            "message": "Test message",
+            "correlationId": "corr-app-error-1",
+        })
+
+        assert isinstance(result, AgentResponse)
+        assert len(result.messages) == 1
+        content = result.messages[0].contents[0]
+        assert content.type == "error"
+        assert "Agent error" in (content.message or "")
+        assert content.error_code == "Exception"
+
+    def test_entity_function_handles_exception(self) -> None:
+        """Test that the entity function handles exceptions gracefully."""
+        mock_agent = Mock()
+        # Force an exception by making get_input fail
+        mock_agent.run = AsyncMock(side_effect=Exception("Test error"))
+
+        entity_function = create_agent_entity(mock_agent)
+
+        mock_context = Mock()
+        mock_context.operation_name = "run"
+        mock_context.get_input.side_effect = Exception("Input error")
+        mock_context.get_state.return_value = None
+
+        # Execute entity function - should not raise
+        entity_function(mock_context)
+
+        # Verify error result was set
+        assert mock_context.set_result.called
+        result_call = mock_context.set_result.call_args[0][0]
+        assert "error" in result_call
+
+
+class TestIncomingRequestParsing:
+    """Tests for parsing run requests with JSON and plain text bodies."""
+
+    def _create_app(self) -> AgentFunctionApp:
+        mock_agent = Mock()
+        mock_agent.name = "ParserAgent"
+        return AgentFunctionApp(agents=[mock_agent], enable_health_check=False)
+
+    def test_parse_plain_text_body(self) -> None:
+        """Test parsing a plain-text request body."""
+        app = self._create_app()
+
+        request = Mock()
+        request.headers = {}
+        request.params = {}
+        request.get_json.side_effect = ValueError("Invalid JSON")
+        request.get_body.return_value = b"Plain text message"
+
+        req_body, message, response_format = app._parse_incoming_request(request)
+
+        assert req_body == {}
+        assert message == "Plain text message"
+
+        assert response_format == "text"
+
+    def test_parse_plain_text_trims_whitespace(self) -> None:
+        """Plain-text parser returns an empty string when the body contains only whitespace."""
+        app = self._create_app()
+
+        request = Mock()
+        request.headers = {}
+        request.params = {}
+        request.get_json.side_effect = ValueError("Invalid JSON")
+        request.get_body.return_value = b"   "
+
+        req_body, message, response_format = app._parse_incoming_request(request)
+
+        assert req_body == {}
+        assert message == ""
+        assert response_format == "text"
+
+    def test_accept_header_prefers_json(self) -> None:
+        """Test that the Accept header can force JSON responses for plain-text bodies."""
+        app = self._create_app()
+
+        request = Mock()
+        request.headers = {"accept": MIMETYPE_APPLICATION_JSON}
+        request.params = {}
+        request.get_json.side_effect = ValueError("Invalid JSON")
+        request.get_body.return_value = b"Plain text message"
+
+        _, message, response_format = app._parse_incoming_request(request)
+
+        assert message == "Plain text message"
+        assert response_format == "json"
+
+    def test_extract_thread_id_from_query_params(self) -> None:
+        """Test thread identifier extraction from query parameters."""
+        app = self._create_app()
+
+        request = Mock()
+        request.params = {"thread_id": "query-thread"}
+        req_body: dict[str, Any] = {}
+
+        thread_id = app._resolve_thread_id(request, req_body)
+
+        assert thread_id == "query-thread"
+
+
+class TestHttpRunRoute:
+    """Tests for the HTTP run route behavior."""
+
+    @staticmethod
+    def _get_run_handler(agent: Mock) -> Callable[[func.HttpRequest, Any], Awaitable[func.HttpResponse]]:
+        captured_handlers: dict[str | None, Callable[..., Awaitable[func.HttpResponse]]] = {}
+
+        def capture_decorator(*args: Any, **kwargs: Any) -> Callable[[FuncT], FuncT]:
+            def decorator(func: FuncT) -> FuncT:
+                return func
+
+            return decorator
+
+        def capture_route(*args: Any, **kwargs: Any) -> Callable[[FuncT], FuncT]:
+            def decorator(func: FuncT) -> FuncT:
+                route_key = kwargs.get("route") if kwargs else None
+                captured_handlers[route_key] = func
+                return func
+
+            return decorator
+
+        with (
+            patch.object(AgentFunctionApp, "function_name", new=capture_decorator),
+            patch.object(AgentFunctionApp, "route", new=capture_route),
+            patch.object(AgentFunctionApp, "durable_client_input", new=capture_decorator),
+            patch.object(AgentFunctionApp, "entity_trigger", new=capture_decorator),
+        ):
+            AgentFunctionApp(agents=[agent], enable_health_check=False)
+
+        run_route = f"agents/{agent.name}/run"
+        return captured_handlers[run_route]
+
+    async def test_http_run_accepts_plain_text(self) -> None:
+        """Test that the HTTP handler accepts plain-text requests."""
+        mock_agent = Mock()
+        mock_agent.name = "HttpAgent"
+
+        handler = self._get_run_handler(mock_agent)
+
+        request = Mock()
+        request.headers = {WAIT_FOR_RESPONSE_HEADER: "false"}
+        request.params = {}
+        request.route_params = {}
+        request.get_json.side_effect = ValueError("Invalid JSON")
+        request.get_body.return_value = b"Plain text via HTTP"
+
+        client = AsyncMock()
+
+        response = await handler(request, client)
+
+        assert response.status_code == 202
+        assert response.mimetype == MIMETYPE_TEXT_PLAIN
+        assert response.headers.get(THREAD_ID_HEADER) is not None
+        assert response.get_body().decode("utf-8") == "Agent request accepted"
+
+        signal_args = client.signal_entity.call_args[0]
+        run_request = signal_args[2]
+
+        assert run_request["message"] == "Plain text via HTTP"
+        assert run_request["role"] == "user"
+        assert "thread_id" not in run_request
+
+    async def test_http_run_accept_header_returns_json(self) -> None:
+        """Test that Accept header requesting JSON results in JSON response."""
+        mock_agent = Mock()
+        mock_agent.name = "HttpAgentJson"
+
+        handler = self._get_run_handler(mock_agent)
+
+        request = Mock()
+        request.headers = {WAIT_FOR_RESPONSE_HEADER: "false", "Accept": MIMETYPE_APPLICATION_JSON}
+        request.params = {}
+        request.route_params = {}
+        request.get_json.side_effect = ValueError("Invalid JSON")
+        request.get_body.return_value = b"Plain text via HTTP"
+
+        client = AsyncMock()
+
+        response = await handler(request, client)
+
+        assert response.status_code == 202
+        assert response.mimetype == MIMETYPE_APPLICATION_JSON
+        assert response.headers.get(THREAD_ID_HEADER) is None
+        body = response.get_body().decode("utf-8")
+        assert '"status": "accepted"' in body
+
+    async def test_http_run_rejects_empty_message(self) -> None:
+        """Test that the HTTP handler rejects empty messages with a 400 response."""
+        mock_agent = Mock()
+        mock_agent.name = "HttpAgentEmpty"
+
+        handler = self._get_run_handler(mock_agent)
+
+        request = Mock()
+        request.headers = {WAIT_FOR_RESPONSE_HEADER: "false"}
+        request.params = {}
+        request.route_params = {}
+        request.get_json.side_effect = ValueError("Invalid JSON")
+        request.get_body.return_value = b"   "
+
+        client = AsyncMock()
+
+        response = await handler(request, client)
+
+        assert response.status_code == 400
+        assert response.mimetype == MIMETYPE_TEXT_PLAIN
+        assert response.headers.get(THREAD_ID_HEADER) is not None
+        assert response.get_body().decode("utf-8") == "Message is required"
+        client.signal_entity.assert_not_called()
+
+
+class TestMCPToolEndpoint:
+    """Test suite for MCP tool endpoint functionality."""
+
+    def test_init_with_mcp_tool_endpoint_enabled(self) -> None:
+        """Test initialization with MCP tool endpoint enabled."""
+        mock_agent = Mock()
+        mock_agent.name = "TestAgent"
+
+        app = AgentFunctionApp(agents=[mock_agent], enable_mcp_tool_trigger=True)
+
+        assert app.enable_mcp_tool_trigger is True
+
+    def test_init_with_mcp_tool_endpoint_disabled(self) -> None:
+        """Test initialization with MCP tool endpoint disabled (default)."""
+        mock_agent = Mock()
+        mock_agent.name = "TestAgent"
+
+        app = AgentFunctionApp(agents=[mock_agent])
+
+        assert app.enable_mcp_tool_trigger is False
+
+    def test_add_agent_with_mcp_tool_trigger_enabled(self) -> None:
+        """Test adding an agent with MCP tool trigger explicitly enabled."""
+        mock_agent = Mock()
+        mock_agent.name = "MCPAgent"
+        mock_agent.description = "Test MCP Agent"
+
+        with patch.object(AgentFunctionApp, "_setup_agent_functions") as setup_mock:
+            app = AgentFunctionApp()
+            app.add_agent(mock_agent, enable_mcp_tool_trigger=True)
+
+        setup_mock.assert_called_once()
+        _, _, _, _, enable_mcp = setup_mock.call_args[0]
+        assert enable_mcp is True
+
+    def test_add_agent_with_mcp_tool_trigger_disabled(self) -> None:
+        """Test adding an agent with MCP tool trigger explicitly disabled."""
+        mock_agent = Mock()
+        mock_agent.name = "NoMCPAgent"
+
+        with patch.object(AgentFunctionApp, "_setup_agent_functions") as setup_mock:
+            app = AgentFunctionApp(enable_mcp_tool_trigger=True)
+            app.add_agent(mock_agent, enable_mcp_tool_trigger=False)
+
+        setup_mock.assert_called_once()
+        _, _, _, _, enable_mcp = setup_mock.call_args[0]
+        assert enable_mcp is False
+
+    def test_agent_override_enables_mcp_when_app_disabled(self) -> None:
+        """Test that per-agent override can enable MCP when app-level is disabled."""
+        mock_agent = Mock()
+        mock_agent.name = "OverrideAgent"
+
+        with patch.object(AgentFunctionApp, "_setup_mcp_tool_trigger") as mcp_setup_mock:
+            app = AgentFunctionApp(enable_mcp_tool_trigger=False)
+            app.add_agent(mock_agent, enable_mcp_tool_trigger=True)
+
+        mcp_setup_mock.assert_called_once()
+
+    def test_agent_override_disables_mcp_when_app_enabled(self) -> None:
+        """Test that per-agent override can disable MCP when app-level is enabled."""
+        mock_agent = Mock()
+        mock_agent.name = "NoOverrideAgent"
+
+        with patch.object(AgentFunctionApp, "_setup_mcp_tool_trigger") as mcp_setup_mock:
+            app = AgentFunctionApp(enable_mcp_tool_trigger=True)
+            app.add_agent(mock_agent, enable_mcp_tool_trigger=False)
+
+        mcp_setup_mock.assert_not_called()
+
+    def test_setup_mcp_tool_trigger_registers_decorators(self) -> None:
+        """Test that _setup_mcp_tool_trigger registers the correct decorators."""
+        mock_agent = Mock()
+        mock_agent.name = "MCPToolAgent"
+        mock_agent.description = "Test MCP Tool"
+
+        app = AgentFunctionApp()
+
+        # Mock the decorators
+        with (
+            patch.object(app, "function_name") as func_name_mock,
+            patch.object(app, "mcp_tool_trigger") as mcp_trigger_mock,
+            patch.object(app, "durable_client_input") as client_mock,
+        ):
+            # Setup mock decorator chain
+            func_name_mock.return_value = _identity_decorator
+            mcp_trigger_mock.return_value = _identity_decorator
+            client_mock.return_value = _identity_decorator
+
+            app._setup_mcp_tool_trigger(mock_agent.name, mock_agent.description)
+
+            # Verify decorators were called with correct parameters
+            func_name_mock.assert_called_once()
+            mcp_trigger_mock.assert_called_once_with(
+                arg_name="context",
+                tool_name=mock_agent.name,
+                description=mock_agent.description,
+                tool_properties=ANY,
+                data_type=func.DataType.UNDEFINED,
+            )
+            client_mock.assert_called_once_with(client_name="client")
+
+    def test_setup_mcp_tool_trigger_uses_default_description(self) -> None:
+        """Test that _setup_mcp_tool_trigger uses default description when none provided."""
+        mock_agent = Mock()
+        mock_agent.name = "NoDescAgent"
+
+        app = AgentFunctionApp()
+
+        with (
+            patch.object(app, "function_name", return_value=_identity_decorator),
+            patch.object(app, "mcp_tool_trigger") as mcp_trigger_mock,
+            patch.object(app, "durable_client_input", return_value=_identity_decorator),
+        ):
+            mcp_trigger_mock.return_value = _identity_decorator
+
+            app._setup_mcp_tool_trigger(mock_agent.name, None)
+
+            # Verify default description was used
+            call_args = mcp_trigger_mock.call_args
+            assert call_args[1]["description"] == f"Interact with {mock_agent.name} agent"
+
+    async def test_handle_mcp_tool_invocation_with_json_string(self) -> None:
+        """Test _handle_mcp_tool_invocation with JSON string context."""
+        mock_agent = Mock()
+        mock_agent.name = "TestAgent"
+
+        app = AgentFunctionApp(agents=[mock_agent])
+        client = AsyncMock()
+
+        # Mock the entity response
+        mock_state = Mock()
+        mock_state.entity_state = {
+            "schemaVersion": "1.0.0",
+            "data": {"conversationHistory": []},
+        }
+        client.read_entity_state.return_value = mock_state
+
+        # Create JSON string context
+        context = '{"arguments": {"query": "test query", "threadId": "test-thread"}}'
+
+        with patch.object(app, "_get_response_from_entity") as get_response_mock:
+            get_response_mock.return_value = {"status": "success", "response": "Test response"}
+
+            result = await app._handle_mcp_tool_invocation("TestAgent", context, client)
+
+            assert result == "Test response"
+            get_response_mock.assert_called_once()
+
+    async def test_handle_mcp_tool_invocation_with_json_context(self) -> None:
+        """Test _handle_mcp_tool_invocation with JSON string context."""
+        mock_agent = Mock()
+        mock_agent.name = "TestAgent"
+
+        app = AgentFunctionApp(agents=[mock_agent])
+        client = AsyncMock()
+
+        # Mock the entity response
+        mock_state = Mock()
+        mock_state.entity_state = {
+            "schemaVersion": "1.0.0",
+            "data": {"conversationHistory": []},
+        }
+        client.read_entity_state.return_value = mock_state
+
+        # Create JSON string context
+        context = json.dumps({"arguments": {"query": "test query", "threadId": "test-thread"}})
+
+        with patch.object(app, "_get_response_from_entity") as get_response_mock:
+            get_response_mock.return_value = {"status": "success", "response": "Test response"}
+
+            result = await app._handle_mcp_tool_invocation("TestAgent", context, client)
+
+            assert result == "Test response"
+            get_response_mock.assert_called_once()
+
+    async def test_handle_mcp_tool_invocation_missing_query(self) -> None:
+        """Test _handle_mcp_tool_invocation raises ValueError when query is missing."""
+        mock_agent = Mock()
+        mock_agent.name = "TestAgent"
+
+        app = AgentFunctionApp(agents=[mock_agent])
+        client = AsyncMock()
+
+        # Context missing query (as JSON string)
+        context = json.dumps({"arguments": {}})
+
+        with pytest.raises(ValueError, match="missing required 'query' argument"):
+            await app._handle_mcp_tool_invocation("TestAgent", context, client)
+
+    async def test_handle_mcp_tool_invocation_invalid_json(self) -> None:
+        """Test _handle_mcp_tool_invocation raises ValueError for invalid JSON."""
+        mock_agent = Mock()
+        mock_agent.name = "TestAgent"
+
+        app = AgentFunctionApp(agents=[mock_agent])
+        client = AsyncMock()
+
+        # Invalid JSON string
+        context = "not valid json"
+
+        with pytest.raises(ValueError, match="Invalid MCP context format"):
+            await app._handle_mcp_tool_invocation("TestAgent", context, client)
+
+    async def test_handle_mcp_tool_invocation_runtime_error(self) -> None:
+        """Test _handle_mcp_tool_invocation raises RuntimeError when agent fails."""
+        mock_agent = Mock()
+        mock_agent.name = "TestAgent"
+
+        app = AgentFunctionApp(agents=[mock_agent])
+        client = AsyncMock()
+
+        # Mock the entity response
+        mock_state = Mock()
+        mock_state.entity_state = {
+            "schemaVersion": "1.0.0",
+            "data": {"conversationHistory": []},
+        }
+        client.read_entity_state.return_value = mock_state
+
+        context = '{"arguments": {"query": "test query"}}'
+
+        with patch.object(app, "_get_response_from_entity") as get_response_mock:
+            get_response_mock.return_value = {"status": "failed", "error": "Agent error"}
+
+            with pytest.raises(RuntimeError, match="Agent execution failed"):
+                await app._handle_mcp_tool_invocation("TestAgent", context, client)
+
+    async def test_handle_mcp_tool_invocation_ignores_agent_name_in_thread_id(self) -> None:
+        """Test that MCP tool invocation uses the agent_name parameter, not the name from thread_id."""
+        mock_agent = Mock()
+        mock_agent.name = "PlantAdvisor"
+
+        app = AgentFunctionApp(agents=[mock_agent])
+        client = AsyncMock()
+
+        # Mock the entity response
+        mock_state = Mock()
+        mock_state.entity_state = {
+            "schemaVersion": "1.0.0",
+            "data": {"conversationHistory": []},
+        }
+        client.read_entity_state.return_value = mock_state
+
+        # Thread ID contains a different agent name (@StockAdvisor@poc123)
+        # but we're invoking PlantAdvisor - it should use PlantAdvisor's entity
+        context = json.dumps({"arguments": {"query": "test query", "threadId": "@StockAdvisor@test123"}})
+
+        with patch.object(app, "_get_response_from_entity") as get_response_mock:
+            get_response_mock.return_value = {"status": "success", "response": "Test response"}
+
+            await app._handle_mcp_tool_invocation("PlantAdvisor", context, client)
+
+            # Verify signal_entity was called with PlantAdvisor's entity, not StockAdvisor's
+            client.signal_entity.assert_called_once()
+            call_args = client.signal_entity.call_args
+            entity_id = call_args[0][0]
+
+            # Entity name should be dafx-PlantAdvisor, not dafx-StockAdvisor
+            assert entity_id.name == "dafx-PlantAdvisor"
+            assert entity_id.key == "test123"
+
+    async def test_handle_mcp_tool_invocation_uses_plain_thread_id_as_key(self) -> None:
+        """Test that a plain thread_id (not in @name@key format) is used as-is for the key."""
+        mock_agent = Mock()
+        mock_agent.name = "TestAgent"
+
+        app = AgentFunctionApp(agents=[mock_agent])
+        client = AsyncMock()
+
+        mock_state = Mock()
+        mock_state.entity_state = {
+            "schemaVersion": "1.0.0",
+            "data": {"conversationHistory": []},
+        }
+        client.read_entity_state.return_value = mock_state
+
+        # Plain thread_id without @name@key format
+        context = json.dumps({"arguments": {"query": "test query", "threadId": "simple-thread-123"}})
+
+        with patch.object(app, "_get_response_from_entity") as get_response_mock:
+            get_response_mock.return_value = {"status": "success", "response": "Test response"}
+
+            await app._handle_mcp_tool_invocation("TestAgent", context, client)
+
+            client.signal_entity.assert_called_once()
+            call_args = client.signal_entity.call_args
+            entity_id = call_args[0][0]
+
+            assert entity_id.name == "dafx-TestAgent"
+            assert entity_id.key == "simple-thread-123"
+
+    def test_health_check_includes_mcp_tool_enabled(self) -> None:
+        """Test that health check endpoint includes mcp_tool_enabled field."""
+        mock_agent = Mock()
+        mock_agent.name = "HealthAgent"
+
+        app = AgentFunctionApp(agents=[mock_agent], enable_mcp_tool_trigger=True)
+
+        # Capture the health check handler function
+        captured_handler: Callable[[func.HttpRequest], func.HttpResponse] | None = None
+
+        def capture_decorator(*args: Any, **kwargs: Any) -> Callable[[FuncT], FuncT]:
+            def decorator(func: FuncT) -> FuncT:
+                nonlocal captured_handler
+                captured_handler = func
+                return func
+
+            return decorator
+
+        with patch.object(app, "route", side_effect=capture_decorator):
+            app._setup_health_route()
+
+        # Verify we captured the handler
+        assert captured_handler is not None
+
+        # Call the health handler
+        request = Mock()
+        response = captured_handler(request)
+
+        # Verify response includes mcp_tool_enabled
+        import json
+
+        body = json.loads(response.get_body().decode("utf-8"))
+        assert "agents" in body
+        assert len(body["agents"]) == 1
+        assert "mcp_tool_enabled" in body["agents"][0]
+        assert body["agents"][0]["mcp_tool_enabled"] is True
+
+
+class TestAgentFunctionAppErrorPaths:
+    """Test suite for error handling paths."""
+
+    def test_init_with_invalid_max_poll_retries(self) -> None:
+        """Test initialization handles invalid max_poll_retries by falling back to default."""
+        mock_agent = Mock()
+        mock_agent.name = "TestAgent"
+
+        # Test with invalid type
+        app = AgentFunctionApp(agents=[mock_agent], max_poll_retries="invalid")  # type: ignore[arg-type] # pyrefly: ignore[bad-argument-type] # ty: ignore[invalid-argument-type]
+        assert app.max_poll_retries >= 1  # Should use default
+
+        # Test with None
+        app2 = AgentFunctionApp(agents=[mock_agent], max_poll_retries=None)  # type: ignore[arg-type] # pyrefly: ignore[bad-argument-type] # ty: ignore[invalid-argument-type]
+        assert app2.max_poll_retries >= 1  # Should use default
+
+    def test_init_with_invalid_poll_interval_seconds(self) -> None:
+        """Test initialization handles invalid poll_interval_seconds by falling back to default."""
+        mock_agent = Mock()
+        mock_agent.name = "TestAgent"
+
+        # Test with invalid type
+        app = AgentFunctionApp(agents=[mock_agent], poll_interval_seconds="invalid")  # type: ignore[arg-type] # pyrefly: ignore[bad-argument-type] # ty: ignore[invalid-argument-type]
+        assert app.poll_interval_seconds > 0  # Should use default
+
+        # Test with None
+        app2 = AgentFunctionApp(agents=[mock_agent], poll_interval_seconds=None)  # type: ignore[arg-type] # pyrefly: ignore[bad-argument-type] # ty: ignore[invalid-argument-type]
+        assert app2.poll_interval_seconds > 0  # Should use default
+
+    def test_get_agent_raises_for_unregistered_agent(self) -> None:
+        """Test get_agent raises ValueError for unregistered agent."""
+        mock_agent = Mock()
+        mock_agent.name = "RegisteredAgent"
+
+        app = AgentFunctionApp(agents=[mock_agent], enable_http_endpoints=False)
+
+        # Create mock orchestration context
+        mock_context = Mock()
+
+        # Should raise ValueError for unregistered agent
+        with pytest.raises(ValueError, match="Agent 'UnknownAgent' is not registered"):
+            app.get_agent(mock_context, "UnknownAgent")
+
+    def test_convert_payload_to_text_with_response_key(self) -> None:
+        """Test _convert_payload_to_text returns response key value."""
+        app = AgentFunctionApp(enable_http_endpoints=False, enable_health_check=False)
+
+        # Test with response key
+        payload = {"response": "Test response"}
+        result = app._convert_payload_to_text(payload)
+        assert result == "Test response"
+
+        # Test with error key
+        payload = {"error": "Error message"}
+        result = app._convert_payload_to_text(payload)
+        assert result == "Error message"
+
+        # Test with message key
+        payload = {"message": "Message text"}
+        result = app._convert_payload_to_text(payload)
+        assert result == "Message text"
+
+        # Test with no matching keys - should return JSON string
+        payload = {"other": "value"}
+        result = app._convert_payload_to_text(payload)
+        assert "other" in result
+        assert "value" in result
+
+    def test_create_session_id_with_thread_id(self) -> None:
+        """Test _create_session_id with provided thread_id."""
+        app = AgentFunctionApp(enable_http_endpoints=False, enable_health_check=False)
+
+        # With thread_id provided
+        session_id = app._create_session_id("TestAgent", "my-thread-123")
+        assert session_id.key == "my-thread-123"
+
+        # Without thread_id (None) - should generate random
+        session_id = app._create_session_id("TestAgent", None)
+        assert session_id.key is not None
+        assert len(session_id.key) > 0
+
+    def test_resolve_thread_id_from_body(self) -> None:
+        """Test _resolve_thread_id extracts from body."""
+        app = AgentFunctionApp(enable_http_endpoints=False, enable_health_check=False)
+
+        mock_req = Mock()
+        mock_req.params = {}
+
+        # Thread ID in body - field name is "thread_id"
+        req_body = {"thread_id": "body-thread-123"}
+        result = app._resolve_thread_id(mock_req, req_body)
+        assert result == "body-thread-123"
+
+    def test_select_body_parser_json_content_type(self) -> None:
+        """Test _select_body_parser for JSON content type."""
+        app = AgentFunctionApp(enable_http_endpoints=False, enable_health_check=False)
+
+        # Test with application/json
+        parser, format_str = app._select_body_parser("application/json")
+        assert parser == app._parse_json_body
+        assert format_str == "json"
+
+        # Test with +json suffix
+        parser, format_str = app._select_body_parser("application/vnd.api+json")
+        assert parser == app._parse_json_body
+        assert format_str == "json"
+
+    def test_accepts_json_response_with_accept_header(self) -> None:
+        """Test _accepts_json_response checks accept header."""
+        app = AgentFunctionApp(enable_http_endpoints=False, enable_health_check=False)
+
+        # With application/json in accept header
+        headers = {"accept": "application/json"}
+        result = app._accepts_json_response(headers)
+        assert result is True
+
+        # Without accept header
+        headers = {}
+        result = app._accepts_json_response(headers)
+        assert result is False
+
+    def test_parse_json_body_invalid_type(self) -> None:
+        """Test _parse_json_body raises error for invalid JSON."""
+        from agent_framework_azurefunctions._errors import IncomingRequestError
+
+        app = AgentFunctionApp(enable_http_endpoints=False, enable_health_check=False)
+
+        # Mock request with non-dict JSON
+        mock_req = Mock()
+        mock_req.get_json.return_value = ["not", "a", "dict"]
+
+        with pytest.raises(IncomingRequestError, match="Invalid JSON payload"):
+            app._parse_json_body(mock_req)
+
+    def test_coerce_to_bool_with_none(self) -> None:
+        """Test _coerce_to_bool handles None and various value types."""
+        app = AgentFunctionApp(enable_http_endpoints=False, enable_health_check=False)
+
+        # None returns False
+        assert app._coerce_to_bool(None) is False
+
+        # Integer
+        assert app._coerce_to_bool(1) is True
+        assert app._coerce_to_bool(0) is False
+
+        # String
+        assert app._coerce_to_bool("true") is True
+        assert app._coerce_to_bool("false") is False
+
+        # Other type returns False
+        assert app._coerce_to_bool([]) is False
+
+
+class TestAgentFunctionAppWorkflow:
+    """Test suite for AgentFunctionApp workflow support."""
+
+    def test_init_with_workflow_stores_workflow(self) -> None:
+        """Test that workflow is stored when provided."""
+        mock_workflow = Mock()
+        mock_workflow.name = "test_workflow"
+        mock_workflow.executors = {}
+
+        with (
+            patch.object(AgentFunctionApp, "_setup_executor_activity"),
+            patch.object(AgentFunctionApp, "_setup_workflow_orchestration"),
+        ):
+            app = AgentFunctionApp(workflow=mock_workflow)
+
+        assert app.workflow is mock_workflow
+
+    def test_init_with_workflow_registers_agent_entity_by_executor_id(self) -> None:
+        """Workflow agent executors are registered as entities keyed by executor id."""
+        from agent_framework import AgentExecutor
+
+        mock_agent = Mock()
+        mock_agent.name = "WorkflowAgent"
+
+        mock_executor = Mock(spec=AgentExecutor)
+        mock_executor.agent = mock_agent
+        # Executor id intentionally differs from the agent name to exercise the
+        # identity fix: dispatch uses the executor id, so registration must too.
+        mock_executor.id = "custom-executor-id"
+
+        mock_workflow = Mock()
+        mock_workflow.name = "orders"
+        mock_workflow.executors = {"custom-executor-id": mock_executor}
+
+        with (
+            patch.object(AgentFunctionApp, "_setup_executor_activity"),
+            patch.object(AgentFunctionApp, "_setup_workflow_orchestration"),
+            patch.object(AgentFunctionApp, "_setup_agent_entity") as setup_entity,
+        ):
+            app = AgentFunctionApp(workflow=mock_workflow)
+
+        # The entity is registered under the workflow-scoped dispatch identity.
+        setup_entity.assert_called_once()
+        call_args = setup_entity.call_args.args
+        assert call_args[0] is mock_agent
+        assert call_args[1] == "orders-custom-executor-id"
+
+        # Regression guard: the workflow agent must also be tracked on the app's
+        # normal registration surface, keyed by the scoped id, so it appears in
+        # ``agents`` and is retrievable via ``get_agent``.
+        assert "orders-custom-executor-id" in app.agents
+        assert app.agents["orders-custom-executor-id"] is mock_agent
+
+    def test_init_with_workflow_calls_setup_methods(self) -> None:
+        """Test that workflow setup methods are called."""
+        mock_executor = Mock()
+        mock_executor.id = "TestExecutor"
+
+        mock_workflow = Mock()
+        mock_workflow.name = "test_workflow"
+        # Include a non-AgentExecutor so _setup_executor_activity is called
+        mock_workflow.executors = {"TestExecutor": mock_executor}
+
+        with (
+            patch.object(AgentFunctionApp, "_setup_executor_activity") as setup_exec,
+            patch.object(AgentFunctionApp, "_setup_workflow_orchestration") as setup_orch,
+        ):
+            AgentFunctionApp(workflow=mock_workflow)
+
+        setup_exec.assert_called_once()
+        setup_orch.assert_called_once()
+
+    def test_init_without_workflow_does_not_call_workflow_setup(self) -> None:
+        """Test that workflow setup is not called when no workflow provided."""
+        mock_agent = Mock()
+        mock_agent.name = "TestAgent"
+
+        with (
+            patch.object(AgentFunctionApp, "_setup_executor_activity") as setup_exec,
+            patch.object(AgentFunctionApp, "_setup_workflow_orchestration") as setup_orch,
+        ):
+            AgentFunctionApp(agents=[mock_agent])
+
+        setup_exec.assert_not_called()
+        setup_orch.assert_not_called()
+
+    def test_init_with_workflow_and_explicit_agent_does_not_raise(self) -> None:
+        """An agent passed explicitly and present in the workflow registers without error."""
+        from agent_framework import AgentExecutor
+
+        mock_agent = Mock()
+        mock_agent.name = "SharedAgent"
+
+        mock_executor = Mock(spec=AgentExecutor)
+        mock_executor.agent = mock_agent
+        mock_executor.id = "SharedAgent"
+
+        mock_workflow = Mock()
+        mock_workflow.name = "shared_flow"
+        mock_workflow.executors = {"SharedAgent": mock_executor}
+
+        with (
+            patch.object(AgentFunctionApp, "_setup_executor_activity"),
+            patch.object(AgentFunctionApp, "_setup_workflow_orchestration"),
+            patch.object(AgentFunctionApp, "_setup_agent_functions"),
+            patch.object(AgentFunctionApp, "_setup_agent_entity"),
+        ):
+            # Same agent passed explicitly AND present in workflow — should not raise
+            app = AgentFunctionApp(agents=[mock_agent], workflow=mock_workflow)
+
+        assert "SharedAgent" in app.agents
+
+    def test_init_with_multiple_workflows_registers_each(self) -> None:
+        """The workflows= list registers each workflow keyed by name."""
+        from agent_framework import Executor
+
+        def _wf(name: str, executor_id: str) -> Mock:
+            ex = Mock(spec=Executor)
+            ex.id = executor_id
+            wf = Mock()
+            wf.name = name
+            wf.executors = {executor_id: ex}
+            return wf
+
+        with (
+            patch.object(AgentFunctionApp, "_setup_executor_activity") as setup_exec,
+            patch.object(AgentFunctionApp, "_setup_workflow_orchestration") as setup_orch,
+        ):
+            app = AgentFunctionApp(workflows=[_wf("orders", "router"), _wf("billing", "router")])
+
+        assert set(app.workflows) == {"orders", "billing"}
+        assert app.workflow is None  # ambiguous with >1 workflow
+        assert setup_exec.call_count == 2
+        assert setup_orch.call_count == 2
+
+    def test_init_rejects_duplicate_workflow_name(self) -> None:
+        """Two workflows with the same name are rejected."""
+        from agent_framework import Executor
+
+        def _wf(executor_id: str) -> Mock:
+            ex = Mock(spec=Executor)
+            ex.id = executor_id
+            wf = Mock()
+            wf.name = "orders"
+            wf.executors = {executor_id: ex}
+            return wf
+
+        with (
+            patch.object(AgentFunctionApp, "_setup_executor_activity"),
+            patch.object(AgentFunctionApp, "_setup_workflow_orchestration"),
+            pytest.raises(ValueError, match="already registered"),
+        ):
+            AgentFunctionApp(workflows=[_wf("a"), _wf("b")])
+
+    def test_init_rejects_case_insensitive_duplicate_workflow_name(self) -> None:
+        """Workflow names that differ only by case collide and are rejected.
+
+        The route ownership guard folds case, so hosting both ``orders`` and
+        ``Orders`` would let one workflow's routes reach the other's instances.
+        """
+        from agent_framework import Executor
+
+        def _wf(name: str, executor_id: str) -> Mock:
+            ex = Mock(spec=Executor)
+            ex.id = executor_id
+            wf = Mock()
+            wf.name = name
+            wf.executors = {executor_id: ex}
+            return wf
+
+        with (
+            patch.object(AgentFunctionApp, "_setup_executor_activity"),
+            patch.object(AgentFunctionApp, "_setup_workflow_orchestration"),
+            pytest.raises(ValueError, match="case-insensitively"),
+        ):
+            AgentFunctionApp(workflows=[_wf("orders", "a"), _wf("Orders", "b")])
+
+    def test_init_rejects_mapping_key_mismatch(self) -> None:
+        """A workflows mapping whose key disagrees with Workflow.name is rejected."""
+        mock_workflow = Mock()
+        mock_workflow.name = "orders"
+        mock_workflow.executors = {}
+
+        with (
+            patch.object(AgentFunctionApp, "_setup_executor_activity"),
+            patch.object(AgentFunctionApp, "_setup_workflow_orchestration"),
+            pytest.raises(ValueError, match="does not match"),
+        ):
+            AgentFunctionApp(workflows={"wrong_key": mock_workflow})
+
+    def test_init_rejects_auto_generated_workflow_name(self) -> None:
+        """An auto-generated WorkflowBuilder name is rejected."""
+        import uuid
+
+        mock_workflow = Mock()
+        mock_workflow.name = f"WorkflowBuilder-{uuid.uuid4()}"
+        mock_workflow.executors = {}
+
+        with (
+            patch.object(AgentFunctionApp, "_setup_executor_activity"),
+            patch.object(AgentFunctionApp, "_setup_workflow_orchestration"),
+            pytest.raises(ValueError, match="auto-generated"),
+        ):
+            AgentFunctionApp(workflow=mock_workflow)
+
+
+class TestAgentFunctionAppSubworkflow:
+    """Test recursive registration of nested sub-workflows on the Functions app."""
+
+    @staticmethod
+    def _inner_agent_wf(name: str, executor_id: str) -> tuple[Mock, Mock]:
+        from agent_framework import AgentExecutor
+
+        agent = Mock()
+        agent.name = "InnerAssistant"
+        ex = Mock(spec=AgentExecutor)
+        ex.agent = agent
+        ex.id = executor_id
+        wf = Mock()
+        wf.name = name
+        wf.executors = {executor_id: ex}
+        return wf, agent
+
+    @staticmethod
+    def _outer_wf(name: str, inner: Mock, *, sub_ids: tuple[str, ...] = ("sub",)) -> Mock:
+        from agent_framework import Executor, WorkflowExecutor
+
+        executors: dict[str, Mock] = {}
+        for sid in sub_ids:
+            sub = Mock(spec=WorkflowExecutor)
+            sub.id = sid
+            sub.workflow = inner
+            sub.allow_direct_output = False
+            executors[sid] = sub
+        router = Mock(spec=Executor)
+        router.id = "router"
+        executors["router"] = router
+        wf = Mock()
+        wf.name = name
+        wf.executors = executors
+        return wf
+
+    def test_nested_workflow_registers_both_orchestrations(self) -> None:
+        """An outer workflow registers an orchestration for itself and the inner workflow."""
+        inner, _ = self._inner_agent_wf("inner", "agent_node")
+        outer = self._outer_wf("outer", inner)
+
+        with (
+            patch.object(AgentFunctionApp, "_setup_executor_activity"),
+            patch.object(AgentFunctionApp, "_setup_workflow_orchestration") as setup_orch,
+        ):
+            app = AgentFunctionApp(workflow=outer)
+
+        assert setup_orch.call_count == 2
+        registered = {call.args[0].name for call in setup_orch.call_args_list}
+        assert registered == {"outer", "inner"}
+        # Only the top-level workflow is tracked as an addressable workflow.
+        assert set(app.workflows) == {"outer"}
+
+    def test_nested_workflow_registers_inner_agent_scoped(self) -> None:
+        """The inner workflow's agent entity is registered under the inner-scoped id."""
+        inner, inner_agent = self._inner_agent_wf("inner", "agent_node")
+        outer = self._outer_wf("outer", inner)
+
+        with (
+            patch.object(AgentFunctionApp, "_setup_executor_activity"),
+            patch.object(AgentFunctionApp, "_setup_workflow_orchestration"),
+            patch.object(AgentFunctionApp, "_setup_agent_entity") as setup_entity,
+        ):
+            app = AgentFunctionApp(workflow=outer)
+
+        setup_entity.assert_called_once()
+        call_args = setup_entity.call_args.args
+        assert call_args[0] is inner_agent
+        assert call_args[1] == "inner-agent_node"
+        assert "inner-agent_node" in app.agents
+
+    def test_nested_workflow_routes_only_top_level(self) -> None:
+        """HTTP routes are registered only for the top-level workflow."""
+        inner, _ = self._inner_agent_wf("inner", "agent_node")
+        outer = self._outer_wf("outer", inner)
+
+        with (
+            patch.object(AgentFunctionApp, "_setup_executor_activity"),
+            patch.object(AgentFunctionApp, "_setup_workflow_orchestration"),
+            patch.object(AgentFunctionApp, "_register_workflow_routes") as routes,
+        ):
+            AgentFunctionApp(workflow=outer)
+
+        routes.assert_called_once()
+        assert routes.call_args.args[0] is outer
+
+    def test_shared_subworkflow_registered_once(self) -> None:
+        """A sub-workflow reused by two nodes registers its orchestration only once."""
+        inner, _ = self._inner_agent_wf("inner", "agent_node")
+        outer = self._outer_wf("outer", inner, sub_ids=("sub_a", "sub_b"))
+
+        with (
+            patch.object(AgentFunctionApp, "_setup_executor_activity"),
+            patch.object(AgentFunctionApp, "_setup_workflow_orchestration") as setup_orch,
+        ):
+            AgentFunctionApp(workflow=outer)
+
+        registered = sorted(call.args[0].name for call in setup_orch.call_args_list)
+        assert registered == ["inner", "outer"]
+
+    def test_nested_workflow_with_invalid_name_is_rejected(self) -> None:
+        """A nested sub-workflow must also have a valid, stable name."""
+        inner, _ = self._inner_agent_wf("has space", "agent_node")
+        outer = self._outer_wf("outer", inner)
+
+        with (
+            patch.object(AgentFunctionApp, "_setup_executor_activity"),
+            patch.object(AgentFunctionApp, "_setup_workflow_orchestration"),
+            pytest.raises(ValueError, match="invalid"),
+        ):
+            AgentFunctionApp(workflow=outer)
+
+    def test_different_subworkflow_sharing_a_name_is_rejected(self) -> None:
+        """Two different sub-workflow instances that share a name collide and are rejected."""
+        inner_a, _ = self._inner_agent_wf("shared", "agent_node")
+        inner_b, _ = self._inner_agent_wf("shared", "other_node")  # different instance, same name
+        from agent_framework import WorkflowExecutor
+
+        sub_a = Mock(spec=WorkflowExecutor)
+        sub_a.id = "a"
+        sub_a.workflow = inner_a
+        sub_b = Mock(spec=WorkflowExecutor)
+        sub_b.id = "b"
+        sub_b.workflow = inner_b
+        outer = Mock()
+        outer.name = "outer"
+        outer.executors = {"a": sub_a, "b": sub_b}
+
+        with (
+            patch.object(AgentFunctionApp, "_setup_executor_activity"),
+            patch.object(AgentFunctionApp, "_setup_workflow_orchestration"),
+            pytest.raises(ValueError, match="different workflow"),
+        ):
+            AgentFunctionApp(workflow=outer)
+
+    def test_cross_registration_nested_collision_is_atomic(self) -> None:
+        """A later top-level workflow whose nested child collides aborts before committing it.
+
+        Hosting ``[first, second]`` where ``second``'s nested sub-workflow reuses
+        ``first``'s child name must raise *before* ``second`` registers any primitives,
+        so the app is never left with ``second`` half-configured.
+        """
+        shared_a, _ = self._inner_agent_wf("shared", "agent_node")
+        shared_b, _ = self._inner_agent_wf("shared", "other_node")  # different instance, same name
+        first = self._outer_wf("first", shared_a)
+        second = self._outer_wf("second", shared_b)
+
+        with (
+            patch.object(AgentFunctionApp, "_setup_executor_activity"),
+            patch.object(AgentFunctionApp, "_setup_workflow_orchestration") as setup_orch,
+            pytest.raises(ValueError, match="collides"),
+        ):
+            AgentFunctionApp(workflows=[first, second])
+
+        # Only 'first' and its child 'shared' committed primitives; the collision aborted
+        # before 'second' (or its colliding child) registered anything.
+        registered = {call.args[0].name for call in setup_orch.call_args_list}
+        assert registered == {"first", "shared"}
+        assert "second" not in registered
+
+    def test_executor_id_with_reserved_separator_is_rejected(self) -> None:
+        """An executor id containing the nested-HITL separator is rejected at registration."""
+        from agent_framework import Executor
+
+        ex = Mock(spec=Executor)
+        ex.id = "bad~id"
+        wf = Mock()
+        wf.name = "orders"
+        wf.executors = {"bad~id": ex}
+
+        with (
+            patch.object(AgentFunctionApp, "_setup_executor_activity"),
+            patch.object(AgentFunctionApp, "_setup_workflow_orchestration"),
+            pytest.raises(ValueError, match="reserved sub-workflow request separator"),
+        ):
+            AgentFunctionApp(workflow=wf)
+
+
+# NOTE: State snapshot/diff tests were moved to durabletask once the activity
+# execution body was extracted into the host-agnostic execute_workflow_activity.
+# See packages/durabletask/tests/test_workflow_activity.py.
+
+
+class TestWorkflowStatusOutputEncoding:
+    """The workflow status endpoint emits clean domain JSON for reconstructed outputs.
+
+    Reconstructed outputs (see ``deserialize_workflow_output``) may be framework
+    models or dataclasses; ``_json_default`` converts them via their own
+    serialization so the HTTP body is clean domain JSON rather than opaque
+    checkpoint-marker dicts or repr strings.
+    """
+
+    def test_encodes_framework_model_via_to_dict(self) -> None:
+        from agent_framework_azurefunctions._app import _json_default
+
+        response = AgentResponse(messages=[Message(role="assistant", contents=["hello"])])
+
+        encoded = _json_default(response)
+
+        assert encoded == response.to_dict()
+        # The result must be JSON-serializable (no marker dicts, no objects).
+        assert "hello" in json.dumps(encoded)
+
+    def test_encodes_dataclass_via_asdict(self) -> None:
+        from dataclasses import dataclass
+
+        from agent_framework_azurefunctions._app import _json_default
+
+        @dataclass
+        class Decision:
+            approved: bool
+            note: str
+
+        encoded = _json_default(Decision(approved=True, note="ok"))
+
+        assert encoded == {"approved": True, "note": "ok"}
+
+    def test_falls_back_to_str_for_plain_objects(self) -> None:
+        from agent_framework_azurefunctions._app import _json_default
+
+        class Opaque:
+            def __str__(self) -> str:
+                return "opaque-value"
+
+        assert _json_default(Opaque()) == "opaque-value"
+
+
+class TestWorkflowOrchestrationScoping:
+    """Scoping of the workflow status/respond endpoints to the workflow orchestrator.
+
+    Both endpoints address durable instances by ID only, but the durable client resolves
+    IDs across every orchestration in the task hub (agent entities, user-registered
+    orchestrations, other apps on the same hub). ``_is_owned_orchestration`` gates the
+    endpoints so a leaked instance ID for a different orchestration is treated as
+    "not found" instead of leaking its status/HITL details or accepting injected events.
+    """
+
+    def _app_for(self, workflow_name: str) -> AgentFunctionApp:
+        mock_workflow = Mock()
+        mock_workflow.name = workflow_name
+        mock_workflow.executors = {}
+        with (
+            patch.object(AgentFunctionApp, "_setup_executor_activity"),
+            patch.object(AgentFunctionApp, "_setup_workflow_orchestration"),
+        ):
+            return AgentFunctionApp(workflow=mock_workflow)
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            workflow_orchestrator_name("orders"),  # exact dafx-orders
+            workflow_orchestrator_name("orders").upper(),  # case-insensitive: must match
+            "DAFX-orders",  # mixed case prefix
+        ],
+    )
+    def test_accepts_matching_workflow_orchestration(self, name: str) -> None:
+        app = self._app_for("orders")
+        status = Mock()
+        status.name = name
+        assert app._is_owned_orchestration(status, "orders") is True
+
+    def test_rejects_none_status(self) -> None:
+        # client.get_status returns None when no instance resolves for the ID.
+        app = self._app_for("orders")
+        assert app._is_owned_orchestration(None, "orders") is False
+
+    def test_rejects_status_without_name(self) -> None:
+        app = self._app_for("orders")
+        status = Mock()
+        status.name = None
+        assert app._is_owned_orchestration(status, "orders") is False
+
+    @pytest.mark.parametrize(
+        "other_name",
+        [
+            "SomeUserOrchestration",
+            "dafx-WeatherAgent",  # an agent entity, not this workflow's orchestration
+            "dafx-billing",  # a *different* workflow's orchestration
+            "workflow_orchestrator",  # the deprecated fixed name
+        ],
+    )
+    def test_rejects_other_orchestration_name(self, other_name: str) -> None:
+        app = self._app_for("orders")
+        status = Mock()
+        status.name = other_name
+        assert app._is_owned_orchestration(status, "orders") is False
+
+
+class TestAgentFunctionAppSubworkflowHitl:
+    """Sub-workflow HITL plumbing: gather nested pending requests and route responses.
+
+    These exercise the host-side helpers the ``workflow/{name}/status`` and
+    ``.../respond`` routes use to support nested sub-workflows behind a single
+    top-level addressing surface (B2 qualified request ids).
+    """
+
+    @staticmethod
+    def _app() -> AgentFunctionApp:
+        mock_workflow = Mock()
+        mock_workflow.name = "orders"
+        mock_workflow.executors = {}
+        with (
+            patch.object(AgentFunctionApp, "_setup_executor_activity"),
+            patch.object(AgentFunctionApp, "_setup_workflow_orchestration"),
+        ):
+            return AgentFunctionApp(workflow=mock_workflow)
+
+    @staticmethod
+    def _client(by_instance: dict[str, dict | None]) -> AsyncMock:
+        """An AsyncMock durable client whose get_status returns a per-instance custom status."""
+
+        async def _get_status(instance_id: str) -> Mock | None:
+            if instance_id not in by_instance:
+                return None
+            status = Mock()
+            status.custom_status = by_instance[instance_id]
+            return status
+
+        client = AsyncMock()
+        client.get_status.side_effect = _get_status
+        return client
+
+    async def test_gather_returns_top_level_requests_unqualified(self) -> None:
+        app = self._app()
+        client = self._client({})
+        custom_status = {"pending_requests": {"top-1": {"source_executor_id": "outer"}}}
+
+        gathered = await app._gather_pending_hitl_requests(client, custom_status)
+
+        assert gathered == [("top-1", {"source_executor_id": "outer"})]
+
+    async def test_gather_qualifies_nested_requests(self) -> None:
+        app = self._app()
+        client = self._client({"child-1": {"pending_requests": {"inner-1": {"source_executor_id": "inner"}}}})
+        parent_status = {
+            "pending_requests": {"top-1": {"source_executor_id": "outer"}},
+            "subworkflows": {"sub": ["child-1"]},
+        }
+
+        gathered = await app._gather_pending_hitl_requests(client, parent_status)
+
+        ids = {qid for qid, _ in gathered}
+        assert ids == {"top-1", "sub~0~inner-1"}
+
+    async def test_gather_accumulates_deep_path(self) -> None:
+        app = self._app()
+        client = self._client({
+            "child-1": {"subworkflows": {"leaf": ["child-2"]}},
+            "child-2": {"pending_requests": {"deep": {"source_executor_id": "leaf_node"}}},
+        })
+        parent_status = {"subworkflows": {"mid": ["child-1"]}}
+
+        gathered = await app._gather_pending_hitl_requests(client, parent_status)
+
+        assert [qid for qid, _ in gathered] == ["mid~0~leaf~0~deep"]
+
+    async def test_resolve_unqualified_targets_same_instance(self) -> None:
+        app = self._app()
+        client = self._client({})
+
+        resolved = await app._resolve_hitl_target(client, "parent", "req-1")
+
+        assert resolved == ("parent", "req-1")
+
+    async def test_resolve_qualified_targets_child_instance(self) -> None:
+        app = self._app()
+        client = self._client({"parent": {"subworkflows": {"sub": ["child-1"]}}})
+
+        resolved = await app._resolve_hitl_target(client, "parent", "sub~0~req-9")
+
+        assert resolved == ("child-1", "req-9")
+
+    async def test_resolve_deeply_qualified_targets_leaf(self) -> None:
+        app = self._app()
+        client = self._client({
+            "parent": {"subworkflows": {"mid": ["child-1"]}},
+            "child-1": {"subworkflows": {"leaf": ["child-2"]}},
+        })
+
+        resolved = await app._resolve_hitl_target(client, "parent", "mid~0~leaf~0~deep")
+
+        assert resolved == ("child-2", "deep")
+
+    async def test_resolve_unknown_subworkflow_returns_none(self) -> None:
+        app = self._app()
+        client = self._client({"parent": {"state": "running"}})  # no subworkflows map
+
+        resolved = await app._resolve_hitl_target(client, "parent", "sub~0~req-9")
+
+        assert resolved is None
+
+    async def test_multiple_children_of_one_executor_stay_addressable(self) -> None:
+        app = self._app()
+        client = self._client({
+            "parent": {"subworkflows": {"sub": ["child-1", "child-2"]}},
+            "child-1": {"pending_requests": {"r1": {"source_executor_id": "a"}}},
+            "child-2": {"pending_requests": {"r2": {"source_executor_id": "b"}}},
+        })
+        parent_status = {"subworkflows": {"sub": ["child-1", "child-2"]}}
+
+        gathered = await app._gather_pending_hitl_requests(client, parent_status)
+        assert {qid for qid, _ in gathered} == {"sub~0~r1", "sub~1~r2"}
+
+        # The second child (ordinal 1) resolves distinctly, not shadowed by the first.
+        resolved = await app._resolve_hitl_target(client, "parent", "sub~1~r2")
+        assert resolved == ("child-2", "r2")
+
+    async def test_nested_double_colon_leaf_round_trips(self) -> None:
+        app = self._app()
+        client = self._client({
+            "parent": {"subworkflows": {"sub": ["child-1"]}},
+            "child-1": {"pending_requests": {"auto::0": {"request_id": "auto::0", "source_executor_id": "fn"}}},
+        })
+        parent_status = {"subworkflows": {"sub": ["child-1"]}}
+
+        gathered = await app._gather_pending_hitl_requests(client, parent_status)
+        assert [qid for qid, _ in gathered] == ["sub~0~auto::0"]
+
+        resolved = await app._resolve_hitl_target(client, "parent", "sub~0~auto::0")
+        assert resolved == ("child-1", "auto::0")
+
+    async def test_top_level_double_colon_leaf_is_not_nested(self) -> None:
+        app = self._app()
+        client = self._client({})
+
+        resolved = await app._resolve_hitl_target(client, "parent", "auto::0")
+
+        assert resolved == ("parent", "auto::0")
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v", "--tb=short"])

--- a/python/packages/azurefunctions/tests/test_entities.py
+++ b/python/packages/azurefunctions/tests/test_entities.py
@@ -1,0 +1,293 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+"""Unit tests for create_agent_entity factory function.
+
+Run with: pytest tests/test_entities.py -v
+"""
+
+from collections.abc import Callable
+from typing import Any, TypeVar
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+from agent_framework import AgentResponse, Message
+
+from agent_framework_azurefunctions._entities import create_agent_entity
+
+FuncT = TypeVar("FuncT", bound=Callable[..., Any])
+
+
+def _agent_response(text: str | None) -> AgentResponse:
+    """Create an AgentResponse with a single assistant message."""
+    message = (
+        Message(role="assistant", contents=[text]) if text is not None else Message(role="assistant", contents=[""])
+    )
+    return AgentResponse(messages=[message])
+
+
+class TestCreateAgentEntity:
+    """Test suite for the create_agent_entity factory function."""
+
+    def test_create_agent_entity_returns_callable(self) -> None:
+        """Test that create_agent_entity returns a callable."""
+        mock_agent = Mock()
+
+        entity_function = create_agent_entity(mock_agent)
+
+        assert callable(entity_function)
+
+    def test_entity_function_handles_run_agent(self) -> None:
+        """Test that the entity function handles the run_agent operation."""
+        mock_agent = Mock()
+        mock_agent.run = AsyncMock(return_value=_agent_response("Response"))
+
+        entity_function = create_agent_entity(mock_agent)
+
+        # Mock context
+        mock_context = Mock()
+        mock_context.operation_name = "run"
+        mock_context.entity_key = "conv-123"
+        mock_context.get_input.return_value = {
+            "message": "Test message",
+            "correlationId": "corr-entity-factory",
+        }
+        mock_context.get_state.return_value = None
+
+        # Execute
+        entity_function(mock_context)
+
+        # Verify result and state were set
+        assert mock_context.set_result.called
+        assert mock_context.set_state.called
+
+    def test_entity_function_handles_reset(self) -> None:
+        """Test that the entity function handles the reset operation."""
+        mock_agent = Mock()
+
+        entity_function = create_agent_entity(mock_agent)
+
+        # Mock context with existing state
+        mock_context = Mock()
+        mock_context.operation_name = "reset"
+        mock_context.get_state.return_value = {
+            "schemaVersion": "1.0.0",
+            "data": {
+                "conversationHistory": [
+                    {
+                        "$type": "request",
+                        "correlationId": "test-correlation-id",
+                        "createdAt": "2024-01-01T00:00:00Z",
+                        "messages": [
+                            {
+                                "role": "user",
+                                "contents": [{"$type": "text", "text": "test"}],
+                            }
+                        ],
+                    }
+                ]
+            },
+        }
+
+        # Execute
+        entity_function(mock_context)
+
+        # Verify reset result
+        assert mock_context.set_result.called
+        result = mock_context.set_result.call_args[0][0]
+        assert result["status"] == "reset"
+
+        # Verify state was cleared
+        assert mock_context.set_state.called
+        state = mock_context.set_state.call_args[0][0]
+        assert state["data"]["conversationHistory"] == []
+
+    def test_entity_function_handles_unknown_operation(self) -> None:
+        """Test that the entity function handles unknown operations."""
+        mock_agent = Mock()
+
+        entity_function = create_agent_entity(mock_agent)
+
+        mock_context = Mock()
+        mock_context.operation_name = "invalid_operation"
+        mock_context.get_state.return_value = None
+
+        # Execute
+        entity_function(mock_context)
+
+        # Verify error result
+        assert mock_context.set_result.called
+        result = mock_context.set_result.call_args[0][0]
+        assert "error" in result
+        assert "invalid_operation" in result["error"].lower()
+
+    def test_entity_function_creates_new_entity_on_first_call(self) -> None:
+        """Test that the entity function creates a new entity when no state exists."""
+        mock_agent = Mock()
+        mock_agent.__class__.__name__ = "Agent"
+
+        entity_function = create_agent_entity(mock_agent)
+        mock_context = Mock()
+        mock_context.operation_name = "reset"
+        mock_context.get_state.return_value = None  # No existing state
+
+        # Execute
+        entity_function(mock_context)
+
+        # Verify new entity state was created
+        assert mock_context.set_result.called
+        result = mock_context.set_result.call_args[0][0]
+        assert result["status"] == "reset"
+        assert mock_context.set_state.called
+        state = mock_context.set_state.call_args[0][0]
+        assert state["data"] == {"conversationHistory": []}
+
+    def test_entity_function_restores_existing_state(self) -> None:
+        """Test that the entity function can operate when existing state is present."""
+        mock_agent = Mock()
+
+        entity_function = create_agent_entity(mock_agent)
+
+        existing_state = {
+            "schemaVersion": "1.0.0",
+            "data": {
+                "conversationHistory": [
+                    {
+                        "$type": "request",
+                        "correlationId": "corr-existing-1",
+                        "createdAt": "2024-01-01T00:00:00Z",
+                        "messages": [
+                            {
+                                "role": "user",
+                                "contents": [
+                                    {
+                                        "$type": "text",
+                                        "text": "msg1",
+                                    }
+                                ],
+                            }
+                        ],
+                    },
+                    {
+                        "$type": "response",
+                        "correlationId": "corr-existing-1",
+                        "createdAt": "2024-01-01T00:05:00Z",
+                        "messages": [
+                            {
+                                "role": "assistant",
+                                "contents": [
+                                    {
+                                        "$type": "text",
+                                        "text": "resp1",
+                                    }
+                                ],
+                            }
+                        ],
+                    },
+                ],
+            },
+        }
+
+        mock_context = Mock()
+        mock_context.operation_name = "reset"
+        mock_context.get_state.return_value = existing_state
+
+        entity_function(mock_context)
+
+        assert mock_context.set_result.called
+
+        # Reset should clear history and persist via set_state
+        assert mock_context.set_state.called
+        persisted_state = mock_context.set_state.call_args[0][0]
+        assert persisted_state["data"]["conversationHistory"] == []
+
+    def test_entity_function_handles_string_input(self) -> None:
+        """Test that the entity function handles non-dict input by converting to string."""
+        mock_agent = Mock()
+        mock_agent.run = AsyncMock(return_value=_agent_response("String response"))
+
+        entity_function = create_agent_entity(mock_agent)
+
+        # Mock context with non-dict input (like a number)
+        mock_context = Mock()
+        mock_context.operation_name = "run"
+        mock_context.entity_key = "conv-456"
+        # Use a number to test the str() conversion path
+        mock_context.get_input.return_value = 12345
+        mock_context.get_state.return_value = None
+
+        # Execute - entity will convert non-dict input to string
+        entity_function(mock_context)
+
+        # Verify the result was set
+        assert mock_context.set_result.called
+
+    def test_entity_function_handles_none_input(self) -> None:
+        """Test that the entity function handles None input by converting to empty string."""
+        mock_agent = Mock()
+        mock_agent.run = AsyncMock(return_value=_agent_response("Empty response"))
+
+        entity_function = create_agent_entity(mock_agent)
+
+        # Mock context with None input
+        mock_context = Mock()
+        mock_context.operation_name = "run"
+        mock_context.entity_key = "conv-789"
+        mock_context.get_input.return_value = None
+        mock_context.get_state.return_value = None
+
+        # Execute - should hit error path since entity expects dict or valid JSON string
+        entity_function(mock_context)
+
+        # Verify the result was set (likely error result)
+        assert mock_context.set_result.called
+
+    def test_entity_function_runs_on_persistent_loop(self) -> None:
+        """Entity coroutines run on the shared persistent loop and set a result."""
+        mock_agent = Mock()
+        mock_agent.run = AsyncMock(return_value=_agent_response("Response"))
+
+        entity_function = create_agent_entity(mock_agent)
+
+        mock_context = Mock()
+        mock_context.operation_name = "run"
+        mock_context.entity_key = "conv-loop-test"
+        mock_context.get_input.return_value = {"message": "Test", "correlationId": "corr-loop-test"}
+        mock_context.get_state.return_value = None
+
+        # Execute - the persistent loop should run the coroutine and set a result.
+        entity_function(mock_context)
+
+        assert mock_context.set_result.called
+        mock_agent.run.assert_awaited()
+
+    def test_entity_function_runs_across_threads_without_hang(self) -> None:
+        """Successive entity invocations from different threads must not hang.
+
+        This reproduces the cross-loop scenario that previously deadlocked: a
+        shared async resource bound to one loop being awaited from a different
+        worker thread. The persistent loop keeps every invocation on one loop.
+        """
+        from concurrent.futures import ThreadPoolExecutor
+
+        mock_agent = Mock()
+        mock_agent.run = AsyncMock(return_value=_agent_response("Response"))
+
+        entity_function = create_agent_entity(mock_agent)
+
+        def invoke(i: int) -> bool:
+            ctx = Mock()
+            ctx.operation_name = "run"
+            ctx.entity_key = f"conv-{i}"
+            ctx.get_input.return_value = {"message": f"Test {i}", "correlationId": f"corr-{i}"}
+            ctx.get_state.return_value = None
+            entity_function(ctx)
+            return ctx.set_result.called
+
+        with ThreadPoolExecutor(max_workers=8) as ex:
+            results = list(ex.map(invoke, range(16)))
+
+        assert all(results)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v", "--tb=short"])

--- a/python/packages/azurefunctions/tests/test_errors.py
+++ b/python/packages/azurefunctions/tests/test_errors.py
@@ -1,0 +1,38 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+"""Unit tests for custom exception types."""
+
+import pytest
+
+from agent_framework_azurefunctions._errors import IncomingRequestError
+
+
+class TestIncomingRequestError:
+    """Test suite for IncomingRequestError exception."""
+
+    def test_incoming_request_error_default_status_code(self) -> None:
+        """Test that IncomingRequestError has a default status code of 400."""
+        error = IncomingRequestError("Invalid request")
+
+        assert str(error) == "Invalid request"
+        assert error.status_code == 400
+
+    def test_incoming_request_error_custom_status_code(self) -> None:
+        """Test that IncomingRequestError can have a custom status code."""
+        error = IncomingRequestError("Unauthorized", status_code=401)
+
+        assert str(error) == "Unauthorized"
+        assert error.status_code == 401
+
+    def test_incoming_request_error_is_value_error(self) -> None:
+        """Test that IncomingRequestError inherits from ValueError."""
+        error = IncomingRequestError("Test error")
+
+        assert isinstance(error, ValueError)
+
+    def test_incoming_request_error_can_be_raised_and_caught(self) -> None:
+        """Test that IncomingRequestError can be raised and caught."""
+        with pytest.raises(IncomingRequestError) as exc_info:
+            raise IncomingRequestError("Bad request", status_code=400)
+
+        assert exc_info.value.status_code == 400

--- a/python/packages/azurefunctions/tests/test_func_utils.py
+++ b/python/packages/azurefunctions/tests/test_func_utils.py
@@ -1,0 +1,162 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+"""Unit tests for workflow utility functions."""
+
+from unittest.mock import Mock
+
+import pytest
+from agent_framework import WorkflowEvent, WorkflowMessage
+
+from agent_framework_azurefunctions._context import CapturingRunnerContext
+
+
+class TestCapturingRunnerContext:
+    """Test suite for CapturingRunnerContext."""
+
+    @pytest.fixture
+    def context(self) -> CapturingRunnerContext:
+        """Create a fresh CapturingRunnerContext for each test."""
+        return CapturingRunnerContext()
+
+    @pytest.mark.asyncio
+    async def test_send_message_captures_message(self, context: CapturingRunnerContext) -> None:
+        """Test that send_message captures messages correctly."""
+        message = WorkflowMessage(data="test data", target_id="target_1", source_id="source_1")
+
+        await context.send_message(message)
+
+        messages = await context.drain_messages()
+        assert "source_1" in messages
+        assert len(messages["source_1"]) == 1
+        assert messages["source_1"][0].data == "test data"
+
+    @pytest.mark.asyncio
+    async def test_send_multiple_messages_groups_by_source(self, context: CapturingRunnerContext) -> None:
+        """Test that messages are grouped by source_id."""
+        msg1 = WorkflowMessage(data="msg1", target_id="target", source_id="source_a")
+        msg2 = WorkflowMessage(data="msg2", target_id="target", source_id="source_a")
+        msg3 = WorkflowMessage(data="msg3", target_id="target", source_id="source_b")
+
+        await context.send_message(msg1)
+        await context.send_message(msg2)
+        await context.send_message(msg3)
+
+        messages = await context.drain_messages()
+        assert len(messages["source_a"]) == 2
+        assert len(messages["source_b"]) == 1
+
+    @pytest.mark.asyncio
+    async def test_drain_messages_clears_messages(self, context: CapturingRunnerContext) -> None:
+        """Test that drain_messages clears the message store."""
+        message = WorkflowMessage(data="test", target_id="t", source_id="s")
+        await context.send_message(message)
+
+        await context.drain_messages()  # First drain
+        messages = await context.drain_messages()  # Second drain
+
+        assert messages == {}
+
+    @pytest.mark.asyncio
+    async def test_has_messages_returns_correct_status(self, context: CapturingRunnerContext) -> None:
+        """Test has_messages returns correct boolean."""
+        assert await context.has_messages() is False
+
+        await context.send_message(WorkflowMessage(data="test", target_id="t", source_id="s"))
+
+        assert await context.has_messages() is True
+
+    @pytest.mark.asyncio
+    async def test_add_event_queues_event(self, context: CapturingRunnerContext) -> None:
+        """Test that add_event queues events correctly."""
+        event = WorkflowEvent("output", executor_id="exec_1", data="output")
+
+        await context.add_event(event)
+
+        events = await context.drain_events()
+        assert len(events) == 1
+        assert isinstance(events[0], WorkflowEvent)
+        assert events[0].type == "output"
+        assert events[0].data == "output"
+
+    @pytest.mark.asyncio
+    async def test_drain_events_clears_queue(self, context: CapturingRunnerContext) -> None:
+        """Test that drain_events clears the event queue."""
+        await context.add_event(WorkflowEvent("output", executor_id="e", data="test"))
+
+        await context.drain_events()  # First drain
+        events = await context.drain_events()  # Second drain
+
+        assert events == []
+
+    @pytest.mark.asyncio
+    async def test_has_events_returns_correct_status(self, context: CapturingRunnerContext) -> None:
+        """Test has_events returns correct boolean."""
+        assert await context.has_events() is False
+
+        await context.add_event(WorkflowEvent("output", executor_id="e", data="test"))
+
+        assert await context.has_events() is True
+
+    @pytest.mark.asyncio
+    async def test_next_event_waits_for_event(self, context: CapturingRunnerContext) -> None:
+        """Test that next_event returns queued events."""
+        event = WorkflowEvent("output", executor_id="e", data="waited")
+        await context.add_event(event)
+
+        result = await context.next_event()
+
+        assert result.data == "waited"
+
+    def test_has_checkpointing_returns_false(self, context: CapturingRunnerContext) -> None:
+        """Test that checkpointing is not supported."""
+        assert context.has_checkpointing() is False
+
+    def test_is_streaming_returns_false_by_default(self, context: CapturingRunnerContext) -> None:
+        """Test streaming is disabled by default."""
+        assert context.is_streaming() is False
+
+    def test_set_streaming(self, context: CapturingRunnerContext) -> None:
+        """Test setting streaming mode."""
+        context.set_streaming(True)
+        assert context.is_streaming() is True
+
+        context.set_streaming(False)
+        assert context.is_streaming() is False
+
+    def test_set_workflow_id(self, context: CapturingRunnerContext) -> None:
+        """Test setting workflow ID."""
+        context.set_workflow_id("workflow-123")
+        assert context._workflow_id == "workflow-123"
+
+    @pytest.mark.asyncio
+    async def test_reset_for_new_run_clears_state(self, context: CapturingRunnerContext) -> None:
+        """Test that reset_for_new_run clears all state."""
+        await context.send_message(WorkflowMessage(data="test", target_id="t", source_id="s"))
+        await context.add_event(WorkflowEvent("output", executor_id="e", data="event"))
+        context.set_streaming(True)
+
+        context.reset_for_new_run()
+
+        assert await context.has_messages() is False
+        assert await context.has_events() is False
+        assert context.is_streaming() is False
+
+    @pytest.mark.asyncio
+    async def test_create_checkpoint_raises_not_implemented(self, context: CapturingRunnerContext) -> None:
+        """Test that checkpointing methods raise NotImplementedError."""
+        from agent_framework._workflows._state import State
+
+        with pytest.raises(NotImplementedError):
+            await context.create_checkpoint("test_workflow", "abc123", State(), None, 1)
+
+    @pytest.mark.asyncio
+    async def test_load_checkpoint_raises_not_implemented(self, context: CapturingRunnerContext) -> None:
+        """Test that load_checkpoint raises NotImplementedError."""
+        with pytest.raises(NotImplementedError):
+            await context.load_checkpoint("some-id")
+
+    @pytest.mark.asyncio
+    async def test_apply_checkpoint_raises_not_implemented(self, context: CapturingRunnerContext) -> None:
+        """Test that apply_checkpoint raises NotImplementedError."""
+        with pytest.raises(NotImplementedError):
+            await context.apply_checkpoint(Mock())

--- a/python/packages/azurefunctions/tests/test_hitl_context.py
+++ b/python/packages/azurefunctions/tests/test_hitl_context.py
@@ -1,0 +1,231 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+"""Unit tests for WorkflowHitlContext (HITL respond-URL helper)."""
+
+# pyright: reportPrivateUsage=false
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from agent_framework_azurefunctions import WorkflowHitlContext
+from agent_framework_azurefunctions._hitl_context import WEBSITE_HOSTNAME_ENV, _is_loopback
+
+
+def _ctx(metadata: Any) -> SimpleNamespace:
+    """Build a stand-in WorkflowContext exposing ``_runner_context.host_metadata``."""
+    return SimpleNamespace(_runner_context=SimpleNamespace(host_metadata=metadata))
+
+
+class TestFromContext:
+    """Construction from a workflow executor's context."""
+
+    def test_returns_context_when_metadata_present(self) -> None:
+        hitl = WorkflowHitlContext.from_context(_ctx({"instance_id": "inst-1", "workflow_name": "content_moderation"}))
+        assert hitl is not None
+        assert hitl.instance_id == "inst-1"
+        assert hitl.workflow_name == "content_moderation"
+
+    def test_returns_none_when_no_runner_context(self) -> None:
+        # A bare object without _runner_context (e.g. an unexpected ctx) yields None.
+        assert WorkflowHitlContext.from_context(SimpleNamespace()) is None
+
+    def test_returns_none_when_metadata_absent(self) -> None:
+        # In-process RunnerContext has no host_metadata -> getattr default None.
+        assert WorkflowHitlContext.from_context(_ctx(None)) is None
+
+    def test_returns_none_when_metadata_not_a_dict(self) -> None:
+        assert WorkflowHitlContext.from_context(_ctx("not-a-dict")) is None
+
+    def test_returns_none_when_instance_id_missing(self) -> None:
+        assert WorkflowHitlContext.from_context(_ctx({"workflow_name": "wf"})) is None
+
+    def test_returns_none_when_workflow_name_missing(self) -> None:
+        assert WorkflowHitlContext.from_context(_ctx({"instance_id": "inst-1"})) is None
+
+
+class TestBaseUrl:
+    """base_url resolution from override and WEBSITE_HOSTNAME."""
+
+    def test_explicit_override_wins(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(WEBSITE_HOSTNAME_ENV, "ignored.azurewebsites.net")
+        hitl = WorkflowHitlContext.from_context(
+            _ctx({"instance_id": "i", "workflow_name": "wf"}),
+            base_url="https://contoso.example.com/",
+        )
+        assert hitl is not None
+        # Trailing slash trimmed; override used verbatim over the env host.
+        assert hitl.base_url == "https://contoso.example.com"
+
+    def test_website_hostname_gets_https(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(WEBSITE_HOSTNAME_ENV, "myapp.azurewebsites.net")
+        hitl = WorkflowHitlContext.from_context(_ctx({"instance_id": "i", "workflow_name": "wf"}))
+        assert hitl is not None
+        assert hitl.base_url == "https://myapp.azurewebsites.net"
+
+    def test_localhost_gets_http(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(WEBSITE_HOSTNAME_ENV, "localhost:7071")
+        hitl = WorkflowHitlContext.from_context(_ctx({"instance_id": "i", "workflow_name": "wf"}))
+        assert hitl is not None
+        assert hitl.base_url == "http://localhost:7071"
+
+    def test_override_with_scheme_preserved(self) -> None:
+        hitl = WorkflowHitlContext.from_context(
+            _ctx({"instance_id": "i", "workflow_name": "wf"}),
+            base_url="http://127.0.0.1:7071",
+        )
+        assert hitl is not None
+        assert hitl.base_url == "http://127.0.0.1:7071"
+
+    def test_raises_when_no_base_url_available(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv(WEBSITE_HOSTNAME_ENV, raising=False)
+        hitl = WorkflowHitlContext.from_context(_ctx({"instance_id": "i", "workflow_name": "wf"}))
+        assert hitl is not None
+        with pytest.raises(RuntimeError, match=WEBSITE_HOSTNAME_ENV):
+            _ = hitl.base_url
+
+
+class TestUrlBuilders:
+    """respond/status URL shapes match the AgentFunctionApp routes."""
+
+    def test_build_respond_url(self) -> None:
+        hitl = WorkflowHitlContext.from_context(
+            _ctx({"instance_id": "inst-1", "workflow_name": "content_moderation"}),
+            base_url="https://app.example.com",
+        )
+        assert hitl is not None
+        assert hitl.build_respond_url("req-9") == (
+            "https://app.example.com/api/workflow/content_moderation/respond/inst-1/req-9"
+        )
+
+    def test_build_respond_url_accepts_qualified_id(self) -> None:
+        # A nested sub-workflow request id (executor~ordinal~rid) flows through unchanged.
+        hitl = WorkflowHitlContext.from_context(
+            _ctx({"instance_id": "inst-1", "workflow_name": "wf"}),
+            base_url="https://app.example.com",
+        )
+        assert hitl is not None
+        assert hitl.build_respond_url("reviewer~0~req-9") == (
+            "https://app.example.com/api/workflow/wf/respond/inst-1/reviewer~0~req-9"
+        )
+
+    def test_build_status_url(self) -> None:
+        hitl = WorkflowHitlContext.from_context(
+            _ctx({"instance_id": "inst-1", "workflow_name": "wf"}),
+            base_url="https://app.example.com",
+        )
+        assert hitl is not None
+        assert hitl.build_status_url() == "https://app.example.com/api/workflow/wf/status/inst-1"
+
+
+class TestNestedPrefix:
+    """request_path_prefix qualifies a bare request id back to the root instance."""
+
+    def test_prefix_read_from_metadata(self) -> None:
+        # host_metadata for a nested executor carries the root instance/workflow and the
+        # accumulated path prefix; instance_id/workflow_name are the *root* values.
+        hitl = WorkflowHitlContext.from_context(
+            _ctx({
+                "instance_id": "root-inst",
+                "workflow_name": "moderation_pipeline",
+                "request_path_prefix": "review_sub~0~",
+            }),
+            base_url="https://app.example.com",
+        )
+        assert hitl is not None
+        assert hitl.request_path_prefix == "review_sub~0~"
+        # A bare request id is qualified back to the top-level instance automatically.
+        assert hitl.build_respond_url("req-9") == (
+            "https://app.example.com/api/workflow/moderation_pipeline/respond/root-inst/review_sub~0~req-9"
+        )
+
+    def test_deep_prefix(self) -> None:
+        hitl = WorkflowHitlContext.from_context(
+            _ctx({
+                "instance_id": "root-inst",
+                "workflow_name": "wf",
+                "request_path_prefix": "outer~2~inner~1~",
+            }),
+            base_url="https://app.example.com",
+        )
+        assert hitl is not None
+        assert hitl.build_respond_url("rid") == (
+            "https://app.example.com/api/workflow/wf/respond/root-inst/outer~2~inner~1~rid"
+        )
+
+    def test_absent_prefix_defaults_empty(self) -> None:
+        # Top-level metadata may omit the key; the bare id is used unqualified.
+        hitl = WorkflowHitlContext.from_context(
+            _ctx({"instance_id": "inst-1", "workflow_name": "wf"}),
+            base_url="https://app.example.com",
+        )
+        assert hitl is not None
+        assert hitl.request_path_prefix == ""
+        assert hitl.build_respond_url("rid") == ("https://app.example.com/api/workflow/wf/respond/inst-1/rid")
+
+
+def _ctx_with_pending(pending: dict[str, Any] | None, *, has_getter: bool = True) -> SimpleNamespace:
+    """Build a ctx whose runner context returns the given pending request-info events."""
+    if not has_getter:
+        return SimpleNamespace(_runner_context=SimpleNamespace())
+
+    async def _get() -> dict[str, Any]:
+        return pending or {}
+
+    return SimpleNamespace(_runner_context=SimpleNamespace(get_pending_request_info_events=_get))
+
+
+class TestPendingRequestId:
+    """Reading back the framework-generated request id after request_info."""
+
+    async def test_returns_latest_request_id(self) -> None:
+        # Dicts preserve insertion order; the most recently emitted request wins.
+        ctx = _ctx_with_pending({"r1": object(), "r2": object()})
+        assert await WorkflowHitlContext.pending_request_id(ctx) == "r2"
+
+    async def test_returns_single_request_id(self) -> None:
+        ctx = _ctx_with_pending({"only-one": object()})
+        assert await WorkflowHitlContext.pending_request_id(ctx) == "only-one"
+
+    async def test_returns_none_when_no_pending(self) -> None:
+        ctx = _ctx_with_pending({})
+        assert await WorkflowHitlContext.pending_request_id(ctx) is None
+
+    async def test_returns_none_when_no_runner_context(self) -> None:
+        assert await WorkflowHitlContext.pending_request_id(SimpleNamespace()) is None
+
+    async def test_returns_none_when_getter_absent(self) -> None:
+        # A runner context that doesn't track request-info events degrades to None.
+        ctx = _ctx_with_pending(None, has_getter=False)
+        assert await WorkflowHitlContext.pending_request_id(ctx) is None
+
+
+class TestLoopback:
+    """Loopback detection covers the addresses ``func start`` can bind, not just localhost."""
+
+    @pytest.mark.parametrize(
+        ("host", "expected"),
+        [
+            ("localhost", True),
+            ("localhost:7071", True),
+            ("127.0.0.1", True),
+            ("127.0.0.1:7071", True),
+            ("127.5.9.9", True),
+            ("0.0.0.0", True),
+            ("0.0.0.0:7071", True),
+            ("::1", True),
+            ("[::1]:7071", True),
+            ("myapp.azurewebsites.net", False),
+            ("contoso.example.com:443", False),
+        ],
+    )
+    def test_is_loopback(self, host: str, expected: bool) -> None:
+        assert _is_loopback(host) is expected
+
+    def test_ipv6_loopback_base_url_gets_http(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # WEBSITE_HOSTNAME may report a bracketed IPv6 loopback locally; it must resolve to http.
+        monkeypatch.setenv(WEBSITE_HOSTNAME_ENV, "[::1]:7071")
+        hitl = WorkflowHitlContext.from_context(_ctx({"instance_id": "i", "workflow_name": "wf"}))
+        assert hitl is not None
+        assert hitl.base_url == "http://[::1]:7071"

--- a/python/packages/azurefunctions/tests/test_multi_agent.py
+++ b/python/packages/azurefunctions/tests/test_multi_agent.py
@@ -1,0 +1,155 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+"""Unit tests for multi-agent support in AgentFunctionApp."""
+
+from unittest.mock import Mock
+
+import pytest
+
+from agent_framework_azurefunctions import AgentFunctionApp
+
+
+class TestMultiAgentInit:
+    """Test suite for multi-agent initialization."""
+
+    def test_init_with_agents_list(self) -> None:
+        """Test initialization with list of agents."""
+        agent1 = Mock()
+        agent1.name = "Agent1"
+        agent2 = Mock()
+        agent2.name = "Agent2"
+
+        app = AgentFunctionApp(agents=[agent1, agent2])
+
+        assert len(app.agents) == 2
+        assert "Agent1" in app.agents
+        assert "Agent2" in app.agents
+        assert app.agents["Agent1"] == agent1
+        assert app.agents["Agent2"] == agent2
+
+    def test_init_with_empty_agents_list(self) -> None:
+        """Test initialization with empty list of agents."""
+        app = AgentFunctionApp(agents=[])
+
+        assert len(app.agents) == 0
+
+    def test_init_with_no_agents(self) -> None:
+        """Test initialization without any agents."""
+        app = AgentFunctionApp()
+
+        assert len(app.agents) == 0
+
+    def test_init_with_duplicate_agent_names(self) -> None:
+        """Test initialization with duplicate agent names deduplicates with warning."""
+        agent1 = Mock()
+        agent1.name = "TestAgent"
+        agent2 = Mock()
+        agent2.name = "TestAgent"
+
+        app = AgentFunctionApp(agents=[agent1, agent2])
+
+        # Duplicate is skipped, only the first agent is registered
+        assert len(app.agents) == 1
+        assert "TestAgent" in app.agents
+
+    def test_init_with_agent_without_name(self) -> None:
+        """Test initialization with agent missing name attribute raises error."""
+        agent1 = Mock()
+        agent1.name = "Agent1"
+        agent2 = Mock(spec=[])  # Mock without name attribute
+
+        with pytest.raises(ValueError, match="does not have a 'name' attribute"):
+            AgentFunctionApp(agents=[agent1, agent2])
+
+
+class TestAddAgentMethod:
+    """Test suite for add_agent() method."""
+
+    def test_add_agent_to_empty_app(self) -> None:
+        """Test adding agent to app initialized without agents."""
+        app = AgentFunctionApp()
+
+        agent = Mock()
+        agent.name = "NewAgent"
+
+        app.add_agent(agent)
+
+        assert len(app.agents) == 1
+        assert "NewAgent" in app.agents
+        assert app.agents["NewAgent"] == agent
+
+    def test_add_multiple_agents(self) -> None:
+        """Test adding multiple agents sequentially."""
+        app = AgentFunctionApp()
+
+        agent1 = Mock()
+        agent1.name = "Agent1"
+        agent2 = Mock()
+        agent2.name = "Agent2"
+
+        app.add_agent(agent1)
+        app.add_agent(agent2)
+
+        assert len(app.agents) == 2
+        assert "Agent1" in app.agents
+        assert "Agent2" in app.agents
+
+    def test_add_agent_with_duplicate_name_skips(self) -> None:
+        """Test that adding agent with duplicate name logs warning and skips."""
+        agent1 = Mock()
+        agent1.name = "MyAgent"
+        agent2 = Mock()
+        agent2.name = "MyAgent"
+
+        app = AgentFunctionApp(agents=[agent1])
+
+        # Duplicate is silently skipped with a warning
+        app.add_agent(agent2)
+
+        # Only the original agent remains
+        assert len(app.agents) == 1
+
+    def test_add_agent_to_app_with_existing_agents(self) -> None:
+        """Test adding agent to app that already has agents."""
+        agent1 = Mock()
+        agent1.name = "Agent1"
+        agent2 = Mock()
+        agent2.name = "Agent2"
+
+        app = AgentFunctionApp(agents=[agent1])
+        app.add_agent(agent2)
+
+        assert len(app.agents) == 2
+        assert "Agent1" in app.agents
+        assert "Agent2" in app.agents
+
+    def test_add_agent_without_name_raises_error(self) -> None:
+        """Test that adding agent without name attribute raises error."""
+        app = AgentFunctionApp()
+
+        agent = Mock(spec=[])  # Mock without name attribute
+
+        with pytest.raises(ValueError, match="does not have a 'name' attribute"):
+            app.add_agent(agent)
+
+
+class TestHealthCheckWithMultipleAgents:
+    """Test suite for health check with multiple agents."""
+
+    def test_health_check_returns_all_agents(self) -> None:
+        """Test that health check returns information about all agents."""
+        agent1 = Mock()
+        agent1.name = "Agent1"
+        agent2 = Mock()
+        agent2.name = "Agent2"
+
+        app = AgentFunctionApp(agents=[agent1, agent2])
+
+        # Note: We can't easily test the actual health check endpoint without running the app
+        # But we can verify the agents dictionary is properly populated
+        assert len(app.agents) == 2
+        assert app.enable_health_check is True
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v", "--tb=short"])

--- a/python/packages/azurefunctions/tests/test_orchestration.py
+++ b/python/packages/azurefunctions/tests/test_orchestration.py
@@ -1,0 +1,399 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+"""Unit tests for orchestration support (DurableAIAgent)."""
+
+from typing import Any
+from unittest.mock import Mock
+
+import pytest
+from agent_framework import AgentResponse, Message
+from agent_framework_durabletask import DurableAIAgent
+from azure.durable_functions.models.Task import TaskBase, TaskState
+
+from agent_framework_azurefunctions import AgentFunctionApp
+from agent_framework_azurefunctions._orchestration import AgentTask
+
+
+def _app_with_registered_agents(*agent_names: str) -> AgentFunctionApp:
+    app = AgentFunctionApp(enable_health_check=False, enable_http_endpoints=False)
+    for name in agent_names:
+        agent = Mock()
+        agent.name = name
+        app.add_agent(agent)
+    return app
+
+
+class _FakeTask(TaskBase):
+    """Concrete TaskBase for testing AgentTask wiring."""
+
+    def __init__(self, task_id: int = 1):
+        super().__init__(task_id, [])
+        self._set_is_scheduled(False)
+        self.action_repr: list[Any] = []  # pyrefly: ignore[bad-override-mutable-attribute]
+        self.state = TaskState.RUNNING
+
+
+def _create_entity_task(task_id: int = 1) -> TaskBase:
+    """Create a minimal TaskBase instance for AgentTask tests."""
+    return _FakeTask(task_id)
+
+
+@pytest.fixture
+def mock_context():
+    """Create a mock orchestration context with UUID support."""
+    context = Mock()
+    context.instance_id = "test-instance"
+    context.current_utc_datetime = Mock()
+    return context
+
+
+@pytest.fixture
+def mock_context_with_uuid() -> tuple[Mock, str]:
+    """Create a mock context with a single UUID."""
+    from uuid import UUID
+
+    context = Mock()
+    context.instance_id = "test-instance"
+    context.current_utc_datetime = Mock()
+    test_uuid = UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+    context.new_uuid = Mock(return_value=test_uuid)
+    return context, test_uuid.hex
+
+
+@pytest.fixture
+def mock_context_with_multiple_uuids() -> tuple[Mock, list[str]]:
+    """Create a mock context with multiple UUIDs via side_effect."""
+    from uuid import UUID
+
+    context = Mock()
+    context.instance_id = "test-instance"
+    context.current_utc_datetime = Mock()
+    uuids = [
+        UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"),
+        UUID("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"),
+        UUID("cccccccc-cccc-cccc-cccc-cccccccccccc"),
+    ]
+    context.new_uuid = Mock(side_effect=uuids)
+    # Return the hex versions for assertion checking
+    hex_uuids = [uuid.hex for uuid in uuids]
+    return context, hex_uuids
+
+
+@pytest.fixture
+def executor_with_uuid() -> tuple[Any, Mock, str]:
+    """Create an executor with a mocked generate_unique_id method."""
+    from agent_framework_azurefunctions._orchestration import AzureFunctionsAgentExecutor
+
+    context = Mock()
+    context.instance_id = "test-instance"
+    context.current_utc_datetime = Mock()
+
+    executor = AzureFunctionsAgentExecutor(context)
+    test_uuid_hex = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+    executor.generate_unique_id = Mock(return_value=test_uuid_hex)  # type: ignore[method-assign]
+
+    return executor, context, test_uuid_hex
+
+
+@pytest.fixture
+def executor_with_multiple_uuids() -> tuple[Any, Mock, list[str]]:
+    """Create an executor with multiple mocked UUIDs."""
+    from agent_framework_azurefunctions._orchestration import AzureFunctionsAgentExecutor
+
+    context = Mock()
+    context.instance_id = "test-instance"
+    context.current_utc_datetime = Mock()
+
+    executor = AzureFunctionsAgentExecutor(context)
+    uuid_hexes = [
+        "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+        "cccccccc-cccc-cccc-cccc-cccccccccccc",
+        "dddddddd-dddd-dddd-dddd-dddddddddddd",
+        "eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee",
+    ]
+    executor.generate_unique_id = Mock(side_effect=uuid_hexes)  # type: ignore[method-assign]
+
+    return executor, context, uuid_hexes
+
+
+@pytest.fixture
+def executor_with_context(mock_context_with_uuid: tuple[Mock, str]) -> tuple[Any, Mock]:
+    """Create an executor with a mocked context."""
+    from agent_framework_azurefunctions._orchestration import AzureFunctionsAgentExecutor
+
+    context, _ = mock_context_with_uuid
+    return AzureFunctionsAgentExecutor(context), context
+
+
+class TestAgentResponseHelpers:
+    """Tests for response handling through public AgentTask API."""
+
+    def test_try_set_value_exception_handling(self) -> None:
+        """Test try_set_value handles exceptions raised when converting a successful task result to AgentResponse."""
+        entity_task = _create_entity_task()
+        task = AgentTask(entity_task, None, "correlation-id")
+
+        # Simulate successful entity task with invalid result that causes exception
+        entity_task.state = TaskState.SUCCEEDED
+        entity_task.result = {"invalid": "format"}  # Missing required fields for AgentResponse
+
+        # Clear pending_tasks to simulate that parent has processed the child
+        task.pending_tasks.clear()
+
+        # Call try_set_value - should catch exception and set error
+        task.try_set_value(entity_task)
+
+        # Verify task failed due to conversion exception
+        assert task.state == TaskState.FAILED
+        assert isinstance(task.result, Exception)
+
+    def test_try_set_value_success(self) -> None:
+        """Test try_set_value correctly processes successful task completion."""
+        entity_task = _create_entity_task()
+        task = AgentTask(entity_task, None, "correlation-id")
+
+        # Simulate successful entity task completion
+        entity_task.state = TaskState.SUCCEEDED
+        entity_task.result = AgentResponse(messages=[Message(role="assistant", contents=["Test response"])]).to_dict()
+
+        # Clear pending_tasks to simulate that parent has processed the child
+        task.pending_tasks.clear()
+
+        # Call try_set_value
+        task.try_set_value(entity_task)
+
+        # Verify task completed successfully with AgentResponse
+        assert task.state == TaskState.SUCCEEDED
+        assert isinstance(task.result, AgentResponse)
+        assert task.result.text == "Test response"
+
+    def test_try_set_value_failure(self) -> None:
+        """Test try_set_value correctly handles failed task completion."""
+        entity_task = _create_entity_task()
+        task = AgentTask(entity_task, None, "correlation-id")
+
+        # Simulate failed entity task
+        entity_task.state = TaskState.FAILED
+        entity_task.result = Exception("Entity call failed")
+
+        # Call try_set_value
+        task.try_set_value(entity_task)
+
+        # Verify task failed with the error
+        assert task.state == TaskState.FAILED
+        assert isinstance(task.result, Exception)
+        assert str(task.result) == "Entity call failed"
+
+    def test_try_set_value_with_response_format(self) -> None:
+        """Test try_set_value parses structured output when response_format is provided."""
+        from pydantic import BaseModel
+
+        class TestSchema(BaseModel):
+            answer: str
+
+        entity_task = _create_entity_task()
+        task = AgentTask(entity_task, TestSchema, "correlation-id")
+
+        # Simulate successful entity task with JSON response
+        entity_task.state = TaskState.SUCCEEDED
+        entity_task.result = AgentResponse(
+            messages=[Message(role="assistant", contents=['{"answer": "42"}'])]
+        ).to_dict()
+
+        # Clear pending_tasks to simulate that parent has processed the child
+        task.pending_tasks.clear()
+
+        # Call try_set_value
+        task.try_set_value(entity_task)
+
+        # Verify task completed and value was parsed
+        assert task.state == TaskState.SUCCEEDED
+        assert isinstance(task.result, AgentResponse)
+        assert isinstance(task.result.value, TestSchema)
+        assert task.result.value.answer == "42"
+
+
+class TestAgentFunctionAppGetAgent:
+    """Test suite for AgentFunctionApp.get_agent."""
+
+    def test_get_agent_raises_for_unregistered_agent(self) -> None:
+        """Test get_agent raises ValueError when agent is not registered."""
+        app = _app_with_registered_agents("KnownAgent")
+
+        with pytest.raises(ValueError, match=r"Agent 'MissingAgent' is not registered with this app\."):
+            app.get_agent(Mock(), "MissingAgent")
+
+
+class TestAzureFunctionsFireAndForget:
+    """Test fire-and-forget mode for AzureFunctionsAgentExecutor."""
+
+    def test_fire_and_forget_calls_signal_entity(self, executor_with_uuid: tuple[Any, Mock, str]) -> None:
+        """Verify wait_for_response=False calls signal_entity instead of call_entity."""
+        executor, context, _ = executor_with_uuid
+        context.signal_entity = Mock()
+        context.call_entity = Mock(return_value=_create_entity_task())
+
+        agent = DurableAIAgent(executor, "TestAgent")
+        session = agent.create_session()
+
+        # Run with wait_for_response=False
+        result = agent.run("Test message", session=session, options={"wait_for_response": False})
+
+        # Verify signal_entity was called and call_entity was not
+        assert context.signal_entity.call_count == 1
+        assert context.call_entity.call_count == 0
+
+        # Should still return an AgentTask
+        assert isinstance(result, AgentTask)
+
+    def test_fire_and_forget_returns_completed_task(self, executor_with_uuid: tuple[Any, Mock, str]) -> None:
+        """Verify wait_for_response=False returns pre-completed AgentTask."""
+        executor, context, _ = executor_with_uuid
+        context.signal_entity = Mock()
+
+        agent = DurableAIAgent(executor, "TestAgent")
+        session = agent.create_session()
+
+        result = agent.run("Test message", session=session, options={"wait_for_response": False})
+
+        # Task should be immediately complete
+        assert isinstance(result, AgentTask)
+        assert result.is_completed
+
+    def test_fire_and_forget_returns_acceptance_response(self, executor_with_uuid: tuple[Any, Mock, str]) -> None:
+        """Verify wait_for_response=False returns acceptance response."""
+        executor, context, _ = executor_with_uuid
+        context.signal_entity = Mock()
+
+        agent = DurableAIAgent(executor, "TestAgent")
+        session = agent.create_session()
+
+        result = agent.run("Test message", session=session, options={"wait_for_response": False})
+
+        # Get the result
+        response = result.result
+        assert isinstance(response, AgentResponse)
+        assert len(response.messages) == 1
+        assert response.messages[0].role == "system"
+        # Check message contains key information
+        message_text = response.messages[0].text
+        assert "accepted" in message_text.lower()
+        assert "background" in message_text.lower()
+
+    def test_blocking_mode_still_works(self, executor_with_uuid: tuple[Any, Mock, str]) -> None:
+        """Verify wait_for_response=True uses call_entity as before."""
+        executor, context, _ = executor_with_uuid
+        context.signal_entity = Mock()
+        context.call_entity = Mock(return_value=_create_entity_task())
+
+        agent = DurableAIAgent(executor, "TestAgent")
+        session = agent.create_session()
+
+        result = agent.run("Test message", session=session, options={"wait_for_response": True})
+
+        # Verify call_entity was called and signal_entity was not
+        assert context.call_entity.call_count == 1
+        assert context.signal_entity.call_count == 0
+
+        # Should return an AgentTask
+        assert isinstance(result, AgentTask)
+
+
+class TestAzureFunctionsAgentExecutor:
+    """Tests for AzureFunctionsAgentExecutor."""
+
+    def test_generate_unique_id(self, mock_context_with_uuid: tuple[Mock, str]) -> None:
+        """Test generate_unique_id method returns UUID from orchestration context."""
+        from agent_framework_azurefunctions._orchestration import AzureFunctionsAgentExecutor
+
+        context, _ = mock_context_with_uuid
+        executor = AzureFunctionsAgentExecutor(context)
+
+        # Call generate_unique_id
+        unique_id = executor.generate_unique_id()
+
+        # Verify it returns the UUID from context (as string with dashes)
+        # The UUID is returned in standard format with dashes
+        context.new_uuid.assert_called_once()
+        # Just verify it's a string representation of UUID
+        assert isinstance(unique_id, str)
+        assert len(unique_id) > 0
+
+
+class TestOrchestrationIntegration:
+    """Integration tests for orchestration scenarios."""
+
+    def test_sequential_agent_calls_simulation(self, executor_with_multiple_uuids: tuple[Any, Mock, list[str]]) -> None:
+        """Simulate sequential agent calls in an orchestration."""
+        executor, context, uuid_hexes = executor_with_multiple_uuids
+
+        # Track entity calls
+        entity_calls: list[dict[str, Any]] = []
+
+        def mock_call_entity_side_effect(entity_id: Any, operation: str, input_data: dict[str, Any]) -> TaskBase:
+            entity_calls.append({"entity_id": str(entity_id), "operation": operation, "input": input_data})
+            return _create_entity_task()
+
+        context.call_entity = Mock(side_effect=mock_call_entity_side_effect)
+
+        # Create agent directly with executor (not via app.get_agent)
+        agent = DurableAIAgent(executor, "WriterAgent")
+
+        # Create session
+        session = agent.create_session()
+
+        # First call - returns AgentTask
+        task1 = agent.run("Write something", session=session)
+        assert isinstance(task1, AgentTask)
+
+        # Second call - returns AgentTask
+        task2 = agent.run("Improve: something", session=session)
+        assert isinstance(task2, AgentTask)
+
+        # Verify both calls used the same entity (same session key)
+        assert len(entity_calls) == 2
+        assert entity_calls[0]["entity_id"] == entity_calls[1]["entity_id"]
+        # EntityId format is @dafx-writeragent@<uuid_hex>
+        expected_entity_id = f"@dafx-writeragent@{uuid_hexes[0]}"
+        assert entity_calls[0]["entity_id"] == expected_entity_id
+        # generate_unique_id called 3 times: session + 2 correlation IDs
+        assert executor.generate_unique_id.call_count == 3
+
+    def test_multiple_agents_in_orchestration(self, executor_with_multiple_uuids: tuple[Any, Mock, list[str]]) -> None:
+        """Test using multiple different agents in one orchestration."""
+        executor, context, uuid_hexes = executor_with_multiple_uuids
+
+        entity_calls: list[str] = []
+
+        def mock_call_entity_side_effect(entity_id: Any, operation: str, input_data: dict[str, Any]) -> TaskBase:
+            entity_calls.append(str(entity_id))
+            return _create_entity_task()
+
+        context.call_entity = Mock(side_effect=mock_call_entity_side_effect)
+
+        # Create agents directly with executor (not via app.get_agent)
+        writer = DurableAIAgent(executor, "WriterAgent")
+        editor = DurableAIAgent(executor, "EditorAgent")
+
+        writer_session = writer.create_session()
+        editor_session = editor.create_session()
+
+        # Call both agents - returns AgentTasks
+        writer_task = writer.run("Write", session=writer_session)
+        editor_task = editor.run("Edit", session=editor_session)
+
+        assert isinstance(writer_task, AgentTask)
+        assert isinstance(editor_task, AgentTask)
+
+        # Verify different entity IDs were used
+        assert len(entity_calls) == 2
+        # EntityId format is @dafx-agentname@uuid_hex (lowercased agent name with dafx- prefix)
+        expected_writer_id = f"@dafx-writeragent@{uuid_hexes[0]}"
+        expected_editor_id = f"@dafx-editoragent@{uuid_hexes[1]}"
+        assert entity_calls[0] == expected_writer_id
+        assert entity_calls[1] == expected_editor_id
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v", "--tb=short"])

--- a/python/packages/azurefunctions/tests/test_routes.py
+++ b/python/packages/azurefunctions/tests/test_routes.py
@@ -1,0 +1,128 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+"""Unit tests for the shared route-prefix resolution and HITL URL builders."""
+
+# pyright: reportPrivateUsage=false
+
+import json
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from agent_framework_azurefunctions import _routes
+
+SCRIPT_ROOT_ENV = "AzureWebJobsScriptRoot"
+
+
+@pytest.fixture(autouse=True)
+def _reset_prefix_cache() -> Iterator[None]:
+    """Keep the route-prefix cache from leaking across tests."""
+    _routes.route_prefix.cache_clear()
+    yield
+    _routes.route_prefix.cache_clear()
+
+
+def _write_host_json(directory: Path, config: dict[str, Any]) -> None:
+    (directory / "host.json").write_text(json.dumps(config), encoding="utf-8")
+
+
+class TestRoutePrefix:
+    """Resolving ``extensions.http.routePrefix`` from host.json, with an ``api`` default."""
+
+    def test_defaults_to_api_without_host_json(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(SCRIPT_ROOT_ENV, str(tmp_path))
+        assert _routes.route_prefix() == "api"
+
+    def test_defaults_to_api_when_prefix_absent(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        _write_host_json(tmp_path, {"version": "2.0", "extensions": {"http": {}}})
+        monkeypatch.setenv(SCRIPT_ROOT_ENV, str(tmp_path))
+        assert _routes.route_prefix() == "api"
+
+    def test_reads_custom_prefix(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        _write_host_json(tmp_path, {"extensions": {"http": {"routePrefix": "gateway"}}})
+        monkeypatch.setenv(SCRIPT_ROOT_ENV, str(tmp_path))
+        assert _routes.route_prefix() == "gateway"
+
+    def test_reads_empty_prefix(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        _write_host_json(tmp_path, {"extensions": {"http": {"routePrefix": ""}}})
+        monkeypatch.setenv(SCRIPT_ROOT_ENV, str(tmp_path))
+        assert _routes.route_prefix() == ""
+
+    def test_strips_surrounding_slashes(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        _write_host_json(tmp_path, {"extensions": {"http": {"routePrefix": "/custom/"}}})
+        monkeypatch.setenv(SCRIPT_ROOT_ENV, str(tmp_path))
+        assert _routes.route_prefix() == "custom"
+
+    def test_defaults_to_api_on_malformed_json(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        (tmp_path / "host.json").write_text("{ not json", encoding="utf-8")
+        monkeypatch.setenv(SCRIPT_ROOT_ENV, str(tmp_path))
+        assert _routes.route_prefix() == "api"
+
+    def test_caches_first_read(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        _write_host_json(tmp_path, {"extensions": {"http": {"routePrefix": "one"}}})
+        monkeypatch.setenv(SCRIPT_ROOT_ENV, str(tmp_path))
+        assert _routes.route_prefix() == "one"
+        # A later host.json change is not observed within a running host.
+        _write_host_json(tmp_path, {"extensions": {"http": {"routePrefix": "two"}}})
+        assert _routes.route_prefix() == "one"
+
+
+class TestUrlBuilders:
+    """Respond/status URL shapes, parameterized by an explicit prefix."""
+
+    def test_respond_url_default_prefix(self) -> None:
+        assert (
+            _routes.build_workflow_respond_url("https://h", "wf", "i", "r", prefix="api")
+            == "https://h/api/workflow/wf/respond/i/r"
+        )
+
+    def test_respond_url_custom_prefix(self) -> None:
+        assert (
+            _routes.build_workflow_respond_url("https://h", "wf", "i", "r", prefix="gw")
+            == "https://h/gw/workflow/wf/respond/i/r"
+        )
+
+    def test_respond_url_empty_prefix(self) -> None:
+        assert (
+            _routes.build_workflow_respond_url("https://h", "wf", "i", "r", prefix="")
+            == "https://h/workflow/wf/respond/i/r"
+        )
+
+    def test_respond_url_template_placeholder(self) -> None:
+        assert (
+            _routes.build_workflow_respond_url("https://h", "wf", "i", "{requestId}", prefix="api")
+            == "https://h/api/workflow/wf/respond/i/{requestId}"
+        )
+
+    def test_status_url_custom_prefix(self) -> None:
+        assert (
+            _routes.build_workflow_status_url("https://h", "wf", "i", prefix="gw")
+            == "https://h/gw/workflow/wf/status/i"
+        )
+
+    def test_status_url_empty_prefix(self) -> None:
+        assert _routes.build_workflow_status_url("https://h", "wf", "i", prefix="") == "https://h/workflow/wf/status/i"
+
+
+class TestSplitRequestUrl:
+    """Deriving base URL and route prefix from an incoming request URL."""
+
+    def test_default_prefix(self) -> None:
+        assert _routes.split_request_url("https://h:7071/api/workflow/wf/run") == ("https://h:7071", "api")
+
+    def test_custom_prefix(self) -> None:
+        assert _routes.split_request_url("https://h/gw/workflow/wf/status/i") == ("https://h", "gw")
+
+    def test_empty_prefix(self) -> None:
+        assert _routes.split_request_url("https://h/workflow/wf/run") == ("https://h", "")
+
+    def test_multi_segment_prefix(self) -> None:
+        assert _routes.split_request_url("https://h/a/b/workflow/wf/run") == ("https://h", "a/b")
+
+    def test_no_workflow_segment(self) -> None:
+        assert _routes.split_request_url("https://h/api/health") == ("https://h", "")
+
+    def test_non_absolute_falls_back(self) -> None:
+        assert _routes.split_request_url("/api/workflow/wf/run") == ("/api/workflow/wf/run", "")

--- a/python/packages/azurefunctions/tests/test_workflow.py
+++ b/python/packages/azurefunctions/tests/test_workflow.py
@@ -1,0 +1,328 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+"""Unit tests for workflow orchestration functions."""
+
+import json
+from dataclasses import dataclass
+from typing import Any
+
+from agent_framework import (
+    AgentExecutorRequest,
+    AgentExecutorResponse,
+    AgentResponse,
+    Message,
+)
+from agent_framework._workflows._edge import (
+    FanInEdgeGroup,
+    FanOutEdgeGroup,
+    SingleEdgeGroup,
+    SwitchCaseEdgeGroup,
+    SwitchCaseEdgeGroupCase,
+    SwitchCaseEdgeGroupDefault,
+)
+
+from agent_framework_azurefunctions._workflow import (
+    _extract_message_content,
+    build_agent_executor_response,
+    route_message_through_edge_groups,
+)
+
+
+class TestRouteMessageThroughEdgeGroups:
+    """Test suite for route_message_through_edge_groups function."""
+
+    def test_single_edge_group_routes_when_condition_matches(self) -> None:
+        """Test SingleEdgeGroup routes when condition is satisfied."""
+        group = SingleEdgeGroup(source_id="src", target_id="tgt", condition=lambda m: True)
+
+        targets = route_message_through_edge_groups([group], "src", "any message")
+
+        assert targets == ["tgt"]
+
+    def test_single_edge_group_does_not_route_when_condition_fails(self) -> None:
+        """Test SingleEdgeGroup does not route when condition fails."""
+        group = SingleEdgeGroup(source_id="src", target_id="tgt", condition=lambda m: False)
+
+        targets = route_message_through_edge_groups([group], "src", "any message")
+
+        assert targets == []
+
+    def test_single_edge_group_ignores_different_source(self) -> None:
+        """Test SingleEdgeGroup ignores messages from different sources."""
+        group = SingleEdgeGroup(source_id="src", target_id="tgt", condition=lambda m: True)
+
+        targets = route_message_through_edge_groups([group], "other_src", "any message")
+
+        assert targets == []
+
+    def test_switch_case_with_selection_func(self) -> None:
+        """Test SwitchCaseEdgeGroup uses selection_func."""
+
+        def select_first_target(msg: Any, targets: list[str]) -> list[str]:
+            return [targets[0]]
+
+        group = SwitchCaseEdgeGroup(
+            source_id="src",
+            cases=[
+                SwitchCaseEdgeGroupCase(condition=lambda m: True, target_id="target_a"),
+                SwitchCaseEdgeGroupDefault(target_id="target_b"),
+            ],
+        )
+        # Manually set the selection function
+        group._selection_func = select_first_target
+
+        targets = route_message_through_edge_groups([group], "src", "test")
+
+        assert targets == ["target_a"]
+
+    def test_switch_case_without_selection_func_broadcasts(self) -> None:
+        """Test SwitchCaseEdgeGroup without selection_func broadcasts to all."""
+        group = SwitchCaseEdgeGroup(
+            source_id="src",
+            cases=[
+                SwitchCaseEdgeGroupCase(condition=lambda m: True, target_id="target_a"),
+                SwitchCaseEdgeGroupDefault(target_id="target_b"),
+            ],
+        )
+        group._selection_func = None
+
+        targets = route_message_through_edge_groups([group], "src", "test")
+
+        assert set(targets) == {"target_a", "target_b"}
+
+    def test_fan_out_with_selection_func(self) -> None:
+        """Test FanOutEdgeGroup uses selection_func."""
+
+        def select_all(msg: Any, targets: list[str]) -> list[str]:
+            return targets
+
+        group = FanOutEdgeGroup(
+            source_id="src",
+            target_ids=["fan_a", "fan_b", "fan_c"],
+            selection_func=select_all,
+        )
+
+        targets = route_message_through_edge_groups([group], "src", "broadcast")
+
+        assert set(targets) == {"fan_a", "fan_b", "fan_c"}
+
+    def test_fan_in_is_not_routed_directly(self) -> None:
+        """Test FanInEdgeGroup is handled separately (not routed here)."""
+        group = FanInEdgeGroup(
+            source_ids=["src_a", "src_b"],
+            target_id="aggregator",
+        )
+
+        # Fan-in should not add targets through this function
+        targets = route_message_through_edge_groups([group], "src_a", "message")
+
+        assert targets == []
+
+    def test_multiple_edge_groups_aggregated(self) -> None:
+        """Test that targets from multiple edge groups are aggregated."""
+        group1 = SingleEdgeGroup(source_id="src", target_id="t1", condition=lambda m: True)
+        group2 = SingleEdgeGroup(source_id="src", target_id="t2", condition=lambda m: True)
+
+        targets = route_message_through_edge_groups([group1, group2], "src", "msg")
+
+        assert set(targets) == {"t1", "t2"}
+
+
+class TestBuildAgentExecutorResponse:
+    """Test suite for build_agent_executor_response function."""
+
+    def test_builds_response_with_text(self) -> None:
+        """Test building response with plain text."""
+        response = build_agent_executor_response(
+            executor_id="my_executor",
+            response_text="Hello, world!",
+            structured_response=None,
+            previous_message="User input",
+        )
+
+        assert response.executor_id == "my_executor"
+        assert response.agent_response.text == "Hello, world!"
+        assert len(response.full_conversation) == 2  # User + Assistant
+
+    def test_builds_response_with_structured_response(self) -> None:
+        """Test building response with structured JSON response."""
+        structured = {"answer": 42, "reason": "because"}
+
+        response = build_agent_executor_response(
+            executor_id="calc",
+            response_text="Original text",
+            structured_response=structured,
+            previous_message="Calculate",
+        )
+
+        # Structured response overrides text
+        assert response.agent_response.text == json.dumps(structured)
+
+    def test_conversation_includes_previous_string_message(self) -> None:
+        """Test that string previous_message is included in conversation."""
+        response = build_agent_executor_response(
+            executor_id="exec",
+            response_text="Response",
+            structured_response=None,
+            previous_message="User said this",
+        )
+
+        assert len(response.full_conversation) == 2
+        assert response.full_conversation[0].role == "user"
+        assert response.full_conversation[0].text == "User said this"
+        assert response.full_conversation[1].role == "assistant"
+
+    def test_conversation_extends_previous_agent_executor_response(self) -> None:
+        """Test that previous AgentExecutorResponse's conversation is extended."""
+        # Create a previous response with conversation history
+        previous = AgentExecutorResponse(
+            executor_id="prev",
+            agent_response=AgentResponse(messages=[Message(role="assistant", contents=["Previous"])]),
+            full_conversation=[
+                Message(role="user", contents=["First"]),
+                Message(role="assistant", contents=["Previous"]),
+            ],
+        )
+
+        response = build_agent_executor_response(
+            executor_id="current",
+            response_text="Current response",
+            structured_response=None,
+            previous_message=previous,
+        )
+
+        # Should have 3 messages: First + Previous + Current
+        assert len(response.full_conversation) == 3
+        assert response.full_conversation[0].text == "First"
+        assert response.full_conversation[1].text == "Previous"
+        assert response.full_conversation[2].text == "Current response"
+
+
+class TestExtractMessageContent:
+    """Test suite for _extract_message_content function."""
+
+    def test_extract_from_string(self) -> None:
+        """Test extracting content from plain string."""
+        result = _extract_message_content("Hello, world!")
+
+        assert result == "Hello, world!"
+
+    def test_extract_from_agent_executor_response_with_text(self) -> None:
+        """Test extracting from AgentExecutorResponse with text."""
+        response = AgentExecutorResponse(
+            executor_id="exec",
+            agent_response=AgentResponse(messages=[Message(role="assistant", contents=["Response text"])]),
+            full_conversation=[Message(role="assistant", contents=["Response text"])],
+        )
+
+        result = _extract_message_content(response)
+
+        assert result == "Response text"
+
+    def test_extract_from_agent_executor_response_with_messages(self) -> None:
+        """Test extracting from AgentExecutorResponse with messages."""
+        response = AgentExecutorResponse(
+            executor_id="exec",
+            agent_response=AgentResponse(
+                messages=[
+                    Message(role="user", contents=["First"]),
+                    Message(role="assistant", contents=["Last message"]),
+                ]
+            ),
+            full_conversation=[
+                Message(role="user", contents=["First"]),
+                Message(role="assistant", contents=["Last message"]),
+            ],
+        )
+
+        result = _extract_message_content(response)
+
+        # AgentResponse.text concatenates all message texts
+        assert result == "FirstLast message"
+
+    def test_extract_from_agent_executor_request(self) -> None:
+        """Test extracting from AgentExecutorRequest."""
+        request = AgentExecutorRequest(
+            messages=[
+                Message(role="user", contents=["First"]),
+                Message(role="user", contents=["Last request"]),
+            ]
+        )
+
+        result = _extract_message_content(request)
+
+        assert result == "Last request"
+
+    def test_extract_from_dict_returns_empty(self) -> None:
+        """Test that dict messages return empty string (unexpected input)."""
+        msg_dict = {"messages": [{"text": "Hello"}]}
+
+        result = _extract_message_content(msg_dict)
+
+        assert result == ""
+
+    def test_extract_returns_empty_for_unknown_type(self) -> None:
+        """Test that unknown types return empty string."""
+        result = _extract_message_content(12345)
+
+        assert result == ""
+
+
+class TestEdgeGroupIntegration:
+    """Integration tests for edge group routing with realistic scenarios."""
+
+    def test_conditional_routing_by_message_type(self) -> None:
+        """Test routing based on message content/type."""
+
+        @dataclass
+        class SpamResult:
+            is_spam: bool
+            reason: str
+
+        def is_spam_condition(msg: Any) -> bool:
+            if isinstance(msg, SpamResult):
+                return msg.is_spam
+            return False
+
+        def is_not_spam_condition(msg: Any) -> bool:
+            if isinstance(msg, SpamResult):
+                return not msg.is_spam
+            return False
+
+        spam_group = SingleEdgeGroup(
+            source_id="detector",
+            target_id="spam_handler",
+            condition=is_spam_condition,
+        )
+        legit_group = SingleEdgeGroup(
+            source_id="detector",
+            target_id="email_handler",
+            condition=is_not_spam_condition,
+        )
+
+        # Test spam message
+        spam_msg = SpamResult(is_spam=True, reason="Suspicious content")
+        targets = route_message_through_edge_groups([spam_group, legit_group], "detector", spam_msg)
+        assert targets == ["spam_handler"]
+
+        # Test legitimate message
+        legit_msg = SpamResult(is_spam=False, reason="Clean")
+        targets = route_message_through_edge_groups([spam_group, legit_group], "detector", legit_msg)
+        assert targets == ["email_handler"]
+
+    def test_fan_out_to_multiple_workers(self) -> None:
+        """Test fan-out to multiple parallel workers."""
+
+        def select_all_workers(msg: Any, targets: list[str]) -> list[str]:
+            return targets
+
+        group = FanOutEdgeGroup(
+            source_id="coordinator",
+            target_ids=["worker_1", "worker_2", "worker_3"],
+            selection_func=select_all_workers,
+        )
+
+        targets = route_message_through_edge_groups([group], "coordinator", {"task": "process"})
+
+        assert len(targets) == 3
+        assert set(targets) == {"worker_1", "worker_2", "worker_3"}

--- a/python/packages/durabletask/agent_framework_durabletask/_worker.py
+++ b/python/packages/durabletask/agent_framework_durabletask/_worker.py
@@ -10,7 +10,7 @@ as durable orchestrations with automatically generated activity functions.
 from __future__ import annotations
 
 import logging
-from typing import Any, cast
+from typing import Any
 
 from agent_framework import SupportsAgentRun, Workflow
 from durabletask.task import ActivityContext, OrchestrationContext
@@ -157,7 +157,7 @@ class DurableAIAgentWorker:
             The worker will block until stopped.
         """
         logger.info("[DurableAIAgentWorker] Starting worker with %d registered agents", len(self._registered_agents))
-        cast(Any, self._worker).start()
+        self._worker.start()
 
     def stop(self) -> None:
         """Stop the worker gracefully.
@@ -166,7 +166,7 @@ class DurableAIAgentWorker:
             This method delegates to the underlying worker's stop method.
         """
         logger.info("[DurableAIAgentWorker] Stopping worker")
-        cast(Any, self._worker).stop()
+        self._worker.stop()
 
     @property
     def registered_agent_names(self) -> list[str]:

--- a/python/packages/durabletask/agent_framework_durabletask/_workflows/activity.py
+++ b/python/packages/durabletask/agent_framework_durabletask/_workflows/activity.py
@@ -67,6 +67,10 @@ def execute_workflow_activity(executor: Executor, input_json: str, workflow: Wor
     # omitted, so coerce None to the appropriate empty default.
     shared_state_snapshot: dict[str, Any] = data.get("shared_state_snapshot") or {}
     source_executor_ids = cast(list[str], data.get("source_executor_ids") or [SOURCE_ORCHESTRATOR])
+    # Orchestration metadata the orchestrator attaches when dispatching this activity
+    # (instance_id, workflow_name). Absent for in-process / legacy inputs, so default
+    # to None and surface it on the runner context for executors that want it.
+    host_context = cast("dict[str, Any] | None", data.get("host_context"))
 
     # Reconstruct the message - deserialize_value restores the original typed
     # objects from the encoded data (with type markers).
@@ -89,6 +93,7 @@ def execute_workflow_activity(executor: Executor, input_json: str, workflow: Wor
     async def _run() -> dict[str, Any]:
         runner_context = CapturingRunnerContext()
         runner_context.set_yield_output_classifier(classify_yielded_output)
+        runner_context.set_host_metadata(host_context)
         shared_state = State()
 
         # Deserialize shared state values to reconstruct dataclasses / Pydantic models.
@@ -101,11 +106,11 @@ def execute_workflow_activity(executor: Executor, input_json: str, workflow: Wor
         shared_state.import_state(deserialized_state)
 
         if is_hitl_response:
-            if not isinstance(message_data, dict):
+            if not isinstance(message, dict):
                 raise ValueError("HITL message payload must be a JSON object")
             await execute_hitl_response_handler(
                 executor=executor,
-                hitl_message=cast(dict[str, Any], message_data),
+                hitl_message=cast(dict[str, Any], message),
                 shared_state=shared_state,
                 runner_context=runner_context,
             )

--- a/python/packages/durabletask/agent_framework_durabletask/_workflows/client.py
+++ b/python/packages/durabletask/agent_framework_durabletask/_workflows/client.py
@@ -417,7 +417,7 @@ class DurableWorkflowClient:
         subworkflows = status_dict.get("subworkflows")
         if isinstance(subworkflows, dict):
             for executor_id, child_ids in cast(dict[str, Any], subworkflows).items():
-                children: list[Any] = child_ids if isinstance(child_ids, list) else []
+                children: list[Any] = cast("list[Any]", child_ids) if isinstance(child_ids, list) else []
                 for ordinal, child_instance_id in enumerate(children):
                     if not isinstance(child_instance_id, str):
                         continue
@@ -520,7 +520,7 @@ class DurableWorkflowClient:
         children_raw = cast(dict[str, Any], subworkflows).get(executor_id)
         if not isinstance(children_raw, list):
             return None
-        children = children_raw
+        children = cast("list[Any]", children_raw)
         if ordinal < 0 or ordinal >= len(children):
             return None
         child = children[ordinal]

--- a/python/packages/durabletask/agent_framework_durabletask/_workflows/orchestrator.py
+++ b/python/packages/durabletask/agent_framework_durabletask/_workflows/orchestrator.py
@@ -50,8 +50,19 @@ from agent_framework._workflows._edge import (
 from agent_framework._workflows._state import State
 
 from .context import WorkflowOrchestrationContext
-from .naming import workflow_executor_activity_name, workflow_orchestrator_name, workflow_scoped_executor_id
+from .naming import (
+    qualify_subworkflow_request_id,
+    workflow_executor_activity_name,
+    workflow_orchestrator_name,
+    workflow_scoped_executor_id,
+)
+from .runner_context import (
+    HOST_METADATA_INSTANCE_ID,
+    HOST_METADATA_REQUEST_PATH_PREFIX,
+    HOST_METADATA_WORKFLOW_NAME,
+)
 from .serialization import (
+    SUBWORKFLOW_ADDRESS_KEY,
     SUBWORKFLOW_INPUT_KEY,
     SUBWORKFLOW_RESULT_KEY,
     deserialize_value,
@@ -261,6 +272,7 @@ def _prepare_activity_task(
     source_executor_id: str,
     shared_state_snapshot: dict[str, Any] | None,
     workflow_name: str,
+    address: dict[str, str],
 ) -> Any:
     """Prepare an activity task for execution via the context adapter.
 
@@ -273,6 +285,17 @@ def _prepare_activity_task(
         "message": serialize_value(message),
         "shared_state_snapshot": shared_state_snapshot,
         "source_executor_ids": [source_executor_id],
+        # host_context addresses the *root* (HTTP-routable) orchestration so an executor
+        # can build a HITL respond URL (see CapturingRunnerContext.host_metadata):
+        # instance_id / workflow_name name the top-level instance, and
+        # request_path_prefix is the accumulated ``{executor}~{ordinal}~`` hops from the
+        # root down to this workflow level. For a top-level workflow the prefix is empty,
+        # so this reduces to addressing the instance directly.
+        "host_context": {
+            HOST_METADATA_INSTANCE_ID: address["root_instance_id"],
+            HOST_METADATA_WORKFLOW_NAME: address["root_workflow_name"],
+            HOST_METADATA_REQUEST_PATH_PREFIX: address["request_path_prefix"],
+        },
     }
     activity_input_json = json.dumps(activity_input)
     activity_name = workflow_executor_activity_name(workflow_name, executor_id)
@@ -284,16 +307,23 @@ def _prepare_subworkflow_task(
     executor: WorkflowExecutor,
     message: Any,
     child_instance_id: str,
+    child_address: dict[str, str],
 ) -> Any:
     """Prepare a child-orchestration task that runs a ``WorkflowExecutor``'s inner workflow.
 
     The inner workflow runs as its own durable orchestration (``dafx-{innerName}``),
     so its executors are independently durable/observable. The node's message is
     serialized and wrapped in a marker so the child orchestrator reconstructs the
-    original typed object (trusted internal input).
+    original typed object (trusted internal input). A sibling address marker carries
+    the root instance / workflow name and this child's request-path prefix, so an
+    executor inside the child can build a respond URL that targets the top-level
+    instance with a qualified request id.
     """
     inner_orchestration_name = workflow_orchestrator_name(executor.workflow.name)
-    child_input = {SUBWORKFLOW_INPUT_KEY: serialize_value(message)}
+    child_input = {
+        SUBWORKFLOW_INPUT_KEY: serialize_value(message),
+        SUBWORKFLOW_ADDRESS_KEY: child_address,
+    }
     return ctx.call_sub_orchestrator(inner_orchestration_name, child_input, instance_id=child_instance_id)
 
 
@@ -378,12 +408,12 @@ def _unpack_subworkflow_result(child_result: Any) -> tuple[list[Any], list[dict[
         envelope = cast("dict[str, Any]", child_result)
         if envelope.get(SUBWORKFLOW_RESULT_KEY):
             raw_outputs = envelope.get("outputs")
-            outputs = raw_outputs if isinstance(raw_outputs, list) else []
+            outputs = cast("list[Any]", raw_outputs) if isinstance(raw_outputs, list) else []
             raw_events = envelope.get("events")
             events = cast("list[dict[str, Any]]", raw_events) if isinstance(raw_events, list) else []
             return outputs, events
     if isinstance(child_result, list):
-        return child_result, []
+        return cast("list[Any]", child_result), []
     if child_result is None:
         return [], []
     return [child_result], []
@@ -637,6 +667,46 @@ def _try_unwrap_subworkflow_input(raw_value: Any) -> tuple[bool, Any]:
     return False, None
 
 
+def _resolve_workflow_address(initial_message: Any, instance_id: str, workflow_name: str) -> dict[str, str]:
+    """Resolve this orchestration's HITL address context.
+
+    Returns ``{root_instance_id, root_workflow_name, request_path_prefix}`` -- the
+    values an executor needs to build a respond URL that targets the addressable
+    top-level instance with a (possibly qualified) request id:
+
+    * A **child** orchestration receives its address from the parent in the
+      :data:`SUBWORKFLOW_ADDRESS_KEY` marker (the root instance/workflow plus the
+      ``{executor}~{ordinal}~`` path prefix down to this level), since its own
+      ``ctx.instance_id`` is a non-addressable child id.
+    * A **top-level** workflow has no such marker (it is stripped from untrusted input
+      at the host boundary by :func:`strip_subworkflow_markers`), so it is its own root
+      with an empty prefix.
+    """
+    if isinstance(initial_message, dict):
+        marker = cast("dict[str, Any]", initial_message)
+        addr = marker.get(SUBWORKFLOW_ADDRESS_KEY)
+        if isinstance(addr, dict):
+            typed = cast("dict[str, Any]", addr)
+            root_instance_id = typed.get("root_instance_id")
+            root_workflow_name = typed.get("root_workflow_name")
+            request_path_prefix = typed.get("request_path_prefix")
+            if (
+                isinstance(root_instance_id, str)
+                and isinstance(root_workflow_name, str)
+                and isinstance(request_path_prefix, str)
+            ):
+                return {
+                    "root_instance_id": root_instance_id,
+                    "root_workflow_name": root_workflow_name,
+                    "request_path_prefix": request_path_prefix,
+                }
+    return {
+        "root_instance_id": instance_id,
+        "root_workflow_name": workflow_name,
+        "request_path_prefix": "",
+    }
+
+
 def _coerce_initial_input(workflow: Workflow, raw_value: Any) -> Any:
     """Coerce the client's initial workflow input to the start executor's type.
 
@@ -779,6 +849,7 @@ def _prepare_all_tasks(
     pending_messages: dict[str, list[tuple[Any, str]]],
     shared_state: dict[str, Any] | None,
     subworkflow_counter: list[int],
+    address: dict[str, str],
 ) -> tuple[list[Any], list[TaskMetadata], list[tuple[str, Any, str]]]:
     """Prepare all pending tasks for parallel execution.
 
@@ -797,6 +868,10 @@ def _prepare_all_tasks(
         shared_state: Optional dict for cross-executor state sharing.
         subworkflow_counter: A single-element mutable counter, persistent across
             supersteps, used to derive unique deterministic child instance ids.
+        address: This orchestration's HITL address context
+            (``{root_instance_id, root_workflow_name, request_path_prefix}``). Surfaced
+            to activity executors via ``host_context`` and extended by one
+            ``{executor}~{ordinal}~`` hop for each dispatched sub-workflow child.
     """
     all_tasks: list[Any] = []
     task_metadata_list: list[TaskMetadata] = []
@@ -804,22 +879,42 @@ def _prepare_all_tasks(
 
     agent_messages_by_executor: dict[str, list[tuple[str, Any, str]]] = defaultdict(list)
 
+    # Per-executor, per-superstep ordinal for sub-workflow dispatch. This must match the
+    # read side's enumerate() index into the custom-status ``subworkflows[executorId]``
+    # list (built in this same dispatch order), so a nested pending request resolves
+    # back to the right child. It is deliberately distinct from ``subworkflow_counter``
+    # (a global, cross-superstep counter that only guarantees child-instance-id
+    # uniqueness, not addressing position).
+    per_executor_sub_ordinal: dict[str, int] = defaultdict(int)
+
     for executor_id, messages_with_sources in pending_messages.items():
         executor = workflow.executors[executor_id]
         is_agent = isinstance(executor, AgentExecutor)
+        is_subworkflow = isinstance(executor, WorkflowExecutor)
 
         for message, source_executor_id in messages_with_sources:
             if is_agent:
                 agent_messages_by_executor[executor_id].append((executor_id, message, source_executor_id))
-            elif isinstance(executor, WorkflowExecutor):
+            elif is_subworkflow:
                 # Derive a deterministic, globally-unique child instance id. The counter
                 # persists across supersteps, so two invocations of the same node (in the
                 # same or different supersteps, e.g. fan-out) never collide, and the ids
                 # are stable across orchestration replay.
                 child_instance_id = f"{ctx.instance_id}::{executor_id}::{subworkflow_counter[0]}"
                 subworkflow_counter[0] += 1
+                # Extend this orchestration's request-path prefix by one hop
+                # (``{executor}~{ordinal}~``) so an executor inside the child builds a
+                # respond URL qualified all the way back to the root instance.
+                ordinal = per_executor_sub_ordinal[executor_id]
+                per_executor_sub_ordinal[executor_id] += 1
+                child_address = {
+                    "root_instance_id": address["root_instance_id"],
+                    "root_workflow_name": address["root_workflow_name"],
+                    "request_path_prefix": address["request_path_prefix"]
+                    + qualify_subworkflow_request_id(executor_id, ordinal, ""),
+                }
                 logger.debug("Preparing sub-workflow task: %s -> %s", executor_id, child_instance_id)
-                task = _prepare_subworkflow_task(ctx, executor, message, child_instance_id)
+                task = _prepare_subworkflow_task(ctx, executor, message, child_instance_id, child_address)
                 all_tasks.append(task)
                 task_metadata_list.append(
                     TaskMetadata(
@@ -833,7 +928,7 @@ def _prepare_all_tasks(
             else:
                 logger.debug("Preparing activity task: %s", executor_id)
                 task = _prepare_activity_task(
-                    ctx, executor_id, message, source_executor_id, shared_state, workflow.name
+                    ctx, executor_id, message, source_executor_id, shared_state, workflow.name, address
                 )
                 all_tasks.append(task)
                 task_metadata_list.append(
@@ -864,6 +959,24 @@ def _prepare_all_tasks(
         remaining_agent_messages.extend(remaining)
 
     return all_tasks, task_metadata_list, remaining_agent_messages
+
+
+def _index_subworkflows(task_metadata_list: list[TaskMetadata]) -> dict[str, list[str]]:
+    """Group dispatched sub-workflow child instance ids by executor id, in dispatch order.
+
+    This is the read-side addressing map the parent publishes to its custom status so the
+    status/respond endpoints can resolve a nested pending request: a request qualified as
+    ``{executorId}~{ordinal}~{bare}`` maps to ``subworkflows[executorId][ordinal]``. That
+    ordinal is the child's position in this list, which must equal the write-side ordinal
+    :func:`_prepare_all_tasks` stamps into the child's request-path prefix. Both derive from
+    the same ``task_metadata_list`` order, so building the map here in one place keeps the
+    two sides from drifting (guarded by ``test_readside_index_matches_dispatch_ordinal``).
+    """
+    subworkflows: dict[str, list[str]] = {}
+    for meta in task_metadata_list:
+        if meta.task_type == TaskType.SUBWORKFLOW and meta.child_instance_id is not None:
+            subworkflows.setdefault(meta.executor_id, []).append(meta.child_instance_id)
+    return subworkflows
 
 
 # ============================================================================
@@ -917,6 +1030,13 @@ def run_workflow_orchestrator(
     # outputs and the inner event timeline. A top-level run returns a bare list, so the
     # external client output path is unchanged.
     is_subworkflow = isinstance(initial_message, dict) and SUBWORKFLOW_INPUT_KEY in initial_message
+
+    # Resolve the HITL address context once: a child orchestration inherits the root
+    # instance/workflow + path prefix from the parent's address marker; a top-level
+    # workflow is its own root with an empty prefix. Threaded into task dispatch so an
+    # executor at any depth can build a respond URL targeting the addressable top-level
+    # instance.
+    workflow_address = _resolve_workflow_address(initial_message, ctx.instance_id, workflow.name)
 
     # Monotonic, replay-stable counter for deriving child orchestration instance ids;
     # persists across supersteps so repeated sub-workflow invocations never collide.
@@ -991,7 +1111,7 @@ def run_workflow_orchestrator(
 
         # Phase 1: Prepare all tasks
         all_tasks, task_metadata_list, remaining_agent_messages = _prepare_all_tasks(
-            ctx, workflow, pending_messages, shared_state, subworkflow_counter
+            ctx, workflow, pending_messages, shared_state, subworkflow_counter, workflow_address
         )
 
         # Agents and sub-workflows bypass the per-executor activity, so synthesize their
@@ -1009,15 +1129,10 @@ def run_workflow_orchestrator(
             logger.debug("Executing %d tasks in parallel (agents + activities)", len(all_tasks))
             # Record dispatched sub-workflow child instance ids before suspending in
             # task_all. While a nested sub-workflow waits for human input, this parent
-            # stays suspended here, so its custom status must already carry the child
-            # ids for the read side to discover and qualify nested pending requests.
-            # Grouped as {executorId: [childInstanceId, ...]} in dispatch order so a
-            # node that dispatches several children this superstep keeps each one
-            # addressable by its ordinal.
-            active_subworkflows: dict[str, list[str]] = {}
-            for meta in task_metadata_list:
-                if meta.task_type == TaskType.SUBWORKFLOW and meta.child_instance_id is not None:
-                    active_subworkflows.setdefault(meta.executor_id, []).append(meta.child_instance_id)
+            # stays suspended here, so its custom status must already carry the child ids
+            # for the read side to discover and qualify nested pending requests (see
+            # _index_subworkflows for the dispatch-order / ordinal addressing contract).
+            active_subworkflows = _index_subworkflows(task_metadata_list)
             if active_subworkflows:
                 publish_live_status("running", subworkflows=active_subworkflows)
             raw_results = yield ctx.task_all(all_tasks)

--- a/python/packages/durabletask/agent_framework_durabletask/_workflows/serialization.py
+++ b/python/packages/durabletask/agent_framework_durabletask/_workflows/serialization.py
@@ -101,7 +101,8 @@ def strip_pickle_markers(data: Any) -> Any:
         return {k: strip_pickle_markers(v) for k, v in typed_dict.items()}
 
     if isinstance(data, list):
-        return [strip_pickle_markers(item) for item in data]
+        typed_list = cast(list[Any], data)
+        return [strip_pickle_markers(item) for item in typed_list]
 
     return data
 
@@ -124,9 +125,18 @@ SUBWORKFLOW_INPUT_KEY = "__subworkflow_input__"
 # is unchanged. See ``orchestrator._process_subworkflow_result``.
 SUBWORKFLOW_RESULT_KEY = "__subworkflow_result__"
 
+# Alongside the input envelope, the parent passes the child its HITL *address* context
+# (the addressable root instance id, the root workflow name, and the accumulated
+# request-path prefix). This lets an executor inside a nested child build a respond URL
+# that targets the top-level instance with a qualified request id, without the child
+# knowing how its parent refers to it. Like SUBWORKFLOW_INPUT_KEY this is trusted
+# internal data (only call_sub_orchestrator sets it, post trust boundary), so it must
+# be stripped from untrusted top-level input (see strip_subworkflow_markers).
+SUBWORKFLOW_ADDRESS_KEY = "__subworkflow_address__"
+
 
 def strip_subworkflow_markers(data: Any) -> Any:
-    """Remove the reserved sub-workflow envelope key from untrusted top-level input.
+    """Remove the reserved sub-workflow envelope keys from untrusted top-level input.
 
     The orchestrator treats a top-level input dict carrying :data:`SUBWORKFLOW_INPUT_KEY`
     as a *trusted* child-orchestration payload and reconstructs it with
@@ -134,22 +144,25 @@ def strip_subworkflow_markers(data: Any) -> Any:
     :func:`strip_pickle_markers` sanitization, because a genuine envelope is only ever
     built internally (post trust boundary) by ``call_sub_orchestrator``. If untrusted
     client input could carry that key, an attacker could smuggle a pickle payload
-    straight into ``pickle.loads`` (RCE).
+    straight into ``pickle.loads`` (RCE). The sibling :data:`SUBWORKFLOW_ADDRESS_KEY`
+    is likewise trusted (it sets the root instance id / workflow name a nested executor
+    builds respond URLs against); if a top-level caller could supply it, they could
+    make the app emit URLs pointing at another instance (confused-deputy / info leak).
 
     Hosts therefore call this on client-supplied workflow input *before* scheduling the
-    orchestration, so the only way the orchestrator ever sees the envelope is from a
-    real internal child dispatch. Only the top-level key is removed (that is the only
-    position the orchestrator interprets it), leaving the rest of the caller's payload
-    untouched.
+    orchestration, so the only way the orchestrator ever sees either key is from a real
+    internal child dispatch. Only the top-level keys are removed (the only position the
+    orchestrator interprets them), leaving the rest of the caller's payload untouched.
     """
     if not isinstance(data, dict):
         return data
     typed = cast(dict[str, Any], data)
-    if SUBWORKFLOW_INPUT_KEY not in typed:
+    if SUBWORKFLOW_INPUT_KEY not in typed and SUBWORKFLOW_ADDRESS_KEY not in typed:
         return typed
-    logger.debug("Stripped reserved sub-workflow envelope key from untrusted input.")
+    logger.debug("Stripped reserved sub-workflow envelope key(s) from untrusted input.")
     cleaned = typed.copy()
     cleaned.pop(SUBWORKFLOW_INPUT_KEY, None)
+    cleaned.pop(SUBWORKFLOW_ADDRESS_KEY, None)
     return cleaned
 
 

--- a/python/packages/durabletask/tests/test_subworkflow_orchestration.py
+++ b/python/packages/durabletask/tests/test_subworkflow_orchestration.py
@@ -13,17 +13,23 @@ orchestration. These tests cover the host-side glue:
   the original typed object on the child side.
 """
 
-from typing import Any
+from typing import Any, cast
 from unittest.mock import Mock
 
 from agent_framework import WorkflowExecutor
 
+from agent_framework_durabletask._workflows.naming import qualify_subworkflow_request_id
 from agent_framework_durabletask._workflows.orchestrator import (
+    SUBWORKFLOW_ADDRESS_KEY,
     SUBWORKFLOW_INPUT_KEY,
+    TaskMetadata,
     TaskType,
     _coerce_initial_input,
+    _index_subworkflows,
+    _prepare_all_tasks,
     _prepare_subworkflow_task,
     _process_subworkflow_result,
+    _resolve_workflow_address,
     _try_unwrap_subworkflow_input,
     _unpack_subworkflow_result,
 )
@@ -57,6 +63,14 @@ def _result_envelope(outputs: list[Any], events: list[dict[str, Any]]) -> dict[s
     return {SUBWORKFLOW_RESULT_KEY: True, "outputs": outputs, "events": events}
 
 
+# A representative child address marker (root instance/workflow + one-hop path prefix).
+_CHILD_ADDRESS = {
+    "root_instance_id": "root-instance",
+    "root_workflow_name": "outer_wf",
+    "request_path_prefix": "sub-node~0~",
+}
+
+
 class TestPrepareSubworkflowTask:
     """Dispatch of a ``WorkflowExecutor`` node as a child orchestration."""
 
@@ -65,7 +79,7 @@ class TestPrepareSubworkflowTask:
         ctx.call_sub_orchestrator.return_value = "task-sentinel"
         executor = _subworkflow_executor("sub-node", "inner_wf")
 
-        task = _prepare_subworkflow_task(ctx, executor, "hello", "parent::sub-node::0")
+        task = _prepare_subworkflow_task(ctx, executor, "hello", "parent::sub-node::0", _CHILD_ADDRESS)
 
         assert task == "task-sentinel"
         ctx.call_sub_orchestrator.assert_called_once()
@@ -77,12 +91,14 @@ class TestPrepareSubworkflowTask:
         ctx = Mock()
         executor = _subworkflow_executor("sub-node", "inner_wf")
 
-        _prepare_subworkflow_task(ctx, executor, "payload", "child-id")
+        _prepare_subworkflow_task(ctx, executor, "payload", "child-id", _CHILD_ADDRESS)
 
         args, _ = ctx.call_sub_orchestrator.call_args
         child_input = args[1]
         # The wrapped payload round-trips back to the original message.
         assert deserialize_value(child_input[SUBWORKFLOW_INPUT_KEY]) == "payload"
+        # The address marker rides alongside so the child can build respond URLs.
+        assert child_input[SUBWORKFLOW_ADDRESS_KEY] == _CHILD_ADDRESS
 
 
 class TestProcessSubworkflowResult:
@@ -251,3 +267,124 @@ class TestSubworkflowInputUnwrap:
         marker = {SUBWORKFLOW_INPUT_KEY: "inner-message"}
 
         assert _coerce_initial_input(workflow, marker) == "inner-message"
+
+
+class TestResolveWorkflowAddress:
+    """Derivation of an orchestration's HITL address (root vs nested child)."""
+
+    def test_top_level_is_its_own_root_with_empty_prefix(self) -> None:
+        addr = _resolve_workflow_address("plain input", "top-instance", "outer_wf")
+        assert addr == {
+            "root_instance_id": "top-instance",
+            "root_workflow_name": "outer_wf",
+            "request_path_prefix": "",
+        }
+
+    def test_child_inherits_address_from_marker(self) -> None:
+        marker = {
+            SUBWORKFLOW_INPUT_KEY: "x",
+            SUBWORKFLOW_ADDRESS_KEY: {
+                "root_instance_id": "root",
+                "root_workflow_name": "outer_wf",
+                "request_path_prefix": "review_sub~0~",
+            },
+        }
+        # ctx.instance_id ("child-id") is ignored in favour of the marker's root values.
+        addr = _resolve_workflow_address(marker, "child-id", "human_review")
+        assert addr == {
+            "root_instance_id": "root",
+            "root_workflow_name": "outer_wf",
+            "request_path_prefix": "review_sub~0~",
+        }
+
+    def test_malformed_address_marker_falls_back_to_self(self) -> None:
+        # A non-dict / incomplete address marker is ignored (treated as top-level).
+        marker = {SUBWORKFLOW_ADDRESS_KEY: {"root_instance_id": 123}}
+        addr = _resolve_workflow_address(marker, "self-id", "wf")
+        assert addr == {"root_instance_id": "self-id", "root_workflow_name": "wf", "request_path_prefix": ""}
+
+
+class TestSubworkflowAddressPropagation:
+    """The dispatch-side request-path prefix must match the read-side qualified id.
+
+    The orchestrator builds each child's prefix from a *per-executor* ordinal; the
+    status/respond read path qualifies a nested request by ``enumerate()``-ing the
+    ``subworkflows[executorId]`` list. These two indexes must agree or an emailed
+    respond URL would resolve to the wrong child (or 404). This guards that agreement
+    for the tricky case: one node fanning out to several children in one superstep.
+    """
+
+    def _dispatch(
+        self, address: dict[str, str], message_count: int
+    ) -> tuple[list[dict[str, str]], list[str], list[TaskMetadata]]:
+        """Run _prepare_all_tasks for one WorkflowExecutor node fanning out N children.
+
+        Returns (child_addresses, child_instance_ids, task_metadata) in dispatch order.
+        """
+        node_id = "review_sub"
+        executor = _subworkflow_executor(node_id, "human_review")
+        workflow = Mock()
+        workflow.executors = {node_id: executor}
+        workflow.name = "moderation_pipeline"
+
+        captured: list[dict[str, str]] = []
+
+        def _call_sub(name: str, input_: dict[str, object], *, instance_id: str) -> str:  # noqa: ARG001
+            captured.append(cast("dict[str, str]", input_[SUBWORKFLOW_ADDRESS_KEY]))
+            return f"task::{instance_id}"
+
+        ctx = Mock()
+        ctx.instance_id = address["root_instance_id"]
+        ctx.call_sub_orchestrator.side_effect = _call_sub
+
+        pending = {node_id: [(f"msg-{i}", "src") for i in range(message_count)]}
+        _all_tasks, task_metadata, _remaining = _prepare_all_tasks(ctx, workflow, pending, None, [0], address)
+        child_ids = [m.child_instance_id for m in task_metadata if m.task_type == TaskType.SUBWORKFLOW]
+        assert all(cid is not None for cid in child_ids)
+        return captured, [cid for cid in child_ids if cid is not None], task_metadata
+
+    def test_fanout_prefixes_match_readside_qualification(self) -> None:
+        top = {"root_instance_id": "root", "root_workflow_name": "moderation_pipeline", "request_path_prefix": ""}
+        addresses, child_ids, _task_metadata = self._dispatch(top, message_count=3)
+
+        # Read side: subworkflows["review_sub"] = [child0, child1, child2]; a nested
+        # request from child ``ordinal`` is qualified as review_sub~{ordinal}~{bare}.
+        bare = "req-xyz"
+        for ordinal, child_address in enumerate(addresses):
+            dispatch_qualified = f"{child_address['request_path_prefix']}{bare}"
+            readside_qualified = qualify_subworkflow_request_id("review_sub", ordinal, bare)
+            assert dispatch_qualified == readside_qualified
+            # Root identity is carried through unchanged at every child.
+            assert child_address["root_instance_id"] == "root"
+            assert child_address["root_workflow_name"] == "moderation_pipeline"
+
+        # Child instance ids use the *global* counter (distinct from the ordinal).
+        assert child_ids == ["root::review_sub::0", "root::review_sub::1", "root::review_sub::2"]
+
+    def test_prefix_accumulates_when_already_nested(self) -> None:
+        # Simulate dispatching from a workflow that is itself one level deep.
+        nested = {
+            "root_instance_id": "root",
+            "root_workflow_name": "moderation_pipeline",
+            "request_path_prefix": "outer_node~2~",
+        }
+        addresses, _child_ids, _task_metadata = self._dispatch(nested, message_count=2)
+
+        assert [a["request_path_prefix"] for a in addresses] == [
+            "outer_node~2~review_sub~0~",
+            "outer_node~2~review_sub~1~",
+        ]
+
+    def test_readside_index_matches_dispatch_ordinal(self) -> None:
+        # Close the loop through the read-side map the parent actually publishes: a nested
+        # request qualified review_sub~{ordinal}~ must resolve, via subworkflows[executor],
+        # to the same child the dispatch stamped that ordinal onto. Guards the write ordinal
+        # and read index from drifting if task_metadata order or the grouping ever changes.
+        top = {"root_instance_id": "root", "root_workflow_name": "moderation_pipeline", "request_path_prefix": ""}
+        addresses, child_ids, task_metadata = self._dispatch(top, message_count=3)
+
+        subworkflows = _index_subworkflows(task_metadata)
+        assert subworkflows == {"review_sub": child_ids}
+        for ordinal, (child_id, child_address) in enumerate(zip(child_ids, addresses, strict=True)):
+            assert child_address["request_path_prefix"] == qualify_subworkflow_request_id("review_sub", ordinal, "")
+            assert subworkflows["review_sub"][ordinal] == child_id

--- a/python/packages/durabletask/tests/test_workflow_activity.py
+++ b/python/packages/durabletask/tests/test_workflow_activity.py
@@ -10,11 +10,20 @@ updates (regression guard for the shallow-copy bug, #4500).
 """
 
 import json
+from dataclasses import dataclass
 from typing import Any
 from unittest.mock import AsyncMock, Mock
 
 from agent_framework_durabletask import execute_workflow_activity
-from agent_framework_durabletask._workflows.orchestrator import SOURCE_ORCHESTRATOR
+from agent_framework_durabletask._workflows.orchestrator import SOURCE_HITL_RESPONSE, SOURCE_ORCHESTRATOR
+from agent_framework_durabletask._workflows.serialization import serialize_value
+
+
+@dataclass
+class ApprovalRequest:
+    """Typed request used to select a HITL response handler."""
+
+    prompt: str
 
 
 def _make_executor(executor_id: str, mutate: Any) -> Mock:
@@ -115,6 +124,67 @@ class TestExecuteWorkflowActivityStateDiff:
 
         assert "to_remove" in result["shared_state_deletes"]
         assert "keep" not in result["shared_state_deletes"]
+
+
+def test_hitl_response_handler_receives_typed_original_request() -> None:
+    """Already-serialized HITL requests are decoded before response handler dispatch."""
+    original_request = ApprovalRequest(prompt="Approve this?")
+    hitl_message = {
+        "original_request": serialize_value(original_request),
+        "response": "approved",
+        "response_type": None,
+    }
+    input_data = json.dumps({
+        "message": serialize_value(hitl_message),
+        "shared_state_snapshot": {},
+        "source_executor_ids": [f"{SOURCE_HITL_RESPONSE}_request-1"],
+    })
+
+    handler = AsyncMock()
+    executor = Mock()
+    executor.id = "review-gate"
+    executor._find_response_handler.return_value = handler
+
+    execute_workflow_activity(executor, input_data)
+
+    executor._find_response_handler.assert_called_once_with(original_request, "approved")
+    handler.assert_awaited_once()
+
+
+class TestExecuteWorkflowActivityHostMetadata:
+    """Orchestration metadata is surfaced to executors via the runner context."""
+
+    def test_host_context_surfaced_on_runner_context(self) -> None:
+        """``host_context`` in the activity input is exposed as ``runner_context.host_metadata``."""
+        captured: dict[str, Any] = {}
+
+        async def capture(message: Any, source_executor_ids: Any, state: Any, runner_context: Any) -> None:
+            captured["metadata"] = runner_context.host_metadata
+            state.commit()
+
+        executor = _make_executor("test-exec", capture)
+        input_data = json.dumps({
+            "message": "test",
+            "shared_state_snapshot": {},
+            "source_executor_ids": [SOURCE_ORCHESTRATOR],
+            "host_context": {"instance_id": "abc123", "workflow_name": "content_moderation"},
+        })
+        json.loads(execute_workflow_activity(executor, input_data))
+
+        assert captured["metadata"] == {"instance_id": "abc123", "workflow_name": "content_moderation"}
+
+    def test_absent_host_context_yields_none(self) -> None:
+        """When the input omits ``host_context``, ``host_metadata`` is ``None`` (in-process parity)."""
+        captured: dict[str, Any] = {}
+
+        async def capture(message: Any, source_executor_ids: Any, state: Any, runner_context: Any) -> None:
+            captured["metadata"] = runner_context.host_metadata
+            state.commit()
+
+        executor = _make_executor("test-exec", capture)
+        _run(executor, {})
+
+        assert captured["metadata"] is None
 
 
 if __name__ == "__main__":

--- a/python/packages/durabletask/tests/test_workflow_serialization.py
+++ b/python/packages/durabletask/tests/test_workflow_serialization.py
@@ -31,6 +31,7 @@ from agent_framework import (
 from pydantic import BaseModel
 
 from agent_framework_durabletask._workflows.serialization import (
+    SUBWORKFLOW_ADDRESS_KEY,
     SUBWORKFLOW_INPUT_KEY,
     deserialize_value,
     deserialize_workflow_event,
@@ -435,6 +436,20 @@ class TestStripSubworkflowMarkers:
 
     def test_strips_input_key(self) -> None:
         data = {SUBWORKFLOW_INPUT_KEY: {"__pickled__": "evil"}, "real": 1}
+        assert strip_subworkflow_markers(data) == {"real": 1}
+
+    def test_strips_address_key(self) -> None:
+        # A forged address marker would otherwise let a top-level caller point respond
+        # URLs at another instance (confused-deputy); it must be stripped too.
+        data = {SUBWORKFLOW_ADDRESS_KEY: {"root_instance_id": "victim"}, "real": 1}
+        assert strip_subworkflow_markers(data) == {"real": 1}
+
+    def test_strips_both_markers_together(self) -> None:
+        data = {
+            SUBWORKFLOW_INPUT_KEY: "x",
+            SUBWORKFLOW_ADDRESS_KEY: {"root_instance_id": "victim"},
+            "real": 1,
+        }
         assert strip_subworkflow_markers(data) == {"real": 1}
 
     def test_strips_full_forged_envelope(self) -> None:

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -69,10 +69,11 @@ environments = [
 ]
 
 [tool.uv.workspace]
-members = ["packages/durabletask"]
+members = ["packages/durabletask", "packages/azurefunctions"]
 
 [tool.uv.sources]
 agent-framework-durabletask = { workspace = true }
+agent-framework-azurefunctions = { workspace = true }
 
 [tool.ruff]
 line-length = 120
@@ -139,7 +140,7 @@ notice-rgx = "^# Copyright \\(c\\) Microsoft\\. All rights reserved\\."
 min-file-size = 1
 
 [tool.pytest.ini_options]
-testpaths = ["packages/durabletask/tests"]
+testpaths = ["packages/durabletask/tests", "packages/azurefunctions/tests"]
 norecursedirs = ["**/lab/**"]
 addopts = "-ra -q -r fEX"
 asyncio_mode = "auto"
@@ -172,8 +173,12 @@ reportUnnecessaryCast = "error"
 reportUnnecessaryTypeIgnoreComment = "error"
 
 [tool.mypy]
+# Type-checks tests only. Package sources are checked by Pyright (strict), matching the
+# Agent Framework repo, which uses Pyright for source and relaxed mypy/ty for tests.
+# ``follow_imports = "silent"`` lets mypy use the sources for context without reporting on them.
 plugins = ["pydantic.mypy"]
 python_version = "3.10"
+follow_imports = "silent"
 ignore_missing_imports = true
 check_untyped_defs = true
 disallow_untyped_defs = false
@@ -193,7 +198,7 @@ follow_imports_for_stubs = true
 unused-type-ignore-comment = "ignore"
 
 [tool.bandit]
-targets = ["agent_framework_durabletask"]
+targets = ["agent_framework_durabletask", "agent_framework_azurefunctions"]
 exclude_dirs = ["tests", "samples"]
 
 [tool.poe]
@@ -204,28 +209,28 @@ help = "Install the Durable Task workspace package and dependency groups."
 cmd = "uv sync --all-packages --group dev --group test"
 
 [tool.poe.tasks.lint]
-help = "Run Ruff checks for the Durable Task package and samples."
-cmd = "ruff check packages/durabletask samples"
+help = "Run Ruff checks for the packages and samples."
+cmd = "ruff check packages/durabletask packages/azurefunctions samples"
 
 [tool.poe.tasks.format]
-help = "Run Ruff formatting for the Durable Task package and samples."
-cmd = "ruff format packages/durabletask samples"
-
-[tool.poe.tasks.mypy]
-help = "Run MyPy for the Durable Task package source."
-cmd = "mypy --config-file packages/durabletask/pyproject.toml packages/durabletask/agent_framework_durabletask"
+help = "Run Ruff formatting for the packages and samples."
+cmd = "ruff format packages/durabletask packages/azurefunctions samples"
 
 [tool.poe.tasks.pyright]
-help = "Run Pyright for the Durable Task package source."
-cmd = "pyright -p packages/durabletask/pyproject.toml"
+help = "Run Pyright for the package sources."
+shell = "pyright -p packages/durabletask/pyproject.toml && pyright -p packages/azurefunctions/pyproject.toml"
+
+[tool.poe.tasks.mypy]
+help = "Run MyPy for the package tests."
+shell = "mypy --config-file pyproject.toml packages/durabletask/tests && mypy --config-file pyproject.toml packages/azurefunctions/tests"
 
 [tool.poe.tasks.test]
-help = "Run the Durable Task unit tests."
-cmd = "pytest -m \"not integration\" packages/durabletask/tests"
+help = "Run the unit tests."
+cmd = "pytest -m \"not integration\" packages/durabletask/tests packages/azurefunctions/tests"
 
 [tool.poe.tasks.build]
-help = "Build the Durable Task package distributions."
-cmd = "uv build packages/durabletask --out-dir dist"
+help = "Build the package distributions."
+shell = "uv build packages/durabletask --out-dir dist && uv build packages/azurefunctions --out-dir dist"
 
 [tool.poe.tasks.clean-dist]
 help = "Remove generated Python package artifacts."

--- a/python/samples/README.md
+++ b/python/samples/README.md
@@ -54,6 +54,13 @@ az account show
 - **[11_subworkflow](11_subworkflow/)**: Compose workflows by embedding an inner `Workflow` as a node via `WorkflowExecutor`. On the durable host the inner workflow runs as its own child orchestration, and a single `configure_workflow` call registers both.
 - **[12_subworkflow_hitl](12_subworkflow_hitl/)**: A human-in-the-loop pause that lives **inside a sub-workflow**. The nested request surfaces to the client with a qualified request id (`{executor}~{ordinal}~{requestId}`) behind a single top-level addressing surface.
 
+### Azure Functions Hosting
+
+These samples host workflows on Azure Durable Functions (`func start`) instead of the worker-client model above. Each has its own setup steps in its README.
+
+- **[azure_functions/12_workflow_hitl](azure_functions/12_workflow_hitl/)**: The workflow human-in-the-loop pattern on Azure Durable Functions, with the reviewer notified from inside the workflow via `WorkflowHitlContext`.
+- **[azure_functions/13_subworkflow_hitl](azure_functions/13_subworkflow_hitl/)**: A human-in-the-loop pause inside a sub-workflow on Azure Durable Functions, exposed through a single top-level respond surface.
+
 ## Running the Samples
 
 These samples are designed to be run locally in a cloned repository.

--- a/python/samples/azure_functions/12_workflow_hitl/.gitignore
+++ b/python/samples/azure_functions/12_workflow_hitl/.gitignore
@@ -1,0 +1,5 @@
+# Local settings - copy from local.settings.json.sample and fill in your values
+local.settings.json
+__pycache__/
+*.pyc
+.venv/

--- a/python/samples/azure_functions/12_workflow_hitl/README.md
+++ b/python/samples/azure_functions/12_workflow_hitl/README.md
@@ -1,0 +1,171 @@
+# 12. Workflow with Human-in-the-Loop (HITL)
+
+This sample demonstrates how to integrate human approval into a MAF workflow running on Azure Durable Functions using the MAF `request_info` and `@response_handler` pattern.
+
+## Overview
+
+The sample implements a content moderation pipeline:
+
+1. **User starts workflow** with content for publication via HTTP endpoint
+2. **AI Agent analyzes** the content for policy compliance
+3. **Workflow pauses** and requests human reviewer approval
+4. **Human responds** via HTTP endpoint with approval/rejection
+5. **Workflow resumes** and publishes or rejects the content
+
+## Key Concepts
+
+### MAF HITL Pattern
+
+This sample uses MAF's built-in human-in-the-loop pattern:
+
+```python
+# In an executor, request human input
+await ctx.request_info(
+    request_data=HumanApprovalRequest(...),
+    response_type=HumanApprovalResponse,
+)
+
+# Handle the response in a separate method
+@response_handler
+async def handle_approval_response(
+    self,
+    original_request: HumanApprovalRequest,
+    response: HumanApprovalResponse,
+    ctx: WorkflowContext,
+) -> None:
+    # Process the human's decision
+    ...
+```
+
+### Notifying a reviewer from inside the workflow
+
+This sample also shows how a workflow notifies a human itself (for example to email an approval link) instead of relying on the caller to poll the status endpoint. It uses a two step pattern so the reviewer gets a working respond URL.
+
+```python
+# Pause the workflow. request_info generates the request id internally.
+await ctx.request_info(
+    request_data=HumanApprovalRequest(...),
+    response_type=HumanApprovalResponse,
+)
+
+# Read that id back, then build the respond URL with WorkflowHitlContext.
+request_id = await WorkflowHitlContext.pending_request_id(ctx)
+hitl = WorkflowHitlContext.from_context(ctx)
+if hitl and request_id:
+    respond_url = hitl.build_respond_url(request_id)  # email this to the reviewer
+```
+
+Two things make this safe and worth understanding.
+
+**You never generate the id.** `request_info` already creates one and stores it on the context before it returns, so `pending_request_id(ctx)` reads it straight back. You must call `pending_request_id` immediately after `request_info`, because it returns the newest pending request, which is the one you just emitted. On the durable host this is reliable. Every executor runs in its own Durable Functions activity with its own runner context, so that pending set only ever holds this executor's own requests. If a single executor emits several requests in one turn, read the id after each call, or pass your own `request_id` to `request_info`.
+
+**The notification runs in a separate executor.** The review executor sends the id to a downstream `NotifyExecutor` that builds the URL, rather than emailing from the executor that generated the id. Because activities are at least once, an executor can be retried, and each retry mints a fresh id. Keeping the email in a downstream executor means only the committed attempt's id ever reaches the notifier, so a retried review executor never emails a dead link. `WorkflowHitlContext.from_context(ctx)` returns `None` when the executor is not on the durable host (for example under `--maf` DevUI), so the notify step skips cleanly there.
+
+The base URL comes from the `WEBSITE_HOSTNAME` app setting, which Azure Functions sets automatically in the cloud. For a custom domain or an API Management gateway, pass `base_url=...` to `from_context`, because `WEBSITE_HOSTNAME` still reports the default `*.azurewebsites.net` host.
+
+### Automatic HITL Endpoints
+
+`AgentFunctionApp` automatically provides all the HTTP endpoints needed for HITL:
+
+| Endpoint | Description |
+|----------|-------------|
+| `POST /api/workflow/content_moderation/run` | Start the workflow |
+| `GET /api/workflow/content_moderation/status/{instanceId}` | Check status and pending HITL requests |
+| `POST /api/workflow/content_moderation/respond/{instanceId}/{requestId}` | Send human response |
+| `GET /api/health` | Health check |
+
+These routes expose workflow status and human-response operations. In production, put them behind your application's authentication and authorization layer and verify that the caller is allowed to inspect or resume the targeted workflow before returning status or accepting a response.
+
+Treat `instanceId` and `requestId` as correlation handles only. They help locate workflow state, but they are not secrets or proof that a caller is authorized to act on that workflow.
+
+### Durable Functions Integration
+
+When running on Durable Functions, the HITL pattern maps to:
+
+| MAF Concept | Durable Functions |
+|-------------|-------------------|
+| `ctx.request_info()` | Workflow pauses, custom status updated |
+| `RequestInfoEvent` | Exposed via status endpoint |
+| HTTP response | `client.raise_event(instance_id, request_id, data)` |
+| `@response_handler` | Workflow resumes, handler invoked |
+
+## Workflow Architecture
+
+```
+┌─────────────────┐     ┌──────────────────────┐     ┌────────────────────────┐
+│  Input Router   │ ──► │ Content Analyzer     │ ──► │ Content Analyzer       │
+│   Executor      │     │ Agent (AI)           │     │ Executor (Parse JSON)  │
+└─────────────────┘     └──────────────────────┘     └────────────────────────┘
+                                                                │
+                                                                ▼
+┌─────────────────┐     ┌──────────────────────┐
+│    Publish      │ ◄── │   Human Review       │ ◄── HITL PAUSE
+│   Executor      │     │   Executor           │     (wait for external event)
+└─────────────────┘     └──────────────────────┘
+```
+
+## Prerequisites
+
+1. **Azure OpenAI** - Access to Azure OpenAI with a deployed chat model
+2. **Durable Task Scheduler** - Local emulator or Azure deployment
+3. **Azurite** - Local Azure Storage emulator
+4. **Azure CLI** - For authentication (`az login`)
+
+## Setup
+
+1. Copy the sample settings file:
+   ```bash
+   cp local.settings.json.sample local.settings.json
+   ```
+
+2. Update `local.settings.json` with your Foundry project settings:
+   ```json
+   {
+     "Values": {
+       "FOUNDRY_PROJECT_ENDPOINT": "https://your-project.services.ai.azure.com/api/projects/your-project",
+       "FOUNDRY_MODEL": "gpt-4o"
+     }
+   }
+   ```
+
+3. Start the local emulators:
+   ```bash
+   # Terminal 1: Start Azurite
+   azurite --silent --location .
+
+   # Terminal 2: Start Durable Task Scheduler (if using local emulator)
+   # Follow Durable Task Scheduler setup instructions
+   ```
+
+4. Start the Function App:
+   ```bash
+   func start
+   ```
+
+## Running in Pure MAF Mode
+
+You can also run this sample in pure MAF mode (without Durable Functions) using the DevUI:
+
+```bash
+python function_app.py --maf
+```
+
+This launches the DevUI at http://localhost:8096 where you can interact with the workflow directly. This is useful for:
+- Local development and debugging
+- Testing the HITL pattern without Durable Functions infrastructure
+- Comparing behavior between MAF and Durable modes
+
+## Testing
+
+Use the `demo.http` file with the VS Code REST Client extension:
+
+1. **Start workflow** - `POST /api/workflow/content_moderation/run` with content payload
+2. **Check status** - `GET /api/workflow/content_moderation/status/{instanceId}` to see pending HITL requests
+3. **Send response** - `POST /api/workflow/content_moderation/respond/{instanceId}/{requestId}` with approval
+4. **Check result** - `GET /api/workflow/content_moderation/status/{instanceId}` to see final output
+
+## Related Samples
+
+- [07_single_agent_orchestration_hitl](../07_single_agent_orchestration_hitl/) - HITL at orchestrator level (not using MAF pattern)
+- [09_workflow_shared_state](../09_workflow_shared_state/) - Workflow with shared state
+- [guessing_game_with_human_input](../../../03-workflows/human-in-the-loop/guessing_game_with_human_input.py) - MAF HITL pattern (non-durable)

--- a/python/samples/azure_functions/12_workflow_hitl/demo.http
+++ b/python/samples/azure_functions/12_workflow_hitl/demo.http
@@ -1,0 +1,123 @@
+### ============================================================================
+### Workflow HITL Sample - Content Moderation with Human Approval
+### ============================================================================
+### This sample demonstrates MAF workflows with human-in-the-loop using the
+### request_info / @response_handler pattern on Azure Durable Functions.
+###
+### The AgentFunctionApp automatically provides all HITL endpoints.
+###
+### Prerequisites:
+### 1. Start Azurite: azurite --silent --location .
+### 2. Start Durable Task Scheduler emulator
+### 3. Configure local.settings.json with Azure OpenAI credentials
+### 4. Run: func start
+### ============================================================================
+
+
+### ============================================================================
+### 1. Start the Workflow with Content for Moderation
+### ============================================================================
+### This starts the workflow. The AI will analyze the content, then the workflow
+### will pause waiting for human approval.
+
+POST http://localhost:7071/api/workflow/content_moderation/run
+Content-Type: application/json
+
+{
+  "content_id": "article-001",
+  "title": "Introduction to AI in Healthcare",
+  "body": "Artificial intelligence is revolutionizing healthcare by enabling faster diagnosis, personalized treatment plans, and improved patient outcomes. Machine learning algorithms can analyze medical images with remarkable accuracy, often detecting issues that human radiologists might miss.",
+  "author": "Dr. Jane Smith"
+}
+
+
+### ============================================================================
+### 2. Start Workflow with Potentially Problematic Content
+### ============================================================================
+### This content should trigger higher risk assessment from the AI analyzer.
+
+POST http://localhost:7071/api/workflow/content_moderation/run
+Content-Type: application/json
+
+{
+  "content_id": "article-002",
+  "title": "Get Rich Quick Scheme",
+  "body": "Click here NOW to make $10,000 overnight! This SECRET method is GUARANTEED to work! Limited time offer - act NOW before it's too late! Send your bank details immediately!",
+  "author": "Definitely Not Spam"
+}
+
+
+### ============================================================================
+### 3. Check Workflow Status
+### ============================================================================
+### Replace INSTANCE_ID with the value returned from the run call.
+### The status will show pending HITL requests if waiting for human approval.
+
+@instanceId = 3130c486c9374e4e87125cbd9a238dfc
+
+GET http://localhost:7071/api/workflow/content_moderation/status/{{instanceId}}
+
+
+### ============================================================================
+### 4. Send Human Approval
+### ============================================================================
+### Approve the content for publication.
+### Replace INSTANCE_ID and REQUEST_ID with values from the status response.
+
+@requestId = 1682e5f8-0917-4b68-aa04-d4688cfa2e69
+
+POST http://localhost:7071/api/workflow/content_moderation/respond/{{instanceId}}/{{requestId}}
+Content-Type: application/json
+
+{
+  "approved": true,
+  "reviewer_notes": "Content is appropriate and well-written. Approved for publication."
+}
+
+
+### ============================================================================
+### 5. Send Human Rejection
+### ============================================================================
+### Reject the content with feedback.
+
+POST http://localhost:7071/api/workflow/content_moderation/respond/{{instanceId}}/{{requestId}}
+Content-Type: application/json
+
+{
+  "approved": false,
+  "reviewer_notes": "Content appears to be spam. Contains multiple spam indicators including urgency language, promises of easy money, and requests for personal information."
+}
+
+
+### ============================================================================
+### Example Workflow - Complete Happy Path
+### ============================================================================
+###
+### Step 1: Start workflow with content
+### POST http://localhost:7071/api/workflow/content_moderation/run
+### -> Returns instanceId: "abc123..."
+###
+### Step 2: Check status (workflow is waiting for human input)
+### GET http://localhost:7071/api/workflow/content_moderation/status/abc123
+### -> Returns pendingHumanInputRequests with requestId: "req-456..."
+###
+### Step 3: Approve content
+### POST http://localhost:7071/api/workflow/content_moderation/respond/abc123/req-456
+### {
+###   "approved": true,
+###   "reviewer_notes": "Looks good!"
+### }
+### -> Returns success
+###
+### Step 4: Check final status
+### GET http://localhost:7071/api/workflow/content_moderation/status/abc123
+### -> Returns runtimeStatus: "Completed", output: "✅ Content approved..."
+###
+### ============================================================================
+
+
+### ============================================================================
+### Health Check
+### ============================================================================
+
+GET http://localhost:7071/api/health

--- a/python/samples/azure_functions/12_workflow_hitl/function_app.py
+++ b/python/samples/azure_functions/12_workflow_hitl/function_app.py
@@ -1,0 +1,549 @@
+# Copyright (c) Microsoft. All rights reserved.
+"""Workflow with Human-in-the-Loop (HITL) using MAF request_info Pattern.
+
+This sample demonstrates how to integrate human approval into a MAF workflow
+running on Azure Durable Functions. It uses the MAF `request_info` and
+`@response_handler` pattern for structured HITL interactions.
+
+The workflow simulates a content moderation pipeline:
+1. User submits content for publication
+2. An AI agent analyzes the content for policy compliance
+3. A human reviewer is emailed an approval link and prompted to approve/reject
+4. Based on approval, content is either published or rejected
+
+Key architectural points:
+- Uses MAF's `ctx.request_info()` to pause workflow and request human input
+- A `NotifyExecutor` builds the respond URL via `WorkflowHitlContext` and notifies the
+  reviewer out-of-band (email) -- the caller never threads instanceId / requestId by hand
+- Uses `@response_handler` decorator to handle the human's response
+- AgentFunctionApp automatically provides HITL endpoints for status and response
+- Durable Functions provides durability while waiting for human input
+
+Prerequisites:
+- Configure `FOUNDRY_PROJECT_ENDPOINT` and `FOUNDRY_MODEL`
+- Durable Task Scheduler connection string
+- Authentication via Azure CLI (az login)
+"""
+
+import logging
+import os
+from dataclasses import dataclass
+from typing import Any
+
+from agent_framework import (
+    Agent,
+    AgentExecutorRequest,
+    AgentExecutorResponse,
+    Executor,
+    Message,
+    Workflow,
+    WorkflowBuilder,
+    WorkflowContext,
+    handler,
+    response_handler,
+)
+from agent_framework.foundry import FoundryChatClient
+from agent_framework.openai import OpenAIChatOptions
+from agent_framework_azurefunctions import AgentFunctionApp, WorkflowHitlContext
+from azure.identity.aio import AzureCliCredential
+from pydantic import BaseModel, ValidationError
+from typing_extensions import Never
+
+logger = logging.getLogger(__name__)
+
+# Environment variable names
+FOUNDRY_PROJECT_ENDPOINT_ENV = "FOUNDRY_PROJECT_ENDPOINT"
+AZURE_OPENAI_DEPLOYMENT_ENV = "FOUNDRY_MODEL"
+
+# Agent names
+CONTENT_ANALYZER_AGENT_NAME = "ContentAnalyzerAgent"
+
+
+# ============================================================================
+# Data Models
+# ============================================================================
+
+
+class ContentAnalysisResult(BaseModel):
+    """Structured output from the content analysis agent."""
+
+    is_appropriate: bool
+    risk_level: str  # low, medium, high
+    concerns: list[str]
+    recommendation: str
+
+
+@dataclass
+class ContentSubmission:
+    """Content submitted for moderation."""
+
+    content_id: str
+    title: str
+    body: str
+    author: str
+
+
+@dataclass
+class HumanApprovalRequest:
+    """Request sent to human reviewer for approval.
+
+    This is the payload passed to ctx.request_info() and will be
+    exposed via the orchestration status for external systems to retrieve.
+    """
+
+    content_id: str
+    title: str
+    body: str
+    author: str
+    ai_analysis: ContentAnalysisResult
+    prompt: str
+
+
+class HumanApprovalResponse(BaseModel):
+    """Response from human reviewer.
+
+    This is what the external system must send back via the HITL response endpoint.
+    """
+
+    approved: bool
+    reviewer_notes: str = ""
+
+
+@dataclass
+class ModerationResult:
+    """Final result of the moderation workflow."""
+
+    content_id: str
+    status: str  # "approved", "rejected"
+    ai_analysis: ContentAnalysisResult | None
+    reviewer_notes: str
+
+
+@dataclass
+class HumanReviewNotification:
+    """Payload handed to the notifier so it can build the respond URL and alert a human.
+
+    Carries the ``request_id`` the review executor passed to ``ctx.request_info`` so the
+    notifier addresses the exact pending request the workflow is waiting on.
+    """
+
+    request_id: str
+    content_id: str
+    prompt: str
+
+
+# ============================================================================
+# Agent Instructions
+# ============================================================================
+
+CONTENT_ANALYZER_INSTRUCTIONS = """You are a content moderation assistant that analyzes user-submitted content
+for policy compliance. Evaluate the content for:
+
+1. Appropriateness - Is the content suitable for a general audience?
+2. Risk level - Rate as 'low', 'medium', or 'high' based on potential issues
+3. Concerns - List any specific issues found (empty list if none)
+4. Recommendation - Provide a brief recommendation for human reviewers
+
+Return a JSON response with:
+- is_appropriate: boolean
+- risk_level: string ('low', 'medium', 'high')
+- concerns: list of strings
+- recommendation: string
+
+Be thorough but fair in your analysis."""
+
+
+# ============================================================================
+# Executors
+# ============================================================================
+
+
+@dataclass
+class AnalysisWithSubmission:
+    """Combines the AI analysis with the original submission for downstream processing."""
+
+    submission: ContentSubmission
+    analysis: ContentAnalysisResult
+
+
+class ContentAnalyzerExecutor(Executor):
+    """Parses the AI agent's response and prepares for human review."""
+
+    def __init__(self):
+        super().__init__(id="content_analyzer_executor")
+
+    @handler
+    async def handle_analysis(
+        self,
+        response: AgentExecutorResponse,
+        ctx: WorkflowContext[AnalysisWithSubmission],
+    ) -> None:
+        """Parse the AI analysis and forward with submission context."""
+        try:
+            analysis = ContentAnalysisResult.model_validate_json(response.agent_response.text)
+        except ValidationError:
+            analysis = ContentAnalysisResult(
+                is_appropriate=False,
+                risk_level="high",
+                concerns=["Agent execution failed or yielded invalid JSON (possible content filter)."],
+                recommendation="Manual review required",
+            )
+
+        # Retrieve the original submission from shared state
+        submission: ContentSubmission = ctx.get_state("current_submission")
+
+        await ctx.send_message(AnalysisWithSubmission(submission=submission, analysis=analysis))
+
+
+class HumanReviewExecutor(Executor):
+    """Requests human approval using MAF's request_info pattern.
+
+    This executor demonstrates the core HITL pattern:
+    1. Receives the AI analysis result
+    2. Calls ctx.request_info() to pause and request human input
+    3. The @response_handler method processes the human's response
+    """
+
+    def __init__(self):
+        super().__init__(id="human_review_executor")
+
+    @handler
+    async def request_review(
+        self,
+        data: AnalysisWithSubmission,
+        ctx: WorkflowContext[HumanReviewNotification],
+    ) -> None:
+        """Request human review for the content.
+
+        This method:
+        1. Constructs the approval request with all context
+        2. Sends the request id to the notifier so it can email the reviewer a link
+        3. Calls request_info to pause the workflow until a response arrives
+        """
+        submission = data.submission
+        analysis = data.analysis
+
+        # Construct the human-readable prompt
+        prompt = (
+            f"Please review the following content for publication:\n\n"
+            f"Title: {submission.title}\n"
+            f"Author: {submission.author}\n"
+            f"Content: {submission.body}\n\n"
+            f"AI Analysis:\n"
+            f"- Appropriate: {analysis.is_appropriate}\n"
+            f"- Risk Level: {analysis.risk_level}\n"
+            f"- Concerns: {', '.join(analysis.concerns) if analysis.concerns else 'None'}\n"
+            f"- Recommendation: {analysis.recommendation}\n\n"
+            f"Please approve or reject this content."
+        )
+
+        approval_request = HumanApprovalRequest(
+            content_id=submission.content_id,
+            title=submission.title,
+            body=submission.body,
+            author=submission.author,
+            ai_analysis=analysis,
+            prompt=prompt,
+        )
+
+        # Store analysis in shared state for the response handler
+        ctx.set_state("pending_analysis", data)
+
+        # Pause the workflow for human input. request_info generates the request id;
+        # read it back so a downstream NotifyExecutor can build the respond URL -- no
+        # need to mint an id by hand.
+        await ctx.request_info(
+            request_data=approval_request,
+            response_type=HumanApprovalResponse,
+        )
+        request_id = await WorkflowHitlContext.pending_request_id(ctx)
+        assert request_id is not None  # always set immediately after request_info
+
+        # Side-branch: hand the request id to the notifier so it can build the respond
+        # URL and alert the reviewer. The email is sent by the downstream NotifyExecutor
+        # (a separate activity), so only this activity's committed id ever reaches the
+        # notifier -- retries of this executor notify no one. The orchestrator drains
+        # this message before entering the HITL wait.
+        await ctx.send_message(
+            HumanReviewNotification(
+                request_id=request_id,
+                content_id=submission.content_id,
+                prompt=prompt,
+            ),
+            target_id="notify_executor",
+        )
+
+    @response_handler
+    async def handle_approval_response(
+        self,
+        original_request: HumanApprovalRequest,
+        response: HumanApprovalResponse,
+        ctx: WorkflowContext[ModerationResult],
+    ) -> None:
+        """Process the human reviewer's decision.
+
+        This method is called automatically when a response to request_info is received.
+        The original_request contains the HumanApprovalRequest we sent.
+        The response contains the HumanApprovalResponse from the reviewer.
+        """
+        logger.info(
+            "Human review received for content %s: approved=%s, notes=%s",
+            original_request.content_id,
+            response.approved,
+            response.reviewer_notes,
+        )
+
+        # Create the final moderation result
+        status = "approved" if response.approved else "rejected"
+        result = ModerationResult(
+            content_id=original_request.content_id,
+            status=status,
+            ai_analysis=original_request.ai_analysis,
+            reviewer_notes=response.reviewer_notes,
+        )
+
+        await ctx.send_message(result, target_id="publish_executor")
+
+
+class NotifyExecutor(Executor):
+    """Notifies a human reviewer with a respond link, without pausing the workflow.
+
+    Reached by an edge from ``HumanReviewExecutor`` in the same superstep that raises the
+    ``request_info`` request. It builds the canonical respond URL with
+    :class:`WorkflowHitlContext` and (in a real app) emails it to the reviewer. Because it
+    runs as a durable activity *downstream* of the id-generating executor, the id it emails
+    is always the one the orchestrator ends up waiting on -- retries of the upstream
+    executor never produce a dead link.
+    """
+
+    def __init__(self):
+        super().__init__(id="notify_executor")
+
+    @handler
+    async def notify(
+        self,
+        notification: HumanReviewNotification,
+        ctx: WorkflowContext,
+    ) -> None:
+        """Build the respond URL and notify the reviewer (logged here for the sample)."""
+        hitl = WorkflowHitlContext.from_context(ctx)
+        if hitl is None:
+            # Not running on the Azure Functions durable host (e.g. in-process DevUI):
+            # there is no respond endpoint to address, so skip notification.
+            logger.info(
+                "Not on the durable host; skipping reviewer notification for content %s.",
+                notification.content_id,
+            )
+            return
+
+        try:
+            respond_url = hitl.build_respond_url(notification.request_id)
+        except RuntimeError:
+            # No base URL configured (WEBSITE_HOSTNAME unset and no override). Notifying
+            # is a best-effort side effect -- the request is still reachable via the
+            # status endpoint -- so warn and continue rather than failing the workflow.
+            logger.warning(
+                "Cannot build a respond URL (set WEBSITE_HOSTNAME, e.g. in "
+                "local.settings.json). Skipping reviewer notification for content %s.",
+                notification.content_id,
+            )
+            return
+
+        # In a real application, send this URL to the reviewer (email, Teams, etc.). The
+        # reviewer POSTs {"approved": bool, "reviewer_notes": str} to it to resume the run.
+        logger.info(
+            "Human review needed for content %s.\n  Respond at: %s\n  Details: %s",
+            notification.content_id,
+            respond_url,
+            notification.prompt,
+        )
+
+
+class PublishExecutor(Executor):
+    """Handles the final publication or rejection of content."""
+
+    def __init__(self):
+        super().__init__(id="publish_executor")
+
+    @handler
+    async def handle_result(
+        self,
+        result: ModerationResult,
+        ctx: WorkflowContext[Never, str],
+    ) -> None:
+        """Finalize the moderation and yield output."""
+        if result.status == "approved":
+            message = (
+                f"✅ Content '{result.content_id}' has been APPROVED and published.\n"
+                f"Reviewer notes: {result.reviewer_notes or 'None'}"
+            )
+        else:
+            message = (
+                f"❌ Content '{result.content_id}' has been REJECTED.\n"
+                f"Reviewer notes: {result.reviewer_notes or 'None'}"
+            )
+
+        logger.info(message)
+        await ctx.yield_output(message)
+
+
+# ============================================================================
+# Input Router Executor
+# ============================================================================
+
+
+def _build_client_kwargs() -> dict[str, Any]:
+    """Build Foundry chat client configuration from environment variables."""
+    project_endpoint = os.getenv(FOUNDRY_PROJECT_ENDPOINT_ENV)
+    if not project_endpoint:
+        raise RuntimeError(f"{FOUNDRY_PROJECT_ENDPOINT_ENV} environment variable is required.")
+
+    model = os.getenv(AZURE_OPENAI_DEPLOYMENT_ENV)
+    if not model:
+        raise RuntimeError(f"{AZURE_OPENAI_DEPLOYMENT_ENV} environment variable is required.")
+
+    return {
+        "project_endpoint": project_endpoint,
+        "model": model,
+        "credential": AzureCliCredential(),
+    }
+
+
+class InputRouterExecutor(Executor):
+    """Routes incoming content submission to the analysis agent."""
+
+    def __init__(self):
+        super().__init__(id="input_router")
+
+    @handler
+    async def route_input(
+        self,
+        submission: ContentSubmission,
+        ctx: WorkflowContext[AgentExecutorRequest],
+    ) -> None:
+        """Create the agent request from the submitted content.
+
+        The durable engine reconstructs this ``ContentSubmission`` from the
+        client's JSON payload before delivery, mirroring in-process execution.
+        """
+        # Store submission in shared state for later retrieval
+        ctx.set_state("current_submission", submission)
+
+        # Create the agent request
+        message = (
+            f"Please analyze the following content for policy compliance:\n\n"
+            f"Title: {submission.title}\n"
+            f"Author: {submission.author}\n"
+            f"Content:\n{submission.body}"
+        )
+
+        await ctx.send_message(
+            AgentExecutorRequest(
+                messages=[Message(role="user", contents=[message])],
+                should_respond=True,
+            )
+        )
+
+
+# ============================================================================
+# Workflow Creation
+# ============================================================================
+
+
+def _create_workflow() -> Workflow:
+    """Create the content moderation workflow with HITL."""
+    client_kwargs = _build_client_kwargs()
+    chat_client = FoundryChatClient(**client_kwargs)
+
+    # Create the content analysis agent
+    content_analyzer_agent = Agent(
+        client=chat_client,
+        name=CONTENT_ANALYZER_AGENT_NAME,
+        instructions=CONTENT_ANALYZER_INSTRUCTIONS,
+        default_options=OpenAIChatOptions[Any](response_format=ContentAnalysisResult),
+    )
+
+    # Create executors
+    input_router = InputRouterExecutor()
+    content_analyzer_executor = ContentAnalyzerExecutor()
+    human_review_executor = HumanReviewExecutor()
+    notify_executor = NotifyExecutor()
+    publish_executor = PublishExecutor()
+
+    # Build the workflow graph
+    # Flow:
+    #   input_router -> content_analyzer_agent -> content_analyzer_executor
+    #   -> human_review_executor (HITL pause here) -> publish_executor
+    # Side-branch: human_review_executor -> notify_executor emails the reviewer a respond
+    # link (built from WorkflowHitlContext) in the same superstep, before the pause.
+    return (
+        WorkflowBuilder(name="content_moderation", start_executor=input_router)
+        .add_edge(input_router, content_analyzer_agent)
+        .add_edge(content_analyzer_agent, content_analyzer_executor)
+        .add_edge(content_analyzer_executor, human_review_executor)
+        .add_edge(human_review_executor, notify_executor)
+        .add_edge(human_review_executor, publish_executor)
+        .build()
+    )
+
+
+# ============================================================================
+# Application Entry Point
+# ============================================================================
+
+
+def launch(durable: bool = True) -> AgentFunctionApp | None:
+    """Launch the function app or DevUI.
+
+    Args:
+        durable: If True, returns AgentFunctionApp for Azure Functions.
+                 If False, launches DevUI for local MAF development.
+    """
+    if durable:
+        # Azure Functions mode with Durable Functions
+        # The app automatically provides per-workflow HITL endpoints (workflow name
+        # "content_moderation"):
+        # - POST /api/workflow/content_moderation/run - Start the workflow
+        # - GET  /api/workflow/content_moderation/status/{instanceId} - Status + pending HITL requests
+        # - POST /api/workflow/content_moderation/respond/{instanceId}/{requestId} - Send HITL response
+        # - GET  /api/health - Health check
+        workflow = _create_workflow()
+        return AgentFunctionApp(workflow=workflow, enable_health_check=True)
+    # Pure MAF mode with DevUI for local development
+    from pathlib import Path
+
+    from agent_framework.devui import serve
+    from dotenv import load_dotenv
+
+    env_path = Path(__file__).parent / ".env"
+    load_dotenv(dotenv_path=env_path)
+
+    logger.info("Starting Workflow HITL Sample in MAF mode")
+    logger.info("Available at: http://localhost:8096")
+    logger.info("\nThis workflow demonstrates:")
+    logger.info("- Human-in-the-loop using request_info / @response_handler pattern")
+    logger.info("- AI content analysis with structured output")
+    logger.info("- Human approval workflow integration")
+    logger.info("\nFlow: InputRouter -> ContentAnalyzer Agent -> HumanReview -> Notify/Publish")
+
+    workflow = _create_workflow()
+    serve(entities=[workflow], port=8096, auto_open=True)
+
+    return None
+
+
+# Default: Azure Functions mode
+# Run with `python function_app.py --maf` for pure MAF mode with DevUI
+app = launch(durable=True)
+
+
+if __name__ == "__main__":
+    import sys
+
+    if "--maf" in sys.argv:
+        # Run in pure MAF mode with DevUI
+        launch(durable=False)
+    else:
+        print("Usage: python function_app.py --maf")
+        print("  --maf    Run in pure MAF mode with DevUI (http://localhost:8096)")
+        print("\nFor Azure Functions mode, use: func start")

--- a/python/samples/azure_functions/12_workflow_hitl/host.json
+++ b/python/samples/azure_functions/12_workflow_hitl/host.json
@@ -1,0 +1,12 @@
+{
+  "version": "2.0",
+  "extensionBundle": {
+    "id": "Microsoft.Azure.Functions.ExtensionBundle",
+    "version": "[4.*, 5.0.0)"
+  },
+  "extensions": {
+    "durableTask": {
+      "hubName": "%TASKHUB_NAME%"
+    }
+  }
+}

--- a/python/samples/azure_functions/12_workflow_hitl/local.settings.json.sample
+++ b/python/samples/azure_functions/12_workflow_hitl/local.settings.json.sample
@@ -1,0 +1,11 @@
+{
+  "IsEncrypted": false,
+  "Values": {
+    "AzureWebJobsStorage": "UseDevelopmentStorage=true",
+    "DURABLE_TASK_SCHEDULER_CONNECTION_STRING": "Endpoint=http://localhost:8080;TaskHub=default;Authentication=None",
+    "TASKHUB_NAME": "default",
+    "FUNCTIONS_WORKER_RUNTIME": "python",
+    "FOUNDRY_PROJECT_ENDPOINT": "<FOUNDRY_PROJECT_ENDPOINT>",
+    "FOUNDRY_MODEL": "<FOUNDRY_MODEL>"
+  }
+}

--- a/python/samples/azure_functions/12_workflow_hitl/requirements.txt
+++ b/python/samples/azure_functions/12_workflow_hitl/requirements.txt
@@ -1,0 +1,14 @@
+# Agent Framework packages
+# To use the deployed version, uncomment the lines below and comment out the local installation lines
+# agent-framework-foundry
+# agent-framework-azurefunctions
+
+# Local installation (for development and testing)
+# Each package must be listed explicitly because pip doesn't resolve uv workspace sources.
+# Without explicit entries, pip would fetch transitive dependencies from PyPI instead of local source.
+agent-framework-foundry>=1.10.1,<2  # Foundry support from PyPI (pulls in core)
+-e ../../../packages/durabletask  # Durable Task support - dependency of azurefunctions
+-e ../../../packages/azurefunctions  # Azure Functions integration - the main package for this sample
+
+# Azure authentication
+azure-identity

--- a/python/samples/azure_functions/13_subworkflow_hitl/.gitignore
+++ b/python/samples/azure_functions/13_subworkflow_hitl/.gitignore
@@ -1,0 +1,5 @@
+# Local settings - copy from local.settings.json.sample and fill in your values
+local.settings.json
+__pycache__/
+*.pyc
+.venv/

--- a/python/samples/azure_functions/13_subworkflow_hitl/README.md
+++ b/python/samples/azure_functions/13_subworkflow_hitl/README.md
@@ -1,0 +1,90 @@
+# 13. Sub-workflow Human-in-the-Loop (HITL)
+
+This sample demonstrates a **nested** human-in-the-loop pause: the `request_info`
+happens inside an **inner workflow** that an outer workflow embeds via
+`WorkflowExecutor`. It runs on Azure Durable Functions and is the Azure Functions
+counterpart of the durabletask `12_subworkflow_hitl` sample.
+
+This sample hosts **no AI agents**, so it needs only Azurite and the Durable Task
+Scheduler emulator, with no model credentials.
+
+## Overview
+
+```
+moderation_pipeline (outer)
+  intake (executor)
+    -> review_sub = WorkflowExecutor(human_review)
+         review_gate (executor: request_info -> response_handler)   <-- HITL pause
+    -> publish (executor)
+```
+
+1. **User starts** the outer `moderation_pipeline` workflow with content.
+2. **`intake`** normalizes the submission and forwards it.
+3. **`review_sub`** runs the inner `human_review` workflow as a **child
+   orchestration**; its `review_gate` pauses via `request_info`.
+4. **The status endpoint** surfaces the nested pending request with a **qualified**
+   id `review_sub~0~{requestId}`.
+5. **The caller responds** against the *top-level* instance with that qualified id;
+   the host routes it to the owning child orchestration.
+6. **The inner workflow resumes**, yields its decision, and the outer `publish`
+   executor produces the final result.
+
+## Key Concept: one addressing surface for nested HITL
+
+On the durable host each `WorkflowExecutor` node runs its inner workflow as its own
+child orchestration, so a nested `request_info` is recorded on the *child* instance.
+`AgentFunctionApp` bubbles those nested requests up into the top-level status with a
+**qualified request id**, so the caller only ever addresses the top-level instance:
+
+| Part | Meaning |
+|------|---------|
+| `review_sub` | the `WorkflowExecutor` node id that owns the child |
+| `0` | the child's ordinal (a node may dispatch several children in one superstep) |
+| `{requestId}` | the inner workflow's bare request id |
+
+The separator is `~` (not `:`), so it never collides with framework-generated
+request ids such as functional-workflow `auto::N` ids.
+
+## Notifying a reviewer from inside a nested workflow
+
+This sample also notifies the reviewer from inside the inner workflow. The `review_gate` reads the id `request_info` generated and sends it to a downstream `NotifyExecutor`, which builds the respond URL with `WorkflowHitlContext`.
+
+```python
+# review_gate, inside the nested human_review workflow
+await ctx.request_info(request_data=HumanApprovalRequest(...), response_type=HumanApprovalResponse)
+request_id = await WorkflowHitlContext.pending_request_id(ctx)
+# ... send request_id to the notify executor ...
+
+# NotifyExecutor (also inside the inner workflow)
+hitl = WorkflowHitlContext.from_context(ctx)
+if hitl and request_id:
+    respond_url = hitl.build_respond_url(request_id)  # already qualified back to the root
+```
+
+The notify executor runs inside the child orchestration, yet `build_respond_url` returns a URL that targets the **top-level** instance with the qualified `review_sub~0~{requestId}` id. You pass only the **bare** inner id. The host propagates the address context (the root instance, the workflow name, and the `review_sub~0~` path prefix) down into the child, so the executor qualifies the id for you and never needs to know how it is embedded.
+
+The same two properties from the flat sample apply here. You never generate the id, because `request_info` creates it and `pending_request_id` reads it back, so call `pending_request_id` immediately after `request_info`. This is safe because each executor runs in its own Durable Functions activity with its own runner context, so the pending set only holds this executor's own requests and the newest one is the request you just emitted. And the email lives in a downstream executor, so a retried `review_gate` (activities are at least once) never emails a dead link, since only the committed attempt's id reaches the notifier.
+
+## Endpoints
+
+`AgentFunctionApp` exposes routes only for the **top-level** workflow; the inner
+workflow is driven as a child orchestration, not addressed directly.
+
+| Endpoint | Description |
+|----------|-------------|
+| `POST /api/workflow/moderation_pipeline/run` | Start the workflow |
+| `GET /api/workflow/moderation_pipeline/status/{instanceId}` | Status + nested pending HITL requests (qualified ids) |
+| `POST /api/workflow/moderation_pipeline/respond/{instanceId}/{requestId}` | Send the human response (use the qualified id) |
+| `GET /api/health` | Health check |
+
+## Running
+
+1. Start Azurite: `azurite --silent --location .`
+2. Start the Durable Task Scheduler emulator on `localhost:8080`.
+3. Copy `local.settings.json.sample` to `local.settings.json`.
+4. `func start`
+5. Drive it with [demo.http](./demo.http): start a run, GET the status to read the
+   qualified `review_sub~0~{requestId}`, then POST the response to the top-level
+   instance with that id.
+
+Run `python function_app.py --maf` for pure MAF mode with DevUI (no Azure Functions).

--- a/python/samples/azure_functions/13_subworkflow_hitl/demo.http
+++ b/python/samples/azure_functions/13_subworkflow_hitl/demo.http
@@ -1,0 +1,74 @@
+### ============================================================================
+### Sub-workflow HITL Sample - Nested Human-in-the-Loop behind one surface
+### ============================================================================
+### The HITL pause lives inside an inner workflow (human_review) that the outer
+### workflow (moderation_pipeline) embeds via WorkflowExecutor. The nested request
+### surfaces with a qualified id (review_sub~0~{requestId}); you respond against the
+### top-level instance and the host routes it to the owning child orchestration.
+###
+### This sample hosts no AI agents, so it needs only Azurite + the DTS emulator.
+###
+### Prerequisites:
+### 1. Start Azurite: azurite --silent --location .
+### 2. Start the Durable Task Scheduler emulator (localhost:8080)
+### 3. Run: func start
+### ============================================================================
+
+
+### ============================================================================
+### 1. Start the Workflow with Content for Moderation (will approve)
+### ============================================================================
+### Starts the outer workflow. It runs intake, then the embedded human_review
+### sub-workflow pauses for approval as a child orchestration.
+
+POST http://localhost:7071/api/workflow/moderation_pipeline/run
+Content-Type: application/json
+
+{
+  "content_id": "article-001",
+  "title": "Introduction to AI in Healthcare",
+  "body": "Artificial intelligence is improving healthcare by enabling faster diagnosis, personalized treatment plans, and better patient outcomes."
+}
+
+
+### ============================================================================
+### 2. Start Workflow with Spammy Content (will reject)
+### ============================================================================
+
+POST http://localhost:7071/api/workflow/moderation_pipeline/run
+Content-Type: application/json
+
+{
+  "content_id": "article-002",
+  "title": "Get Rich Quick",
+  "body": "Click here NOW to make $10,000 overnight! GUARANTEED! Limited time offer!"
+}
+
+
+### ============================================================================
+### 3. Check Workflow Status (shows the nested pending HITL request)
+### ============================================================================
+### Replace INSTANCE_ID with the value returned from the run call. The
+### pendingHumanInputRequests entry carries a qualified requestId of the form
+### "review_sub~0~<uuid>" because the pause lives in the sub-workflow.
+
+@instanceId = REPLACE_WITH_INSTANCE_ID
+
+GET http://localhost:7071/api/workflow/moderation_pipeline/status/{{instanceId}}
+
+
+### ============================================================================
+### 4. Respond to the nested HITL request (approve)
+### ============================================================================
+### Use the qualified requestId from the status response verbatim. The host
+### resolves it to the owning child orchestration.
+
+@requestId = REPLACE_WITH_QUALIFIED_REQUEST_ID
+
+POST http://localhost:7071/api/workflow/moderation_pipeline/respond/{{instanceId}}/{{requestId}}
+Content-Type: application/json
+
+{
+  "approved": true,
+  "reviewer_notes": "Looks good."
+}

--- a/python/samples/azure_functions/13_subworkflow_hitl/function_app.py
+++ b/python/samples/azure_functions/13_subworkflow_hitl/function_app.py
@@ -1,0 +1,352 @@
+# Copyright (c) Microsoft. All rights reserved.
+"""Composed workflow whose Human-in-the-Loop pause lives in a nested sub-workflow.
+
+This sample combines composition with human-in-the-loop on Azure Durable
+Functions: the HITL ``request_info`` happens **inside an inner workflow** that an
+outer workflow embeds via ``WorkflowExecutor``. On the durable host the inner
+workflow runs as its own child orchestration, so its pending request is recorded on
+the *child* instance. The parent records the child instance id in its custom status,
+which lets the host surface the nested request behind a single top-level addressing
+surface.
+
+``AgentFunctionApp`` walks the composition and registers a durable orchestration for
+each workflow, but exposes HTTP routes only for the **top-level** workflow:
+
+- ``dafx-moderation_pipeline`` - the outer workflow (HTTP routes).
+- ``dafx-human_review`` - the inner workflow (run as a child orchestration), which
+  contains the HITL pause (no direct routes).
+
+Composition layout::
+
+    moderation_pipeline (outer)
+      intake (executor)
+        -> review_sub = WorkflowExecutor(human_review)
+             review_gate (executor: request_info -> response_handler)
+        -> publish (executor)
+
+The status endpoint surfaces the inner pending request with a **qualified** request
+id (``review_sub~0~{requestId}``); the caller posts the response back to the
+*top-level* instance and the host routes it to the owning child orchestration
+automatically.
+
+This sample hosts **no AI agents**, so it needs only the Durable Task Scheduler and
+Azurite (no model credentials).
+
+Prerequisites:
+- Start Azurite: ``azurite --silent --location .``
+- Start a Durable Task Scheduler emulator on ``localhost:8080``.
+- Run: ``func start``
+"""
+
+import logging
+from dataclasses import dataclass
+
+from agent_framework import (
+    Executor,
+    Workflow,
+    WorkflowBuilder,
+    WorkflowContext,
+    WorkflowExecutor,
+    handler,
+    response_handler,
+)
+from agent_framework_azurefunctions import AgentFunctionApp, WorkflowHitlContext
+from pydantic import BaseModel
+from typing_extensions import Never
+
+logger = logging.getLogger(__name__)
+
+INNER_WORKFLOW_NAME = "human_review"
+OUTER_WORKFLOW_NAME = "moderation_pipeline"
+
+
+# ============================================================================
+# Data Models
+# ============================================================================
+
+
+@dataclass
+class ContentSubmission:
+    """Content submitted for moderation (outer workflow input)."""
+
+    content_id: str
+    title: str
+    body: str
+
+
+@dataclass
+class HumanApprovalRequest:
+    """Request surfaced to the human reviewer (carried in the orchestration status)."""
+
+    content_id: str
+    title: str
+    body: str
+    prompt: str
+
+
+class HumanApprovalResponse(BaseModel):
+    """Response the external client sends back via the HITL response endpoint."""
+
+    approved: bool
+    reviewer_notes: str = ""
+
+
+@dataclass
+class ModerationDecision:
+    """The inner workflow's output: the human's decision for a submission."""
+
+    content_id: str
+    approved: bool
+    reviewer_notes: str
+
+
+@dataclass
+class HumanReviewNotification:
+    """Payload handed to the notifier so it can build the (qualified) respond URL.
+
+    Carries the ``request_id`` the review gate passed to ``ctx.request_info`` so the
+    notifier addresses the exact pending request the (nested) workflow waits on.
+    """
+
+    request_id: str
+    content_id: str
+    prompt: str
+
+
+# ============================================================================
+# Inner workflow (contains the HITL pause)
+# ============================================================================
+
+
+class ReviewGateExecutor(Executor):
+    """Inner-workflow executor that pauses for human approval via request_info."""
+
+    def __init__(self) -> None:
+        super().__init__(id="review_gate")
+
+    @handler
+    async def request_review(
+        self, submission: ContentSubmission, ctx: WorkflowContext[HumanReviewNotification]
+    ) -> None:
+        prompt = (
+            f"Please review the following content for publication:\n\n"
+            f"Title: {submission.title}\n"
+            f"Content: {submission.body}\n\n"
+            f"Approve or reject this content."
+        )
+        approval_request = HumanApprovalRequest(
+            content_id=submission.content_id,
+            title=submission.title,
+            body=submission.body,
+            prompt=prompt,
+        )
+        # Pause the (inner) workflow and wait for a human response. On the durable host
+        # this pauses the child orchestration running this inner workflow. request_info
+        # generates the request id; read it back so the downstream notifier can build
+        # the (qualified) respond URL -- no need to mint an id by hand.
+        await ctx.request_info(
+            request_data=approval_request,
+            response_type=HumanApprovalResponse,
+        )
+        request_id = await WorkflowHitlContext.pending_request_id(ctx)
+        assert request_id is not None  # always set immediately after request_info
+
+        # Side-branch: hand the request id to the notifier so it can build the respond
+        # URL. The notifier is a separate (downstream) activity, so only this activity's
+        # committed id reaches it -- retries notify no one. This message is drained
+        # before the (inner) workflow pauses.
+        await ctx.send_message(
+            HumanReviewNotification(
+                request_id=request_id,
+                content_id=submission.content_id,
+                prompt=prompt,
+            ),
+            target_id="notify",
+        )
+
+    @response_handler
+    async def handle_approval_response(
+        self,
+        original_request: HumanApprovalRequest,
+        response: HumanApprovalResponse,
+        ctx: WorkflowContext[Never, ModerationDecision],
+    ) -> None:
+        logger.info(
+            "Human review received for content %s: approved=%s",
+            original_request.content_id,
+            response.approved,
+        )
+        # Yield the decision as the inner workflow's output; the WorkflowExecutor
+        # forwards it to the outer workflow as a message to the next node.
+        await ctx.yield_output(
+            ModerationDecision(
+                content_id=original_request.content_id,
+                approved=response.approved,
+                reviewer_notes=response.reviewer_notes,
+            )
+        )
+
+
+class NotifyExecutor(Executor):
+    """Inner-workflow notifier that builds the qualified respond URL for the reviewer.
+
+    Runs inside the nested ``human_review`` child orchestration, so the respond URL it
+    builds via :class:`WorkflowHitlContext` targets the **top-level** instance with a
+    qualified request id (``review_sub~0~{requestId}``) -- the address context is
+    propagated down from the parent, so this executor needs no knowledge of how it is
+    embedded.
+    """
+
+    def __init__(self) -> None:
+        super().__init__(id="notify")
+
+    @handler
+    async def notify(self, notification: HumanReviewNotification, ctx: WorkflowContext) -> None:
+        hitl = WorkflowHitlContext.from_context(ctx)
+        if hitl is None:
+            logger.info(
+                "Not on the durable host; skipping reviewer notification for content %s.",
+                notification.content_id,
+            )
+            return
+
+        try:
+            respond_url = hitl.build_respond_url(notification.request_id)
+        except RuntimeError:
+            # No base URL configured (WEBSITE_HOSTNAME unset and no override). Notifying
+            # is best-effort -- the request is still reachable via the status endpoint --
+            # so warn and continue rather than failing the workflow.
+            logger.warning(
+                "Cannot build a respond URL (set WEBSITE_HOSTNAME). Skipping reviewer notification for content %s.",
+                notification.content_id,
+            )
+            return
+
+        # In a real application, email/Teams this URL to the reviewer. They POST
+        # {"approved": bool, "reviewer_notes": str} to it to resume the run.
+        logger.info(
+            "Human review needed for content %s.\n  Respond at: %s",
+            notification.content_id,
+            respond_url,
+        )
+
+
+def create_inner_workflow() -> Workflow:
+    """Build the inner ``human_review`` workflow (HITL gate + reviewer notifier)."""
+    review_gate = ReviewGateExecutor()
+    notify = NotifyExecutor()
+    # Side-branch: review_gate -> notify builds the qualified respond URL in the same
+    # superstep that raises the request, before the inner workflow pauses.
+    return WorkflowBuilder(name=INNER_WORKFLOW_NAME, start_executor=review_gate).add_edge(review_gate, notify).build()
+
+
+# ============================================================================
+# Outer workflow (embeds the inner workflow)
+# ============================================================================
+
+
+class IntakeExecutor(Executor):
+    """Outer-workflow entry point that normalizes the submission before review."""
+
+    def __init__(self) -> None:
+        super().__init__(id="intake")
+
+    @handler
+    async def intake(self, submission: ContentSubmission, ctx: WorkflowContext[ContentSubmission]) -> None:
+        logger.info("Intake received submission %s", submission.content_id)
+        await ctx.send_message(submission)
+
+
+class PublishExecutor(Executor):
+    """Outer-workflow executor that consumes the inner workflow's forwarded decision."""
+
+    def __init__(self) -> None:
+        super().__init__(id="publish")
+
+    @handler
+    async def handle_decision(self, decision: ModerationDecision, ctx: WorkflowContext[Never, str]) -> None:
+        if decision.approved:
+            message = (
+                f"Content '{decision.content_id}' APPROVED and published. "
+                f"Reviewer notes: {decision.reviewer_notes or 'None'}"
+            )
+        else:
+            message = f"Content '{decision.content_id}' REJECTED. Reviewer notes: {decision.reviewer_notes or 'None'}"
+        logger.info(message)
+        await ctx.yield_output(message)
+
+
+def _create_workflow() -> Workflow:
+    """Build the outer ``moderation_pipeline`` workflow embedding the HITL sub-workflow."""
+    inner_workflow = create_inner_workflow()
+
+    intake = IntakeExecutor()
+    # WorkflowExecutor embeds the inner (HITL) workflow as a single node. On the
+    # durable host this node runs as a child orchestration, and the inner pause
+    # surfaces to the client as a qualified request id (``review_sub~0~{requestId}``).
+    review_sub = WorkflowExecutor(inner_workflow, id="review_sub")
+    publish = PublishExecutor()
+
+    return (
+        WorkflowBuilder(name=OUTER_WORKFLOW_NAME, start_executor=intake)
+        .add_edge(intake, review_sub)
+        .add_edge(review_sub, publish)
+        .build()
+    )
+
+
+# ============================================================================
+# Application Entry Point
+# ============================================================================
+
+
+def launch(durable: bool = True) -> AgentFunctionApp | None:
+    """Launch the function app or DevUI.
+
+    Args:
+        durable: If True, returns AgentFunctionApp for Azure Functions.
+                 If False, launches DevUI for local MAF development.
+    """
+    if durable:
+        # Azure Functions mode. The app automatically provides per-workflow HITL
+        # endpoints for the top-level workflow ("moderation_pipeline"):
+        # - POST /api/workflow/moderation_pipeline/run
+        # - GET  /api/workflow/moderation_pipeline/status/{instanceId}
+        #        (surfaces the nested request as review_sub~0~{requestId})
+        # - POST /api/workflow/moderation_pipeline/respond/{instanceId}/{requestId}
+        # - GET  /api/health
+        workflow = _create_workflow()
+        return AgentFunctionApp(workflow=workflow, enable_health_check=True)
+
+    # Pure MAF mode with DevUI for local development.
+    from pathlib import Path
+
+    from agent_framework.devui import serve
+    from dotenv import load_dotenv
+
+    env_path = Path(__file__).parent / ".env"
+    load_dotenv(dotenv_path=env_path)
+
+    logger.info("Starting Sub-workflow HITL Sample in MAF mode")
+    logger.info("Available at: http://localhost:8097")
+    logger.info("\nThis workflow demonstrates:")
+    logger.info("- Human-in-the-loop inside a nested sub-workflow (WorkflowExecutor)")
+    logger.info("- Qualified request ids (review_sub~0~{requestId}) behind a single surface")
+    logger.info("\nFlow: Intake -> WorkflowExecutor(human_review: ReviewGate HITL) -> Publish")
+
+    workflow = _create_workflow()
+    serve(entities=[workflow], port=8097, auto_open=True)
+
+    return None
+
+
+# Default: Azure Functions mode
+# Run with `python function_app.py --maf` for pure MAF mode with DevUI
+app = launch(durable=True)
+
+
+if __name__ == "__main__":
+    import sys
+
+    if "--maf" in sys.argv:
+        launch(durable=False)

--- a/python/samples/azure_functions/13_subworkflow_hitl/host.json
+++ b/python/samples/azure_functions/13_subworkflow_hitl/host.json
@@ -1,0 +1,12 @@
+{
+  "version": "2.0",
+  "extensionBundle": {
+    "id": "Microsoft.Azure.Functions.ExtensionBundle",
+    "version": "[4.*, 5.0.0)"
+  },
+  "extensions": {
+    "durableTask": {
+      "hubName": "%TASKHUB_NAME%"
+    }
+  }
+}

--- a/python/samples/azure_functions/13_subworkflow_hitl/local.settings.json.sample
+++ b/python/samples/azure_functions/13_subworkflow_hitl/local.settings.json.sample
@@ -1,0 +1,9 @@
+{
+  "IsEncrypted": false,
+  "Values": {
+    "AzureWebJobsStorage": "UseDevelopmentStorage=true",
+    "DURABLE_TASK_SCHEDULER_CONNECTION_STRING": "Endpoint=http://localhost:8080;TaskHub=default;Authentication=None",
+    "TASKHUB_NAME": "default",
+    "FUNCTIONS_WORKER_RUNTIME": "python"
+  }
+}

--- a/python/samples/azure_functions/13_subworkflow_hitl/requirements.txt
+++ b/python/samples/azure_functions/13_subworkflow_hitl/requirements.txt
@@ -1,0 +1,10 @@
+# Agent Framework packages
+# To use the deployed version, uncomment the lines below and comment out the local installation lines
+# agent-framework-azurefunctions
+
+# Local installation (for development and testing)
+# Each package must be listed explicitly because pip doesn't resolve uv workspace sources.
+# Without explicit entries, pip would fetch transitive dependencies from PyPI instead of local source.
+# This sample hosts no AI agents, so it needs only the core + durabletask + azurefunctions packages.
+-e ../../../packages/durabletask  # Durable Task support - dependency of azurefunctions
+-e ../../../packages/azurefunctions  # Azure Functions integration - the main package for this sample

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -29,6 +29,7 @@ supported-markers = [
 
 [manifest]
 members = [
+    "agent-framework-azurefunctions",
     "agent-framework-durable-extension",
     "agent-framework-durabletask",
 ]
@@ -43,14 +44,33 @@ overrides = [
 ]
 
 [[package]]
+name = "agent-framework-azurefunctions"
+version = "1.0.0b260709"
+source = { editable = "packages/azurefunctions" }
+dependencies = [
+    { name = "agent-framework-core", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "agent-framework-durabletask", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "azure-functions", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "azure-functions-durable", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "agent-framework-core", specifier = ">=1.11.0,<2" },
+    { name = "agent-framework-durabletask", editable = "packages/durabletask" },
+    { name = "azure-functions", specifier = ">=1.24.0,<2" },
+    { name = "azure-functions-durable", specifier = ">=1.3.1,<2" },
+]
+
+[[package]]
 name = "agent-framework-core"
 version = "1.11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "opentelemetry-api" },
-    { name = "pydantic" },
-    { name = "python-dotenv" },
-    { name = "typing-extensions" },
+    { name = "opentelemetry-api", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "pydantic", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "python-dotenv", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "typing-extensions", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/96/c2/e42a2ee46c1c30acc1082dd4881c032170f315f18355486094ee689925f1/agent_framework_core-1.11.0.tar.gz", hash = "sha256:758a06812b27cdba2a6c3d02ef6785971bd7b627a5b9482fb6defb3f0caf88ec", size = 498640, upload-time = "2026-07-10T03:42:25.475Z" }
 wheels = [
@@ -64,30 +84,30 @@ source = { virtual = "." }
 
 [package.dev-dependencies]
 dev = [
-    { name = "flit" },
-    { name = "mypy" },
-    { name = "opentelemetry-sdk" },
-    { name = "poethepoet" },
-    { name = "prek" },
-    { name = "pyrefly" },
-    { name = "pyright" },
-    { name = "pytest" },
-    { name = "pytest-asyncio" },
-    { name = "pytest-cov" },
-    { name = "pytest-retry" },
-    { name = "pytest-timeout" },
-    { name = "pytest-xdist", extra = ["psutil"] },
-    { name = "rich" },
-    { name = "ruff" },
-    { name = "tomli" },
-    { name = "ty" },
-    { name = "uv" },
-    { name = "zuban" },
+    { name = "flit", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "mypy", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "opentelemetry-sdk", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "poethepoet", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "prek", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "pyrefly", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "pyright", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "pytest", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "pytest-asyncio", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "pytest-cov", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "pytest-retry", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "pytest-timeout", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "pytest-xdist", extra = ["psutil"], marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "rich", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "ruff", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "tomli", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "ty", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "uv", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "zuban", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 test = [
-    { name = "azure-monitor-opentelemetry" },
-    { name = "mcp", extra = ["ws"] },
-    { name = "redis" },
+    { name = "azure-monitor-opentelemetry", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "mcp", extra = ["ws"], marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "redis", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 
 [package.metadata]
@@ -125,15 +145,15 @@ name = "agent-framework-durabletask"
 version = "1.0.0b260709"
 source = { editable = "packages/durabletask" }
 dependencies = [
-    { name = "agent-framework-core" },
-    { name = "durabletask" },
-    { name = "durabletask-azuremanaged" },
-    { name = "python-dateutil" },
+    { name = "agent-framework-core", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "durabletask", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "durabletask-azuremanaged", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "python-dateutil", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 
 [package.dev-dependencies]
 dev = [
-    { name = "types-python-dateutil" },
+    { name = "types-python-dateutil", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 
 [package.metadata]
@@ -146,6 +166,161 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [{ name = "types-python-dateutil", specifier = "==2.9.0.20260518" }]
+
+[[package]]
+name = "aiohappyeyeballs"
+version = "2.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ce/f4/eec0465c2f67b2664688d0240b3212d5196fd89e741df67ddb81f8d35658/aiohappyeyeballs-2.7.1.tar.gz", hash = "sha256:065665c041c42a5938ed220bdcd7230f22527fbec085e1853d2402c8a3615d9d", size = 24757, upload-time = "2026-07-01T17:11:55.501Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/43/1947f06babed6b3f1d7f38b0c767f52df66bfb2bc10b468c4a7de9eceff2/aiohappyeyeballs-2.7.1-py3-none-any.whl", hash = "sha256:9243213661e29250eb41368e5daa826fc017156c3b8a11440826b2e3ed376472", size = 15038, upload-time = "2026-07-01T17:11:54.055Z" },
+]
+
+[[package]]
+name = "aiohttp"
+version = "3.14.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohappyeyeballs", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "aiosignal", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "async-timeout", marker = "(python_full_version < '3.11' and sys_platform == 'darwin') or (python_full_version < '3.11' and sys_platform == 'linux') or (python_full_version < '3.11' and sys_platform == 'win32')" },
+    { name = "attrs", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "frozenlist", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "multidict", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "propcache", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "typing-extensions", marker = "(python_full_version < '3.13' and sys_platform == 'darwin') or (python_full_version < '3.13' and sys_platform == 'linux') or (python_full_version < '3.13' and sys_platform == 'win32')" },
+    { name = "yarl", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/82/78/8ea7308cac6934de8c74a14f3d5f65d1c89287426688be79538d0e5c013d/aiohttp-3.14.1.tar.gz", hash = "sha256:307f2cff90a764d329e77040603fa032db89c5c24fdad50c4c15334cba744035", size = 7955794, upload-time = "2026-06-07T21:09:35.529Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6d/67/58ded4b3f2e10f94972d8928050c85330e249a31dd45a0e5f3c0e9c3fa05/aiohttp-3.14.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:8f6bb621e5863cfe8fe5ff5468002d200ec31f30f1280b259dc505b02595099e", size = 766140, upload-time = "2026-06-07T21:05:37.471Z" },
+    { url = "https://files.pythonhosted.org/packages/18/68/4ae5b4e08943f316594bb68da89957d3baf5760588fa09509594bd777e4b/aiohttp-3.14.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:4f7215cb3933784f79ed20e5f050e15984f390424339b22375d5a53c933a0491", size = 519430, upload-time = "2026-06-07T21:05:40.751Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/c1/316c8f3549dbe5245f92bfd523ec6f32dd4d98cafe21df3f6a19b1184c75/aiohttp-3.14.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:d9d4e294455b23a68c9b8f042d0e8e377a265bcb15332753695f6e5b6819e0ce", size = 514406, upload-time = "2026-06-07T21:05:42.111Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/ee/fb0ac28684e8d753b83c8a4eebc19a5846912aa0a4daaabb6a9936363840/aiohttp-3.14.1-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b238af795833d5731d049d82bc84b768ae6f8f97f0495963b3ed9935c5901cc3", size = 1703649, upload-time = "2026-06-07T21:05:43.427Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/57/aa2beab673331f111885db8a7b69dfe3ab0e53e446a0ace18ca694b4dc58/aiohttp-3.14.1-cp310-cp310-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:e4e5e0ae56914ecdbf446493addefc0159053dd53962cef37d7839f37f73d505", size = 1675126, upload-time = "2026-06-07T21:05:44.897Z" },
+    { url = "https://files.pythonhosted.org/packages/47/ea/dad128abe365e79be03b16ed464198ac73e0d257e8260c6f7d6f31cbef26/aiohttp-3.14.1-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:092e4ce3619a7c6dee52a6bdabda973d9b34b66781f840ce93c7e0cec30cf521", size = 1771558, upload-time = "2026-06-07T21:05:46.405Z" },
+    { url = "https://files.pythonhosted.org/packages/63/f3/b5b4e10327cb85d34d24232c6b71b64602f190b3ccb238a043ac6b187dac/aiohttp-3.14.1-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:bb33777ea21e8b7ecde0e6fc84f598be0a1192eab1a63bc746d75aa75d38e7bd", size = 1856631, upload-time = "2026-06-07T21:05:47.844Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/9d/93294c3045775c708ac8310eb3d3622a11d2951345ad590d532d62a1faa4/aiohttp-3.14.1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:23119f8fd4f5d16902ed459b63b100bcd269628075162bddac56cc7b5273b3fb", size = 1714139, upload-time = "2026-06-07T21:05:49.982Z" },
+    { url = "https://files.pythonhosted.org/packages/29/c4/93067c85a0373492ce8e577435203c5947c454af074ac48ed4f3a1b9dd4a/aiohttp-3.14.1-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:57fc6745a4b7d0f5a9eb4f40a69718be6c0bc1b8368cc9fe89e90118719f4f42", size = 1588321, upload-time = "2026-06-07T21:05:51.431Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/39/9ff91aaf02af8b7b8222a987466da539f154c3e01732c22b5f5a20a8ee66/aiohttp-3.14.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:6fd35beba67c4183b09375c5fff9accb47524191a244a99f95fd4472f5402c2b", size = 1670375, upload-time = "2026-06-07T21:05:53.109Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/e4/77452a3676b8d99ac1375f77691d6bf65ea6e9f4b201b82ef77c916dc767/aiohttp-3.14.1-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:672b9d65f42eb877f5c3f234a4547e4e1a226ca8c2eed879bb34670a0ce51192", size = 1690933, upload-time = "2026-06-07T21:05:54.902Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/84/b0059a7c7fc05ea23f3bc1596ba91c12f79588b9450564a24cac37536d0a/aiohttp-3.14.1-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:24ba13339fed9251d9b1a1bec8c7ab84c0d1675d79d33501e11f94f8b9a84e05", size = 1740798, upload-time = "2026-06-07T21:05:56.458Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/3a/e2a513ecbfc362591caa51a7f7e011b3bfc8938b388ae44cd95560d36999/aiohttp-3.14.1-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:94da27378da0610e341c4d30de29a191672683cc82b8f9556e8f7c7212a020fe", size = 1576412, upload-time = "2026-06-07T21:05:57.953Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/10/08f1654f538f93d36dcac66310a06eefce4641cdafca83f9f0a5317be254/aiohttp-3.14.1-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:52cdac9432d8b4a719f35094a818d95adcae0f0b4fe9b9b921909e0c87de9e7d", size = 1750199, upload-time = "2026-06-07T21:05:59.488Z" },
+    { url = "https://files.pythonhosted.org/packages/99/e4/d91b70c57d8b8e9611e4a2e52238ca3698d3dc1c2efe25b7a9bf594ac584/aiohttp-3.14.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:672ac254412a24d0d0cf00a9e6c238877e4be5e5fa2d188832c1244f45f31966", size = 1699356, upload-time = "2026-06-07T21:06:01.131Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/f1/15340176f35ff61b95dbe34020bcf43f9e624a2d7bbac934715ff97d2033/aiohttp-3.14.1-cp310-cp310-win32.whl", hash = "sha256:2fe3607e71acc6ebb0ec8e492a247bf7a291226192dc0084236dfc12478916f6", size = 458939, upload-time = "2026-06-07T21:06:02.86Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/c2/a2f1ec5b37f903109e43ae2862268cfe4a67a60c1b2cf43169fcdff5995f/aiohttp-3.14.1-cp310-cp310-win_amd64.whl", hash = "sha256:30099eda75a53c32efb0920e9c33c195314d2cc1c680fbfd30894932ac5f27df", size = 482583, upload-time = "2026-06-07T21:06:04.666Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/7a/7b56f6732ef79530afaa72aa335d41b67c8d79b946995f0b11ad72985435/aiohttp-3.14.1-cp310-cp310-win_arm64.whl", hash = "sha256:5a837f49d901f9e368651b676912bff1104ed8c1a83b280bcd7b29adccef5c9c", size = 453470, upload-time = "2026-06-07T21:06:06.322Z" },
+    { url = "https://files.pythonhosted.org/packages/26/dd/bf526e6f0a1120dd6f2df2e97bacfe4d358f13d17a0ff5847301a1375a51/aiohttp-3.14.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:aa00140699487bd435fde4342d85c94cb256b7cd3a5b9c3396c67f19922afda2", size = 765225, upload-time = "2026-06-07T21:06:07.957Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/e1/a2872aa55495a70f61310d411541c6ee23812d9a884e000c716e1bc3edbf/aiohttp-3.14.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:1c1af67559445498b502030c35c59db59966f47041ca9de5b4e707f86bd10b5f", size = 518743, upload-time = "2026-06-07T21:06:09.749Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/e7/c60c7b209e509cc787de3cea0550a518538cfc08003e1c1e14c1c63fff71/aiohttp-3.14.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:d44ec478e713ee7f29b439f7eb8dc2b9d4079e11ae114d2c2ac3d5daf30516c8", size = 514139, upload-time = "2026-06-07T21:06:11.26Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/8d/614ace2f579702c9840ab1e1447fd8509e35b0b904f7196418fa2f57b25d/aiohttp-3.14.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d3b1a184a9a8f548a6b73f1e26b96b052193e4b3175ed7342aaf1151a1f00a04", size = 1784088, upload-time = "2026-06-07T21:06:12.887Z" },
+    { url = "https://files.pythonhosted.org/packages/49/e0/726e90f99542bf292f81a96a12cc4847deb86f3ccf62c6f4014a201f4d33/aiohttp-3.14.1-cp311-cp311-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:5f2504bc0322437c9a1ff6d3333ca56c7477b727c995f036b976ae17b98372c8", size = 1737835, upload-time = "2026-06-07T21:06:14.564Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/4b/d176d5c4db9d33dacf0543102ea59503bc1d528af4cfd0b719949ca49389/aiohttp-3.14.1-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:73f05ea02013e02512c3bf42714f1208c57168c779cc6fe23516e4543089d0a6", size = 1842801, upload-time = "2026-06-07T21:06:16.228Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/d6/5a99b563690ea0cbed912ae94a2ce33993a5709a651a3a4fe761e7dd973a/aiohttp-3.14.1-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:797457503c2d426bee06eef808d07b31ede30b65e054444e7de64cad0061b7af", size = 1929992, upload-time = "2026-06-07T21:06:17.947Z" },
+    { url = "https://files.pythonhosted.org/packages/76/7f/a987b14a3859094b3cea3f4825219c3e5536242564af6e3f9c2f6c994eb2/aiohttp-3.14.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b821a1f7dedf7e37450654e620038ac3b2e81e8fa6ea269337e97101978ec730", size = 1786989, upload-time = "2026-06-07T21:06:19.677Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/1a/420e5c85a3e73349372ed22ce0b6af86bfa6ce16a4b20a64a2e94608c781/aiohttp-3.14.1-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:4cd96b5ba05d67ed0cf00b5b405c8cd99586d8e3481e8ee0a831057591af7621", size = 1640129, upload-time = "2026-06-07T21:06:22.558Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/80/18a592ed3be0a402cc03670bd72ee1f8563ddbe1d8d5542dbf868f274136/aiohttp-3.14.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:1d459b98a932296c6f0e94f87511a0b1b90a8a02c30a50e60a297619cd5a58ee", size = 1756576, upload-time = "2026-06-07T21:06:24.8Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/0b/8b3d5713373858ff71a617daf6e3b0e81ad63e79d09a3cf2f6b6b983939c/aiohttp-3.14.1-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:764457a7be60825fb770a644852ff717bcbb5042f189f2bd16df61a81b3f6573", size = 1754668, upload-time = "2026-06-07T21:06:26.528Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/49/fd564575cf225821d7ba5a117cb8bc27213d8a7e1811162afb43ae077039/aiohttp-3.14.1-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:f7a16ef45b081454ef844502d87a848876c490c4cb5c650c230f6ec79ed2c1e7", size = 1817019, upload-time = "2026-06-07T21:06:28.297Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/1b/e850c9ae6fc91356552ae668bb6c51e93fa29c8aef13398a10b56678557f/aiohttp-3.14.1-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:2fbc3ed048b3475b9f0cbcb9978e9d2d3511acd91ead203af26ed9f0056004cf", size = 1631638, upload-time = "2026-06-07T21:06:30.242Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/94/3c337ba72451a89806ace6f75bddc92bafc5b8d53d90115a512858024b63/aiohttp-3.14.1-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:bedb0cd073cc2dc035e30aeb99444389d3cd2113afe4ef9fcd23d439f5bade85", size = 1835660, upload-time = "2026-06-07T21:06:31.943Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/9c/9c18cf367a0498212d9ba7daf990b504a5e8ae064cda4b504e2647c89c03/aiohttp-3.14.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:b6feea921016eb3d4e04d65fc4e9ca402d1a3801f562aef94989f54694917af3", size = 1775698, upload-time = "2026-06-07T21:06:33.72Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/63/a251a9d2a6cb45065b2ddc0bde2b3dd10108740a9a42f632c66405a761a2/aiohttp-3.14.1-cp311-cp311-win32.whl", hash = "sha256:313701e488100074ce99850404ee36e741abf6330179fec908a1944ecf570126", size = 458386, upload-time = "2026-06-07T21:06:35.279Z" },
+    { url = "https://files.pythonhosted.org/packages/17/ca/69274c51dcd6e8947d77b2806cf47a4a15f2c846e2cbeb1882547d3da283/aiohttp-3.14.1-cp311-cp311-win_amd64.whl", hash = "sha256:03ab4530fdcb3a543a122ba4b65ac9919da9fe9f78a03d328a6e38ff962f7aa5", size = 483406, upload-time = "2026-06-07T21:06:36.824Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/8a/c25904f77690c3688ec140f87591ef11a0cfe36bf3d5c0f1f38056fb62b3/aiohttp-3.14.1-cp311-cp311-win_arm64.whl", hash = "sha256:486f7d16ed54c39c2cbd7ca71fd8ba2b8bb7860df65bd7b6ed640bab96a38a8b", size = 452987, upload-time = "2026-06-07T21:06:38.371Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/21/151624b51cd92553d95424daf4bf19f19ce9be9002d19253e7e7ce67197b/aiohttp-3.14.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:d35143e27778b4bb0fb189562d7f275bff79c62ab8e98459717c0ea617ff2480", size = 757402, upload-time = "2026-06-07T21:06:40.311Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/82/280619e0bd7bf2454987e19282616e84762255dd9c8468f62382e8c191f1/aiohttp-3.14.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:bcfb80a2cc36fba2534e5e5b5264dc7ae6fcd9bf15256da3e53d2f499e6fa29d", size = 512310, upload-time = "2026-06-07T21:06:42.207Z" },
+    { url = "https://files.pythonhosted.org/packages/55/b2/2aac325583aaa1353045f96dffa586d8a34e8322e14a7ba49cffeb103ab4/aiohttp-3.14.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:27fd7c91e51729b4f7e1577865fa6d34c9adccbc39aabe9000285b48af9f0ec2", size = 512448, upload-time = "2026-06-07T21:06:43.813Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/72/a60607cb849faa8af8a356c9329ea2eb6f395d49e82cc82ccba1fd8deb8f/aiohttp-3.14.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:64c567bf9eaf664280116a8688f63016e6b32db2505908e2bdaca1b6438142f2", size = 1766854, upload-time = "2026-06-07T21:06:45.391Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/d3/d9fe1c9ec7557ab4d0d82bebaa728c6418f0b93295ec2f4ab015f7710cc7/aiohttp-3.14.1-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:f5e6ff2bdbb8f4cd3fbe41f99e25bbcd58e3bf9f13d3dd31a11e7917251cc77a", size = 1740884, upload-time = "2026-06-07T21:06:47.413Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/dc/f2cecfaf9337ba3e63f181500814ff502aa3d00d9c7ec93a9d23d10a27b2/aiohttp-3.14.1-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2f73e01dc37122325caf079982621262f96d74823c179038a82fddfc50359264", size = 1810034, upload-time = "2026-06-07T21:06:50.165Z" },
+    { url = "https://files.pythonhosted.org/packages/66/d7/2ff65c5e65c0d7476daf7e15c032e0805e36811185b9623e3238ad6c763e/aiohttp-3.14.1-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:bb2c0c80d431c0d03f2c7dbf125150fedd4f0de17366a7ca33f7ccb822391842", size = 1904054, upload-time = "2026-06-07T21:06:52.035Z" },
+    { url = "https://files.pythonhosted.org/packages/20/9c/d445818389df371f56d141d881153ba23183c4735a03f7356ffb43f7757d/aiohttp-3.14.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3e6fc1a85fa7194a1a7d19f44e8609180f4a8eb5fa4c7ed8b4355f080fad235c", size = 1790278, upload-time = "2026-06-07T21:06:54.049Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/aa/bf04cb4d865fc6101c2229a294ad744973b72e513fdc5a6b791e6983d72a/aiohttp-3.14.1-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:686b6c0d3911ec387b444ddf5dc62fb7f7c0a7d5186a7861626496a5ab4aff95", size = 1591795, upload-time = "2026-06-07T21:06:55.911Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/b4/4dac0038960427ba832f6609dfb4ea5437d7fd80c72001b9e48f834f428b/aiohttp-3.14.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:c6fa4dc7ad6f8109c70bb1499e589f76b0b792baf39f9b017eb92c8a81d0a199", size = 1728397, upload-time = "2026-06-07T21:06:57.777Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/f9/7cd4e8ad7aa3b75f17d56bb5498dd604a93d4e6eece822ba0568c413fff0/aiohttp-3.14.1-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:87a5eea1b2a5e21e1ebdbb33ad4165359189327e63fc4e4894693e7f821ac817", size = 1766504, upload-time = "2026-06-07T21:07:00.009Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/df/fc01d9fcad0f73fed3f3d361f1f94f975947b50dff82919f6dc2bf4316cc/aiohttp-3.14.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:1c1421eb01d4fd608d88cc8290211d177a58532b55ad94076fb349c5bf467f0a", size = 1777806, upload-time = "2026-06-07T21:07:02.064Z" },
+    { url = "https://files.pythonhosted.org/packages/41/09/47e2d090bddcc8fb4ccb4c314aadc32d7c5d9bb55f50f6ad1c92fc15d501/aiohttp-3.14.1-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:34b257ec41345c1e8f2df68fa908a7952f5de932723871eb633ecbbff396c9a4", size = 1580707, upload-time = "2026-06-07T21:07:03.942Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/36/f1a4ce904ae0b6930cfe9afc96d0896f7ec1a620c400405d63783bb95a9c/aiohttp-3.14.1-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:de538791a80e5d862addbc183f70f0158ac9b9bb872bb147f1fd2a683691e087", size = 1798121, upload-time = "2026-06-07T21:07:05.987Z" },
+    { url = "https://files.pythonhosted.org/packages/70/0a/e0075ce9ca0279ee1d4f0c0b85f54fea02ebc83c3007651a72bece658fec/aiohttp-3.14.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:6f71173be42d3241d428f760122febb748de0623f44308a6f120d0dd9ec572e3", size = 1767580, upload-time = "2026-06-07T21:07:07.873Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/61/a0c0a8f327a9c52095cdd8e312391b00d3ed64ab6c72bb5c33d8ec251cf7/aiohttp-3.14.1-cp312-cp312-win32.whl", hash = "sha256:ec8dc383ee57ea3e883477dcca3f11b65d58199f1080acaf4cd6ad9a99698be4", size = 452771, upload-time = "2026-06-07T21:07:09.669Z" },
+    { url = "https://files.pythonhosted.org/packages/df/d9/ea367c75f16ac9c6cdc8febb25e8318fa21a2b1bc8d6514d4b2d890bface/aiohttp-3.14.1-cp312-cp312-win_amd64.whl", hash = "sha256:2aa92c87868cd13674989f9ee83e5f9f7ea4237589b728048e1f0c8f6caa3271", size = 479873, upload-time = "2026-06-07T21:07:11.538Z" },
+    { url = "https://files.pythonhosted.org/packages/03/64/8d96784a7851156db8a4c6c3f6f91042fdf39fb15a4cc38c8b3c14833c45/aiohttp-3.14.1-cp312-cp312-win_arm64.whl", hash = "sha256:2c840c90759922cb5e6dda94596e079a30fb5a5ba548e7e0dc00574703940847", size = 448073, upload-time = "2026-06-07T21:07:13.637Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/22/a73ccbf9dbd6e26dda0b24d5fd5db7da92ee3383a79f47677ffb834c5c5b/aiohttp-3.14.1-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:915fbb7b41b115192259f8c9ae58f3ddc444d2b5579917270211858e606a4afd", size = 485841, upload-time = "2026-06-07T21:07:19.555Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/b9/57ed8eaf596321c2ad747bd480fb1700dbd7177c60dfc9e4c187f629662e/aiohttp-3.14.1-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:7fb4bdf95b0561a79f259f9d28fbc109728c5ee7f27aff6391f0ca703a329abe", size = 492088, upload-time = "2026-06-07T21:07:21.581Z" },
+    { url = "https://files.pythonhosted.org/packages/78/c0/5ebe5270a7c140d7c6f79dcb018640225f14d406c149e4eec04a7d82fe71/aiohttp-3.14.1-cp313-cp313-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:1b9748363260121d2927704f5d4fc498150669ca3ae93625986ee89c8f80dcd4", size = 501564, upload-time = "2026-06-07T21:07:23.388Z" },
+    { url = "https://files.pythonhosted.org/packages/75/7f/8cdaa24fc7983865e0915153b96a9ac5bcdd3548d64c5a27d17cecccad2d/aiohttp-3.14.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:86a6dab78b0e43e2897a3bbe15745aa60dc5423ca437b7b0b164c069bf91b876", size = 751998, upload-time = "2026-06-07T21:07:25.046Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/f4/c4227aacfacc5cb0cc2d119b65301d177912a6842cd64e120c47af76064f/aiohttp-3.14.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:4dfd6e47d3c44c2279907607f73a4240b88c69eb8b90da7e2441a8045dfd21da", size = 510918, upload-time = "2026-06-07T21:07:27.28Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/01/a2d5f96cd4e74424864d30bc0a7e44d0a12dacdcfa91b5b2d1bd3dca6bf3/aiohttp-3.14.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:317acd9f8602858dc7d59679812c376c7f0b97bcbbf16e0d6237f54141d8a8a6", size = 508657, upload-time = "2026-06-07T21:07:29.252Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/ed/3c0fb5c500fdd8e7ebc10d1889c04384fffa1a9163eac1356088ca9da1b1/aiohttp-3.14.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bd869c427324e5cb15195793de951295710db28be7d818247f3097b4ab5d4b96", size = 1757907, upload-time = "2026-06-07T21:07:31.03Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/ab/d4c924d9bd5be3050c226612413ce68cb54c70d2c31b661bfc8d9a5b6a70/aiohttp-3.14.1-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:93b032b5ec3255473c143627d21a69ac74ae12f7f33974cb587c564d11b1066f", size = 1737565, upload-time = "2026-06-07T21:07:33.031Z" },
+    { url = "https://files.pythonhosted.org/packages/19/2a/37326821ff779084020cdc33224d20b19f42f4183a500ff92022a739eda7/aiohttp-3.14.1-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:f234b4deb12f3ad59127e037bc57c40c21e45b45282df7d3a55a0f409f595296", size = 1799018, upload-time = "2026-06-07T21:07:35.003Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/4f/6e947ba73e4ce09070761c05ed3a8ceb7c21f5e46798671d8b2aac0e4626/aiohttp-3.14.1-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:9af6779bfb46abf124068327abcdf9ce95c9ef8287a3e8da76ccf2d0f16c28fa", size = 1894416, upload-time = "2026-06-07T21:07:36.956Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/6e/dbf1d0625dc711fb2851f4f3c3055c39ed58bae92082d8c627dbe6013736/aiohttp-3.14.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:faccab372e66bc76d5731525e7f1143c922271725b9d38c9f97edcc66266b451", size = 1783881, upload-time = "2026-06-07T21:07:39.063Z" },
+    { url = "https://files.pythonhosted.org/packages/44/c2/5e25098a67268ed369483ae7d1a58bd0a13d03aab860d2a0e4a6eb25b046/aiohttp-3.14.1-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f380468b09d2a81633ee863b0ec5648d364bd17bb8ecfb8c2f387f7ac1faf42c", size = 1587572, upload-time = "2026-06-07T21:07:41.058Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/bd/cf9cee17e140f942a3de73e658a543aa8fbf35a5fc67a9d2538d52d77f0b/aiohttp-3.14.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:97e704dcd26271f5bda3fa07c3ce0fb76d6d3f8659f4baa1a24442cc9ba177ca", size = 1722137, upload-time = "2026-06-07T21:07:43.014Z" },
+    { url = "https://files.pythonhosted.org/packages/89/6d/5684f8c59045c96f81a18cefbc1fbbd79d25b88f1c622f2a5c5c08fcb632/aiohttp-3.14.1-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:269b76ac5394092b95bc4a098f4fc6c191c083c3bd12775d1e30e663132f6a09", size = 1755953, upload-time = "2026-06-07T21:07:45.933Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/40/35caf3170f8359760740a7d9aa0fff2e344bef98e1d1186f5a0f6dec17e6/aiohttp-3.14.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:5c0b3e614340c889d575451696374c9d17affd54cd607ca0babed8f8c37b9397", size = 1766479, upload-time = "2026-06-07T21:07:48.047Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/a1/b0c61e7a137f0d81de49a82023a6df73c3c16d6fefb0f8e4a93d21639002/aiohttp-3.14.1-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:5663ee9257cfa1add7253a7da3035a02f31b6600ec48261585e1800a81533080", size = 1580077, upload-time = "2026-06-07T21:07:50.069Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/41/194ea4623693009fcefebef7aef63c141754f153e9cd0d39d3b9e36c175c/aiohttp-3.14.1-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:603a2c834142172ffddc054067f5ec0ca65d57a0aa98a71bc81952573208e345", size = 1791688, upload-time = "2026-06-07T21:07:52.106Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/45/4de841f005cfe1fd63e2a2fe011262c515e2a62aa6994b15947e7d717ac9/aiohttp-3.14.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:cb21957bb8aca671c1765e32f58164cf0c50e6bf41c0bbbd16da20732ecaf588", size = 1761094, upload-time = "2026-06-07T21:07:54.113Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/ae/dbce10533d3896d544d5053939ed75b7dc31a1b0973d959b1b5ae21028d6/aiohttp-3.14.1-cp313-cp313-win32.whl", hash = "sha256:e509a55f681e6158c20f70f102f9cf61fb20fbc382272bc6d94b7343f2582780", size = 452662, upload-time = "2026-06-07T21:07:56.06Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/d9/0bf1a19362c32f06229da5e7ddfcec91f93474d6307f7a2d3135e9c674dc/aiohttp-3.14.1-cp313-cp313-win_amd64.whl", hash = "sha256:1ac8531b638959718e18c2207fbfe297819875da46a740b29dfa29beba64355a", size = 479748, upload-time = "2026-06-07T21:07:58.319Z" },
+    { url = "https://files.pythonhosted.org/packages/22/0a/62e7232dc9484fbec112ceb32efb6a624cc7994ec6e2b019286f17c4e8f2/aiohttp-3.14.1-cp313-cp313-win_arm64.whl", hash = "sha256:250d14af67f6b6a1a4a811049b1afa69d61d617fca6bf33149b3ab1a6dbcf7b8", size = 447723, upload-time = "2026-06-07T21:08:00.154Z" },
+    { url = "https://files.pythonhosted.org/packages/85/a5/9594ad6289eebbc97d167c44213d557807f90e59115caad24de21ad2c3b1/aiohttp-3.14.1-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:62a759436b29e677181a9e76bab8b8f689a29cb9c535f45f7c48c9c830d3f8c3", size = 487918, upload-time = "2026-06-07T21:08:06.377Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/61/16a32c36c3c49edec122a3dc811f2057df2f94d3b14aa107c8017d981618/aiohttp-3.14.1-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:2964cbf553df4d7a57348da44d961d871895fc1ee4e8c322b2a95612c7b17fba", size = 494014, upload-time = "2026-06-07T21:08:08.263Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/89/3ebcf96ed99c05bec9c434aaac6963fd3cbab4a786ae739908a144d9ce44/aiohttp-3.14.1-cp314-cp314-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:237651caadc3a59badd39319c54642b5299e9cc98a3a194310e55d5bb9f5e397", size = 502398, upload-time = "2026-06-07T21:08:10.244Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/3d/b74870a0c2d40c355928cd5b96c7a11fa821b8a40fc41365e64479b151fb/aiohttp-3.14.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:896e12dfdbbab9d8f7e16d2b28c6769a60126fa92095d1ebf9473d02593a2448", size = 758018, upload-time = "2026-06-07T21:08:12.447Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/66/f42f5c984d99e49c6cff5f26f590750f2e2f7ef1fcfb99966ab5be1b632e/aiohttp-3.14.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:d03f281ed22579314ba00821ce20115a7c0ac430660b4cc05704a3f818b3e004", size = 512462, upload-time = "2026-06-07T21:08:14.624Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/a7/248e1aebe0c7810b0271e021a0f2a5eb6e78a051885b3c9df49f42a5802d/aiohttp-3.14.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:07eabb979d236335fed927e137a928c9adfb7df3b9ec7aa31726f133a62be983", size = 512824, upload-time = "2026-06-07T21:08:16.572Z" },
+    { url = "https://files.pythonhosted.org/packages/26/97/2aa0e5ba0727dc3bd5aaebb7ccbc510f7dfb7fb961ec87497cd496635ab1/aiohttp-3.14.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4fe1f1087cbadb280b5e1bb054a4f00d1423c74d6626c5e48400d871d34ecefe", size = 1749898, upload-time = "2026-06-07T21:08:18.635Z" },
+    { url = "https://files.pythonhosted.org/packages/00/8d/e97f6c96c891d457c8479d92a514ba194d0412f981d72c70341ee18488ed/aiohttp-3.14.1-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:367a9314fdc79dab0fac96e216cb41dd73c85bdca85306ce8999118ba7e0f333", size = 1710114, upload-time = "2026-06-07T21:08:20.892Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/e6/aa8d7e863048c8fceb5cd6ce74017311cec3ead07847387e12265fb4444e/aiohttp-3.14.1-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a24f677ebe83749039e7bdf862ff0bbb16818ae4193d4ef96505e269375bcce0", size = 1802541, upload-time = "2026-06-07T21:08:23.044Z" },
+    { url = "https://files.pythonhosted.org/packages/83/a8/72193137de57fda4ebfae4563182d082c8856e3b6e9871d0b46f028fb369/aiohttp-3.14.1-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:c83afe0ba876be7e943d2e0ba645809ad441575d2840c895c21ee5de93b9377a", size = 1875776, upload-time = "2026-06-07T21:08:25.288Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/18/938441025db6769a3464596b2410af3afde0b21eb2f204c6f766f68af4bd/aiohttp-3.14.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:634e385930fb6d2d479cf3aa66515955863b77a5e3c2b5894ca259a25b308602", size = 1760329, upload-time = "2026-06-07T21:08:27.363Z" },
+    { url = "https://files.pythonhosted.org/packages/60/29/bf2496b4065e76e09fe48015aaffe5ce161d8f089b06ac6982070f653076/aiohttp-3.14.1-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:eeea07c4397bbc57719c4eed8f9c284874d4f175f9b6d57f7a1546b976d455ca", size = 1587293, upload-time = "2026-06-07T21:08:29.805Z" },
+    { url = "https://files.pythonhosted.org/packages/49/a2/2136674d52123b1354bd05dd5753c318db47dc0c927cc70b27bab3755456/aiohttp-3.14.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:335c0cc3e3545ce98dcb9cfcb836f40c3411f43fa03dab757597d80c89af8a35", size = 1714756, upload-time = "2026-06-07T21:08:32.094Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/b9/e5fd2e6f915503081c0f9b1e8540947037929c70c191da2e4d54b31a21a1/aiohttp-3.14.1-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:ae6be797afdef264e8a84864a85b196ca06045586481b3df8a967322fd2fa844", size = 1721052, upload-time = "2026-06-07T21:08:34.167Z" },
+    { url = "https://files.pythonhosted.org/packages/63/5a/2833e324a2263e104e31e2e91bc5bbee81bc499afd32203faee048a883f0/aiohttp-3.14.1-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:8560b4d712474335d08907db7973f71912d3a9a8f1dee992ec06b5d2fe359496", size = 1766888, upload-time = "2026-06-07T21:08:36.95Z" },
+    { url = "https://files.pythonhosted.org/packages/57/fa/dea6511870913162f3b2e8c42a7614eb203a4540b8c2da43e0bfb0548f3c/aiohttp-3.14.1-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:2b7edd08e0a5deb1e8564a2fcd8f4561014a3f05252334671bbf55ddd47db0e5", size = 1581679, upload-time = "2026-06-07T21:08:39.292Z" },
+    { url = "https://files.pythonhosted.org/packages/14/bd/3cf0d55e71784b33534e9710a67d382d900598b4787fbce6cc7317f8c42a/aiohttp-3.14.1-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:b6ff7fcee63287ae57b5df3e4f5957ce032122802509246dec1a5bcc55904c95", size = 1782021, upload-time = "2026-06-07T21:08:41.407Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/af/14bb5843eccbe234f4dfb78ab73e549d99727247e62ae5d62cbd22eaf5b0/aiohttp-3.14.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:6ffbb2f4ec1ceaff7e07d43922954da26b223d188bf30658e561b98e23089444", size = 1742574, upload-time = "2026-06-07T21:08:43.795Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/1e/fbeb7af9210a67ac0f9c9bec0f8f4568497924e33137a3d5b48e1cf85f3f/aiohttp-3.14.1-cp314-cp314-win32.whl", hash = "sha256:a9875b46d910cff3ea2f5962f9d266b465459fe634e22556ab9bd6fc1192eea0", size = 457773, upload-time = "2026-06-07T21:08:46.168Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/2b/13e8d741a9ec5db7d900c060554cf8352ab85e44e2a4469ebb9d377bda17/aiohttp-3.14.1-cp314-cp314-win_amd64.whl", hash = "sha256:af8b4b81a960eeaf1234971ac3cd0ba5901f3cd42eae42a46b4d089a8b492719", size = 485001, upload-time = "2026-06-07T21:08:48.401Z" },
+    { url = "https://files.pythonhosted.org/packages/df/30/491acfa2c4d6c3ff59c49a14fc1b50be3241e25bbb0c84c09e2da4d11395/aiohttp-3.14.1-cp314-cp314-win_arm64.whl", hash = "sha256:cf4491381b1b57425c315a56a439251b1bdac07b2275f19a8c44bc57744532ec", size = 453809, upload-time = "2026-06-07T21:08:50.7Z" },
+    { url = "https://files.pythonhosted.org/packages/34/e3/19dbe1a1f4cc6230eb9e314de7fe68053b0992f9302b27d12141a0b5db53/aiohttp-3.14.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:819c054312f1af92947e6a55883d1b66feefab11531a7fc45e0fb9b63880b5c2", size = 793320, upload-time = "2026-06-07T21:08:52.775Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/20/1b7182219ba1b108430d6e4dc53d25ae02dcfcf5a045b33af4e8c5167527/aiohttp-3.14.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:10ee9c1753a8f706345b22496c79fbddb5be0599e0823f3738b1534058e25340", size = 529077, upload-time = "2026-06-07T21:08:55Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/c8/14ce60ec31a2e5f5274bb17d383a6f7a3aabca31ac04eee05585bbadab16/aiohttp-3.14.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1601cc37baf5750ccacae618ec2daf020769581695550e3b654a911f859c563d", size = 532476, upload-time = "2026-06-07T21:08:57.176Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/02/9ac85e081e53da2e061b02fa7758fe0a12d17b8ce2d1f5e6c7cb76730328/aiohttp-3.14.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4d6e0ac9da31c9c04c84e1c0182ad8d6df35965a85cae29cd71d089621b3ae94", size = 1922347, upload-time = "2026-06-07T21:08:59.563Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/3e/d3ba07a0ab38b5389e10bec4362d21e10a4f667cba2d79ba30837b3a5059/aiohttp-3.14.1-cp314-cp314t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:9e8f2d660c350b3d0e259c7a7e3d9b7fc8b41210cbcc3d4a7076ff0a5e5c2fdc", size = 1786465, upload-time = "2026-06-07T21:09:01.909Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/cb/e2ee978a00cfb2df829704a69528b18154eba5939f45bc1efa8f33aee4c5/aiohttp-3.14.1-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:4691802dda97be727f79d86818acaad7eb8e9252626a1d6b519fedbb92d5e251", size = 1909423, upload-time = "2026-06-07T21:09:04.357Z" },
+    { url = "https://files.pythonhosted.org/packages/73/5d/1430334858b1022b58ae50399a918f0bd6fe8fa7fa183598d657ff61e040/aiohttp-3.14.1-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:c389c482a7e9b9dc3ee2701ac46c4125297a3818875b9c305ddb603c04828fd1", size = 2001906, upload-time = "2026-06-07T21:09:06.722Z" },
+    { url = "https://files.pythonhosted.org/packages/66/4e/560c7472d3d198a23aa5c8b19a5115bf6a9b77b7d3e4bb363da320430ad2/aiohttp-3.14.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fc0cacab7ba4e56f0f81c82a98c09bed2f39c940107b03a34b168bdf7597edd3", size = 1877095, upload-time = "2026-06-07T21:09:09.011Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/f1/4745806578d447db4a784a8591e2dae3afdfc2bcb96f8f81271b13df6543/aiohttp-3.14.1-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:979ed4717f59b8bb12e3963378fa285d93d367e15bcd66c721311826d3c44a6c", size = 1676222, upload-time = "2026-06-07T21:09:11.461Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/c9/48255813cca749a229ef0ab476004ec623728ad79a9c0840616f6c076325/aiohttp-3.14.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:38e1e7daaea81df51c952e18483f323d878499a1e2bfe564790e0f9701d6f203", size = 1842922, upload-time = "2026-06-07T21:09:14.118Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/c0/bbd054e2bee909f529523a5af3891052606af5143c09f5f183ec3b234676/aiohttp-3.14.1-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:4132e72c608fe9fecb8f409113567605915b83e9bdd3ea56538d2f9cd35002f1", size = 1825035, upload-time = "2026-06-07T21:09:16.447Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/ae/90395d4376deceb74e09ec26b6adf7d2015a6f8802d6d84446af860fef04/aiohttp-3.14.1-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:eefd9cc9b6d4a2db5f00a26bc3e4f9acf71926a6ec557cd56c9c6f27c290b665", size = 1849512, upload-time = "2026-06-07T21:09:18.742Z" },
+    { url = "https://files.pythonhosted.org/packages/93/bd/fb25f3049957553d4ce0ba6ae480aa2f592a6985497fca590837d16c1be0/aiohttp-3.14.1-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:b165790117eea512d7f3fb22f1f6dad3d55a7189571993eb015591c1401276d1", size = 1668571, upload-time = "2026-06-07T21:09:21.458Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/22/7f73303d64dd567ff3addca90b556690ed1233a47b8f55d242fb90af3681/aiohttp-3.14.1-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:ed09c7eb1c391271c2ed0314a51903e72a3acb653d5ccfc264cdf3ef11f8269d", size = 1881159, upload-time = "2026-06-07T21:09:23.813Z" },
+    { url = "https://files.pythonhosted.org/packages/44/be/0474c5a8b5640e1e4aa1923430a91f4151be82e511373fe764189b89aef5/aiohttp-3.14.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:99abd37084b82f5830c635fddd0b4993b9742a66eb746dacf433c8590e8f9e3c", size = 1841409, upload-time = "2026-06-07T21:09:26.207Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/3c/bb4a7cba26956cb3da4553cc2056cf67be5b5ff6e6d8fa4fbdff73bfb7ae/aiohttp-3.14.1-cp314-cp314t-win32.whl", hash = "sha256:47ddf841cdecc810749921d25606dee45857d12d2ad5ddb7b5bd7eab12e4b365", size = 494166, upload-time = "2026-06-07T21:09:28.505Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/84/ec80c2c1f66a952555a9f86df6b33af65108a6febfa0471b69013a12f807/aiohttp-3.14.1-cp314-cp314t-win_amd64.whl", hash = "sha256:5e78b522b7a6e27e0b25d19b247b75039ac4c94f99823e3c9e53ae1603a9f7e9", size = 530255, upload-time = "2026-06-07T21:09:30.843Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/71/6e22be134a4061ada85a92951b842f2657f17d926b727f3f94c56ae963d6/aiohttp-3.14.1-cp314-cp314t-win_arm64.whl", hash = "sha256:90d53f1609c29ccc2193945ef732428382a28f78d0456ae4d3daf0d48b74f0f6", size = 469640, upload-time = "2026-06-07T21:09:33.028Z" },
+]
+
+[[package]]
+name = "aiosignal"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "frozenlist", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "typing-extensions", marker = "(python_full_version < '3.13' and sys_platform == 'darwin') or (python_full_version < '3.13' and sys_platform == 'linux') or (python_full_version < '3.13' and sys_platform == 'win32')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/61/62/06741b579156360248d1ec624842ad0edf697050bbaf7c3e46394e106ad1/aiosignal-1.4.0.tar.gz", hash = "sha256:f47eecd9468083c2029cc99945502cb7708b082c232f9aca65da147157b251c7", size = 25007, upload-time = "2025-07-03T22:54:43.528Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/76/641ae371508676492379f16e2fa48f4e2c11741bd63c48be4b12a6b09cba/aiosignal-1.4.0-py3-none-any.whl", hash = "sha256:053243f8b92b990551949e63930a839ff0cf0b0ebbe0597b0f3fb19e1a0fe82e", size = 7490, upload-time = "2025-07-03T22:54:42.156Z" },
+]
 
 [[package]]
 name = "annotated-types"
@@ -161,9 +336,9 @@ name = "anyio"
 version = "4.14.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
-    { name = "idna" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "exceptiongroup", marker = "(python_full_version < '3.11' and sys_platform == 'darwin') or (python_full_version < '3.11' and sys_platform == 'linux') or (python_full_version < '3.11' and sys_platform == 'win32')" },
+    { name = "idna", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "typing-extensions", marker = "(python_full_version < '3.13' and sys_platform == 'darwin') or (python_full_version < '3.13' and sys_platform == 'linux') or (python_full_version < '3.13' and sys_platform == 'win32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/61/cc/a381afa6efea9f496eff839d4a6a1aed3bfafc7b3ab4b0d1b243a12573dd/anyio-4.14.2.tar.gz", hash = "sha256:cfa139f3ed1a23ee8f88a145ddb5ac7605b8bbfd8592baacd7ce3d8bb4313c7f", size = 260176, upload-time = "2026-07-12T20:29:07.082Z" }
 wheels = [
@@ -175,7 +350,7 @@ name = "asgiref"
 version = "3.11.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "(python_full_version < '3.11' and sys_platform == 'darwin') or (python_full_version < '3.11' and sys_platform == 'linux') or (python_full_version < '3.11' and sys_platform == 'win32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/63/40/f03da1264ae8f7cfdbf9146542e5e7e8100a4c66ab48e791df9a03d3f6c0/asgiref-3.11.1.tar.gz", hash = "sha256:5f184dc43b7e763efe848065441eac62229c9f7b0475f41f80e207a114eda4ce", size = 38550, upload-time = "2026-02-03T13:30:14.33Z" }
 wheels = [
@@ -255,8 +430,8 @@ name = "azure-core"
 version = "1.41.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "requests" },
-    { name = "typing-extensions" },
+    { name = "requests", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "typing-extensions", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a6/f3/b416179e408990df5db0d516283022dde0f5d0111d98c1a848e41853e81c/azure_core-1.41.0.tar.gz", hash = "sha256:f46ff5dfcd230f25cf1c19e8a34b8dc08a337b2503e268bb600a16c00db8ad5a", size = 381042, upload-time = "2026-05-07T23:30:54.302Z" }
 wheels = [
@@ -268,8 +443,8 @@ name = "azure-core-tracing-opentelemetry"
 version = "1.0.0b13"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "azure-core" },
-    { name = "opentelemetry-api" },
+    { name = "azure-core", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "opentelemetry-api", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ce/ab/a937e4af8afec9d437d55252f2a3a4419fc3fc7d5e5d54022622bd11b2b6/azure_core_tracing_opentelemetry-1.0.0b13.tar.gz", hash = "sha256:6cb2f8dfd5dee6c11843db0205fc92e2434e1a272c169c953afe92483aafc7eb", size = 25832, upload-time = "2026-05-01T00:59:57.941Z" }
 wheels = [
@@ -277,15 +452,45 @@ wheels = [
 ]
 
 [[package]]
+name = "azure-functions"
+version = "1.24.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "werkzeug", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1d/be/5535830e0658e9668093941b3c33b0ea03eceadbf6bd6b7870aa37ef071a/azure_functions-1.24.0.tar.gz", hash = "sha256:18ea1607c7a7268b7a1e1bd0cc28c5cc57a9db6baaacddb39ba0e9f865728187", size = 134495, upload-time = "2025-10-06T19:08:08.612Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/76/e6c5809ee0295e882b6c9ad595896748e33989d353b67316a854f65fb754/azure_functions-1.24.0-py3-none-any.whl", hash = "sha256:32b12c2a219824525849dd92036488edeb70d306d164efd9e941f10f9ac0a91c", size = 108341, upload-time = "2025-10-06T19:08:07.128Z" },
+]
+
+[[package]]
+name = "azure-functions-durable"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "azure-functions", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "furl", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "opentelemetry-api", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "opentelemetry-sdk", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "python-dateutil", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "requests", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ca/40/a5aaa966fd4b1220c03fbde019ac532bcb3db619defae5dbf1eb4476b07c/azure_functions_durable-1.6.0.tar.gz", hash = "sha256:30feb3968aed71fc481e62b88fbaea5c89e9e8dacd703e0a1d5b86aa12ad8c92", size = 201246, upload-time = "2026-07-09T19:02:19.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fe/4c/4bc2cd4a356ccc425028cf46a6e367e6237d86a66ad89d4e971cbe8f059f/azure_functions_durable-1.6.0-py3-none-any.whl", hash = "sha256:7f28545d7025c10476c0d0ba33b90969476af76115f8d4862827db941b546760", size = 164485, upload-time = "2026-07-09T19:02:20.648Z" },
+]
+
+[[package]]
 name = "azure-identity"
 version = "1.25.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "azure-core" },
-    { name = "cryptography" },
-    { name = "msal" },
-    { name = "msal-extensions" },
-    { name = "typing-extensions" },
+    { name = "azure-core", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "cryptography", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "msal", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "msal-extensions", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "typing-extensions", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c5/0e/3a63efb48aa4a5ae2cfca61ee152fbcb668092134d3eb8bfda472dd5c617/azure_identity-1.25.3.tar.gz", hash = "sha256:ab23c0d63015f50b630ef6c6cf395e7262f439ce06e5d07a64e874c724f8d9e6", size = 286304, upload-time = "2026-03-13T01:12:20.892Z" }
 wheels = [
@@ -297,19 +502,19 @@ name = "azure-monitor-opentelemetry"
 version = "1.8.9"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "azure-core" },
-    { name = "azure-core-tracing-opentelemetry" },
-    { name = "azure-monitor-opentelemetry-exporter" },
-    { name = "opentelemetry-instrumentation-django" },
-    { name = "opentelemetry-instrumentation-fastapi" },
-    { name = "opentelemetry-instrumentation-flask" },
-    { name = "opentelemetry-instrumentation-logging" },
-    { name = "opentelemetry-instrumentation-psycopg2" },
-    { name = "opentelemetry-instrumentation-requests" },
-    { name = "opentelemetry-instrumentation-urllib" },
-    { name = "opentelemetry-instrumentation-urllib3" },
-    { name = "opentelemetry-resource-detector-azure" },
-    { name = "opentelemetry-sdk" },
+    { name = "azure-core", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "azure-core-tracing-opentelemetry", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "azure-monitor-opentelemetry-exporter", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "opentelemetry-instrumentation-django", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "opentelemetry-instrumentation-fastapi", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "opentelemetry-instrumentation-flask", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "opentelemetry-instrumentation-logging", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "opentelemetry-instrumentation-psycopg2", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "opentelemetry-instrumentation-requests", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "opentelemetry-instrumentation-urllib", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "opentelemetry-instrumentation-urllib3", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "opentelemetry-resource-detector-azure", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "opentelemetry-sdk", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/9e/9f/75f517dd019ebc1a6476187c7380ea440f040b7c933c7a6b7159260e2c37/azure_monitor_opentelemetry-1.8.9.tar.gz", hash = "sha256:9cda4481c52e02cb3e8e11a34d2491fb07000ed32ee655d75de0747e7d24fea7", size = 80026, upload-time = "2026-07-01T17:48:58.369Z" }
 wheels = [
@@ -321,12 +526,12 @@ name = "azure-monitor-opentelemetry-exporter"
 version = "1.0.0b55"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "azure-core" },
-    { name = "azure-identity" },
-    { name = "msrest" },
-    { name = "opentelemetry-api" },
-    { name = "opentelemetry-sdk" },
-    { name = "psutil" },
+    { name = "azure-core", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "azure-identity", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "msrest", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "opentelemetry-api", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "opentelemetry-sdk", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "psutil", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ab/21/178fed00e9738e4c953e147d46f5f803bfeb3fde50b11efdb99ae016f05f/azure_monitor_opentelemetry_exporter-1.0.0b55.tar.gz", hash = "sha256:6701307124e5eeb1837b269ddafab0affb69020fdb842d7c5ff1a3122514595a", size = 342308, upload-time = "2026-07-01T23:59:14.53Z" }
 wheels = [
@@ -370,7 +575,7 @@ resolution-markers = [
     "python_full_version < '3.11' and sys_platform == 'win32'",
 ]
 dependencies = [
-    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+    { name = "pycparser", marker = "(python_full_version < '3.14' and implementation_name != 'PyPy' and sys_platform == 'darwin') or (python_full_version < '3.14' and implementation_name != 'PyPy' and sys_platform == 'linux') or (python_full_version < '3.14' and implementation_name != 'PyPy' and sys_platform == 'win32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
 wheels = [
@@ -460,7 +665,7 @@ resolution-markers = [
     "python_full_version == '3.14.*' and sys_platform == 'win32'",
 ]
 dependencies = [
-    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+    { name = "pycparser", marker = "(python_full_version >= '3.14' and implementation_name != 'PyPy' and sys_platform == 'darwin') or (python_full_version >= '3.14' and implementation_name != 'PyPy' and sys_platform == 'linux') or (python_full_version >= '3.14' and implementation_name != 'PyPy' and sys_platform == 'win32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/57/5f/ff100cae70ebe9d8df1c01a00e510e45d9adb5c1fdda84791b199141de97/cffi-2.1.0.tar.gz", hash = "sha256:efc1cdd798b1aaf39b4610bba7aad28c9bea9b910f25c784ccf9ec1fa719d1f9", size = 531036, upload-time = "2026-07-06T21:34:30.382Z" }
 wheels = [
@@ -773,7 +978,7 @@ wheels = [
 
 [package.optional-dependencies]
 toml = [
-    { name = "tomli", marker = "python_full_version <= '3.11'" },
+    { name = "tomli", marker = "(python_full_version <= '3.11' and sys_platform == 'darwin') or (python_full_version <= '3.11' and sys_platform == 'linux') or (python_full_version <= '3.11' and sys_platform == 'win32')" },
 ]
 
 [[package]]
@@ -781,9 +986,9 @@ name = "cryptography"
 version = "49.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cffi", version = "2.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14' and platform_python_implementation != 'PyPy'" },
-    { name = "cffi", version = "2.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14' and platform_python_implementation != 'PyPy'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "cffi", version = "2.0.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.14' and platform_python_implementation != 'PyPy' and sys_platform == 'darwin') or (python_full_version < '3.14' and platform_python_implementation != 'PyPy' and sys_platform == 'linux') or (python_full_version < '3.14' and platform_python_implementation != 'PyPy' and sys_platform == 'win32')" },
+    { name = "cffi", version = "2.1.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform == 'darwin') or (python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform == 'linux') or (python_full_version >= '3.14' and platform_python_implementation != 'PyPy' and sys_platform == 'win32')" },
+    { name = "typing-extensions", marker = "(python_full_version < '3.11' and sys_platform == 'darwin') or (python_full_version < '3.11' and sys_platform == 'linux') or (python_full_version < '3.11' and sys_platform == 'win32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1f/99/d1c90d6041656cc6ee229dc99cd67fd0cd5aec3c5f7d72fffc27cc750054/cryptography-49.0.0.tar.gz", hash = "sha256:f89660a348f4f78a92366240a61404e337586ef7f5909a2fef59ca88ef505493", size = 854345, upload-time = "2026-06-12T20:02:30.512Z" }
 wheels = [
@@ -848,10 +1053,10 @@ name = "durabletask"
 version = "1.7.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "asyncio" },
-    { name = "grpcio" },
-    { name = "packaging" },
-    { name = "protobuf" },
+    { name = "asyncio", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "grpcio", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "packaging", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "protobuf", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ca/c4/bb2d676f12c37b12856a6b47cbf0918c58f3fe0c1d5e7867a78a2e6aaa19/durabletask-1.7.2.tar.gz", hash = "sha256:b22c234d859c8ac3ad621d324132ffb7ba546c011ae3df8e22c2bd7ca7b108d2", size = 169101, upload-time = "2026-07-09T21:39:22.91Z" }
 wheels = [
@@ -863,8 +1068,8 @@ name = "durabletask-azuremanaged"
 version = "1.7.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "azure-identity" },
-    { name = "durabletask" },
+    { name = "azure-identity", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "durabletask", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a1/9a/362661fb9a2637cb6960bca6131d9c224864bc50fd71ceec055cc6ba92c7/durabletask_azuremanaged-1.7.2.tar.gz", hash = "sha256:a0f257256ac9814ac202aec47ea47aa70819e671c99e5f04c9d7e415a2519e36", size = 18389, upload-time = "2026-07-09T21:54:12.37Z" }
 wheels = [
@@ -876,7 +1081,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "(python_full_version < '3.11' and sys_platform == 'darwin') or (python_full_version < '3.11' and sys_platform == 'linux') or (python_full_version < '3.11' and sys_platform == 'win32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -897,11 +1102,11 @@ name = "flit"
 version = "3.12.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "docutils" },
-    { name = "flit-core" },
-    { name = "pip" },
-    { name = "requests" },
-    { name = "tomli-w" },
+    { name = "docutils", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "flit-core", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "pip", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "requests", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "tomli-w", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/9c/0608c91a5b6c013c63548515ae31cff6399cd9ce891bd9daee8c103da09b/flit-3.12.0.tar.gz", hash = "sha256:1c80f34dd96992e7758b40423d2809f48f640ca285d0b7821825e50745ec3740", size = 155038, upload-time = "2025-03-25T08:03:22.505Z" }
 wheels = [
@@ -918,11 +1123,145 @@ wheels = [
 ]
 
 [[package]]
+name = "frozenlist"
+version = "1.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2d/f5/c831fac6cc817d26fd54c7eaccd04ef7e0288806943f7cc5bbf69f3ac1f0/frozenlist-1.8.0.tar.gz", hash = "sha256:3ede829ed8d842f6cd48fc7081d7a41001a56f1f38603f9d49bf3020d59a31ad", size = 45875, upload-time = "2025-10-06T05:38:17.865Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/83/4a/557715d5047da48d54e659203b9335be7bfaafda2c3f627b7c47e0b3aaf3/frozenlist-1.8.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:b37f6d31b3dcea7deb5e9696e529a6aa4a898adc33db82da12e4c60a7c4d2011", size = 86230, upload-time = "2025-10-06T05:35:23.699Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/fb/c85f9fed3ea8fe8740e5b46a59cc141c23b842eca617da8876cfce5f760e/frozenlist-1.8.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:ef2b7b394f208233e471abc541cc6991f907ffd47dc72584acee3147899d6565", size = 49621, upload-time = "2025-10-06T05:35:25.341Z" },
+    { url = "https://files.pythonhosted.org/packages/63/70/26ca3f06aace16f2352796b08704338d74b6d1a24ca38f2771afbb7ed915/frozenlist-1.8.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:a88f062f072d1589b7b46e951698950e7da00442fc1cacbe17e19e025dc327ad", size = 49889, upload-time = "2025-10-06T05:35:26.797Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/ed/c7895fd2fde7f3ee70d248175f9b6cdf792fb741ab92dc59cd9ef3bd241b/frozenlist-1.8.0-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:f57fb59d9f385710aa7060e89410aeb5058b99e62f4d16b08b91986b9a2140c2", size = 219464, upload-time = "2025-10-06T05:35:28.254Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/83/4d587dccbfca74cb8b810472392ad62bfa100bf8108c7223eb4c4fa2f7b3/frozenlist-1.8.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:799345ab092bee59f01a915620b5d014698547afd011e691a208637312db9186", size = 221649, upload-time = "2025-10-06T05:35:29.454Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/c6/fd3b9cd046ec5fff9dab66831083bc2077006a874a2d3d9247dea93ddf7e/frozenlist-1.8.0-cp310-cp310-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:c23c3ff005322a6e16f71bf8692fcf4d5a304aaafe1e262c98c6d4adc7be863e", size = 219188, upload-time = "2025-10-06T05:35:30.951Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/80/6693f55eb2e085fc8afb28cf611448fb5b90e98e068fa1d1b8d8e66e5c7d/frozenlist-1.8.0-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:8a76ea0f0b9dfa06f254ee06053d93a600865b3274358ca48a352ce4f0798450", size = 231748, upload-time = "2025-10-06T05:35:32.101Z" },
+    { url = "https://files.pythonhosted.org/packages/97/d6/e9459f7c5183854abd989ba384fe0cc1a0fb795a83c033f0571ec5933ca4/frozenlist-1.8.0-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:c7366fe1418a6133d5aa824ee53d406550110984de7637d65a178010f759c6ef", size = 236351, upload-time = "2025-10-06T05:35:33.834Z" },
+    { url = "https://files.pythonhosted.org/packages/97/92/24e97474b65c0262e9ecd076e826bfd1d3074adcc165a256e42e7b8a7249/frozenlist-1.8.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:13d23a45c4cebade99340c4165bd90eeb4a56c6d8a9d8aa49568cac19a6d0dc4", size = 218767, upload-time = "2025-10-06T05:35:35.205Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/bf/dc394a097508f15abff383c5108cb8ad880d1f64a725ed3b90d5c2fbf0bb/frozenlist-1.8.0-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:e4a3408834f65da56c83528fb52ce7911484f0d1eaf7b761fc66001db1646eff", size = 235887, upload-time = "2025-10-06T05:35:36.354Z" },
+    { url = "https://files.pythonhosted.org/packages/40/90/25b201b9c015dbc999a5baf475a257010471a1fa8c200c843fd4abbee725/frozenlist-1.8.0-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:42145cd2748ca39f32801dad54aeea10039da6f86e303659db90db1c4b614c8c", size = 228785, upload-time = "2025-10-06T05:35:37.949Z" },
+    { url = "https://files.pythonhosted.org/packages/84/f4/b5bc148df03082f05d2dd30c089e269acdbe251ac9a9cf4e727b2dbb8a3d/frozenlist-1.8.0-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:e2de870d16a7a53901e41b64ffdf26f2fbb8917b3e6ebf398098d72c5b20bd7f", size = 230312, upload-time = "2025-10-06T05:35:39.178Z" },
+    { url = "https://files.pythonhosted.org/packages/db/4b/87e95b5d15097c302430e647136b7d7ab2398a702390cf4c8601975709e7/frozenlist-1.8.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:20e63c9493d33ee48536600d1a5c95eefc870cd71e7ab037763d1fbb89cc51e7", size = 217650, upload-time = "2025-10-06T05:35:40.377Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/70/78a0315d1fea97120591a83e0acd644da638c872f142fd72a6cebee825f3/frozenlist-1.8.0-cp310-cp310-win32.whl", hash = "sha256:adbeebaebae3526afc3c96fad434367cafbfd1b25d72369a9e5858453b1bb71a", size = 39659, upload-time = "2025-10-06T05:35:41.863Z" },
+    { url = "https://files.pythonhosted.org/packages/66/aa/3f04523fb189a00e147e60c5b2205126118f216b0aa908035c45336e27e4/frozenlist-1.8.0-cp310-cp310-win_amd64.whl", hash = "sha256:667c3777ca571e5dbeb76f331562ff98b957431df140b54c85fd4d52eea8d8f6", size = 43837, upload-time = "2025-10-06T05:35:43.205Z" },
+    { url = "https://files.pythonhosted.org/packages/39/75/1135feecdd7c336938bd55b4dc3b0dfc46d85b9be12ef2628574b28de776/frozenlist-1.8.0-cp310-cp310-win_arm64.whl", hash = "sha256:80f85f0a7cc86e7a54c46d99c9e1318ff01f4687c172ede30fd52d19d1da1c8e", size = 39989, upload-time = "2025-10-06T05:35:44.596Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/03/077f869d540370db12165c0aa51640a873fb661d8b315d1d4d67b284d7ac/frozenlist-1.8.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:09474e9831bc2b2199fad6da3c14c7b0fbdd377cce9d3d77131be28906cb7d84", size = 86912, upload-time = "2025-10-06T05:35:45.98Z" },
+    { url = "https://files.pythonhosted.org/packages/df/b5/7610b6bd13e4ae77b96ba85abea1c8cb249683217ef09ac9e0ae93f25a91/frozenlist-1.8.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:17c883ab0ab67200b5f964d2b9ed6b00971917d5d8a92df149dc2c9779208ee9", size = 50046, upload-time = "2025-10-06T05:35:47.009Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/ef/0e8f1fe32f8a53dd26bdd1f9347efe0778b0fddf62789ea683f4cc7d787d/frozenlist-1.8.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:fa47e444b8ba08fffd1c18e8cdb9a75db1b6a27f17507522834ad13ed5922b93", size = 50119, upload-time = "2025-10-06T05:35:48.38Z" },
+    { url = "https://files.pythonhosted.org/packages/11/b1/71a477adc7c36e5fb628245dfbdea2166feae310757dea848d02bd0689fd/frozenlist-1.8.0-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:2552f44204b744fba866e573be4c1f9048d6a324dfe14475103fd51613eb1d1f", size = 231067, upload-time = "2025-10-06T05:35:49.97Z" },
+    { url = "https://files.pythonhosted.org/packages/45/7e/afe40eca3a2dc19b9904c0f5d7edfe82b5304cb831391edec0ac04af94c2/frozenlist-1.8.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:957e7c38f250991e48a9a73e6423db1bb9dd14e722a10f6b8bb8e16a0f55f695", size = 233160, upload-time = "2025-10-06T05:35:51.729Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/aa/7416eac95603ce428679d273255ffc7c998d4132cfae200103f164b108aa/frozenlist-1.8.0-cp311-cp311-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:8585e3bb2cdea02fc88ffa245069c36555557ad3609e83be0ec71f54fd4abb52", size = 228544, upload-time = "2025-10-06T05:35:53.246Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/3d/2a2d1f683d55ac7e3875e4263d28410063e738384d3adc294f5ff3d7105e/frozenlist-1.8.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:edee74874ce20a373d62dc28b0b18b93f645633c2943fd90ee9d898550770581", size = 243797, upload-time = "2025-10-06T05:35:54.497Z" },
+    { url = "https://files.pythonhosted.org/packages/78/1e/2d5565b589e580c296d3bb54da08d206e797d941a83a6fdea42af23be79c/frozenlist-1.8.0-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:c9a63152fe95756b85f31186bddf42e4c02c6321207fd6601a1c89ebac4fe567", size = 247923, upload-time = "2025-10-06T05:35:55.861Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/c3/65872fcf1d326a7f101ad4d86285c403c87be7d832b7470b77f6d2ed5ddc/frozenlist-1.8.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:b6db2185db9be0a04fecf2f241c70b63b1a242e2805be291855078f2b404dd6b", size = 230886, upload-time = "2025-10-06T05:35:57.399Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/76/ac9ced601d62f6956f03cc794f9e04c81719509f85255abf96e2510f4265/frozenlist-1.8.0-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:f4be2e3d8bc8aabd566f8d5b8ba7ecc09249d74ba3c9ed52e54dc23a293f0b92", size = 245731, upload-time = "2025-10-06T05:35:58.563Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/49/ecccb5f2598daf0b4a1415497eba4c33c1e8ce07495eb07d2860c731b8d5/frozenlist-1.8.0-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:c8d1634419f39ea6f5c427ea2f90ca85126b54b50837f31497f3bf38266e853d", size = 241544, upload-time = "2025-10-06T05:35:59.719Z" },
+    { url = "https://files.pythonhosted.org/packages/53/4b/ddf24113323c0bbcc54cb38c8b8916f1da7165e07b8e24a717b4a12cbf10/frozenlist-1.8.0-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:1a7fa382a4a223773ed64242dbe1c9c326ec09457e6b8428efb4118c685c3dfd", size = 241806, upload-time = "2025-10-06T05:36:00.959Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/fb/9b9a084d73c67175484ba2789a59f8eebebd0827d186a8102005ce41e1ba/frozenlist-1.8.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:11847b53d722050808926e785df837353bd4d75f1d494377e59b23594d834967", size = 229382, upload-time = "2025-10-06T05:36:02.22Z" },
+    { url = "https://files.pythonhosted.org/packages/95/a3/c8fb25aac55bf5e12dae5c5aa6a98f85d436c1dc658f21c3ac73f9fa95e5/frozenlist-1.8.0-cp311-cp311-win32.whl", hash = "sha256:27c6e8077956cf73eadd514be8fb04d77fc946a7fe9f7fe167648b0b9085cc25", size = 39647, upload-time = "2025-10-06T05:36:03.409Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/f5/603d0d6a02cfd4c8f2a095a54672b3cf967ad688a60fb9faf04fc4887f65/frozenlist-1.8.0-cp311-cp311-win_amd64.whl", hash = "sha256:ac913f8403b36a2c8610bbfd25b8013488533e71e62b4b4adce9c86c8cea905b", size = 44064, upload-time = "2025-10-06T05:36:04.368Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/16/c2c9ab44e181f043a86f9a8f84d5124b62dbcb3a02c0977ec72b9ac1d3e0/frozenlist-1.8.0-cp311-cp311-win_arm64.whl", hash = "sha256:d4d3214a0f8394edfa3e303136d0575eece0745ff2b47bd2cb2e66dd92d4351a", size = 39937, upload-time = "2025-10-06T05:36:05.669Z" },
+    { url = "https://files.pythonhosted.org/packages/69/29/948b9aa87e75820a38650af445d2ef2b6b8a6fab1a23b6bb9e4ef0be2d59/frozenlist-1.8.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:78f7b9e5d6f2fdb88cdde9440dc147259b62b9d3b019924def9f6478be254ac1", size = 87782, upload-time = "2025-10-06T05:36:06.649Z" },
+    { url = "https://files.pythonhosted.org/packages/64/80/4f6e318ee2a7c0750ed724fa33a4bdf1eacdc5a39a7a24e818a773cd91af/frozenlist-1.8.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:229bf37d2e4acdaf808fd3f06e854a4a7a3661e871b10dc1f8f1896a3b05f18b", size = 50594, upload-time = "2025-10-06T05:36:07.69Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/94/5c8a2b50a496b11dd519f4a24cb5496cf125681dd99e94c604ccdea9419a/frozenlist-1.8.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f833670942247a14eafbb675458b4e61c82e002a148f49e68257b79296e865c4", size = 50448, upload-time = "2025-10-06T05:36:08.78Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/bd/d91c5e39f490a49df14320f4e8c80161cfcce09f1e2cde1edd16a551abb3/frozenlist-1.8.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:494a5952b1c597ba44e0e78113a7266e656b9794eec897b19ead706bd7074383", size = 242411, upload-time = "2025-10-06T05:36:09.801Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/83/f61505a05109ef3293dfb1ff594d13d64a2324ac3482be2cedc2be818256/frozenlist-1.8.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:96f423a119f4777a4a056b66ce11527366a8bb92f54e541ade21f2374433f6d4", size = 243014, upload-time = "2025-10-06T05:36:11.394Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/cb/cb6c7b0f7d4023ddda30cf56b8b17494eb3a79e3fda666bf735f63118b35/frozenlist-1.8.0-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:3462dd9475af2025c31cc61be6652dfa25cbfb56cbbf52f4ccfe029f38decaf8", size = 234909, upload-time = "2025-10-06T05:36:12.598Z" },
+    { url = "https://files.pythonhosted.org/packages/31/c5/cd7a1f3b8b34af009fb17d4123c5a778b44ae2804e3ad6b86204255f9ec5/frozenlist-1.8.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c4c800524c9cd9bac5166cd6f55285957fcfc907db323e193f2afcd4d9abd69b", size = 250049, upload-time = "2025-10-06T05:36:14.065Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/01/2f95d3b416c584a1e7f0e1d6d31998c4a795f7544069ee2e0962a4b60740/frozenlist-1.8.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:d6a5df73acd3399d893dafc71663ad22534b5aa4f94e8a2fabfe856c3c1b6a52", size = 256485, upload-time = "2025-10-06T05:36:15.39Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/03/024bf7720b3abaebcff6d0793d73c154237b85bdf67b7ed55e5e9596dc9a/frozenlist-1.8.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:405e8fe955c2280ce66428b3ca55e12b3c4e9c336fb2103a4937e891c69a4a29", size = 237619, upload-time = "2025-10-06T05:36:16.558Z" },
+    { url = "https://files.pythonhosted.org/packages/69/fa/f8abdfe7d76b731f5d8bd217827cf6764d4f1d9763407e42717b4bed50a0/frozenlist-1.8.0-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:908bd3f6439f2fef9e85031b59fd4f1297af54415fb60e4254a95f75b3cab3f3", size = 250320, upload-time = "2025-10-06T05:36:17.821Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/3c/b051329f718b463b22613e269ad72138cc256c540f78a6de89452803a47d/frozenlist-1.8.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:294e487f9ec720bd8ffcebc99d575f7eff3568a08a253d1ee1a0378754b74143", size = 246820, upload-time = "2025-10-06T05:36:19.046Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/ae/58282e8f98e444b3f4dd42448ff36fa38bef29e40d40f330b22e7108f565/frozenlist-1.8.0-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:74c51543498289c0c43656701be6b077f4b265868fa7f8a8859c197006efb608", size = 250518, upload-time = "2025-10-06T05:36:20.763Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/96/007e5944694d66123183845a106547a15944fbbb7154788cbf7272789536/frozenlist-1.8.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:776f352e8329135506a1d6bf16ac3f87bc25b28e765949282dcc627af36123aa", size = 239096, upload-time = "2025-10-06T05:36:22.129Z" },
+    { url = "https://files.pythonhosted.org/packages/66/bb/852b9d6db2fa40be96f29c0d1205c306288f0684df8fd26ca1951d461a56/frozenlist-1.8.0-cp312-cp312-win32.whl", hash = "sha256:433403ae80709741ce34038da08511d4a77062aa924baf411ef73d1146e74faf", size = 39985, upload-time = "2025-10-06T05:36:23.661Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/af/38e51a553dd66eb064cdf193841f16f077585d4d28394c2fa6235cb41765/frozenlist-1.8.0-cp312-cp312-win_amd64.whl", hash = "sha256:34187385b08f866104f0c0617404c8eb08165ab1272e884abc89c112e9c00746", size = 44591, upload-time = "2025-10-06T05:36:24.958Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/06/1dc65480ab147339fecc70797e9c2f69d9cea9cf38934ce08df070fdb9cb/frozenlist-1.8.0-cp312-cp312-win_arm64.whl", hash = "sha256:fe3c58d2f5db5fbd18c2987cba06d51b0529f52bc3a6cdc33d3f4eab725104bd", size = 40102, upload-time = "2025-10-06T05:36:26.333Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/40/0832c31a37d60f60ed79e9dfb5a92e1e2af4f40a16a29abcc7992af9edff/frozenlist-1.8.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:8d92f1a84bb12d9e56f818b3a746f3efba93c1b63c8387a73dde655e1e42282a", size = 85717, upload-time = "2025-10-06T05:36:27.341Z" },
+    { url = "https://files.pythonhosted.org/packages/30/ba/b0b3de23f40bc55a7057bd38434e25c34fa48e17f20ee273bbde5e0650f3/frozenlist-1.8.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:96153e77a591c8adc2ee805756c61f59fef4cf4073a9275ee86fe8cba41241f7", size = 49651, upload-time = "2025-10-06T05:36:28.855Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/ab/6e5080ee374f875296c4243c381bbdef97a9ac39c6e3ce1d5f7d42cb78d6/frozenlist-1.8.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f21f00a91358803399890ab167098c131ec2ddd5f8f5fd5fe9c9f2c6fcd91e40", size = 49417, upload-time = "2025-10-06T05:36:29.877Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/4e/e4691508f9477ce67da2015d8c00acd751e6287739123113a9fca6f1604e/frozenlist-1.8.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:fb30f9626572a76dfe4293c7194a09fb1fe93ba94c7d4f720dfae3b646b45027", size = 234391, upload-time = "2025-10-06T05:36:31.301Z" },
+    { url = "https://files.pythonhosted.org/packages/40/76/c202df58e3acdf12969a7895fd6f3bc016c642e6726aa63bd3025e0fc71c/frozenlist-1.8.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:eaa352d7047a31d87dafcacbabe89df0aa506abb5b1b85a2fb91bc3faa02d822", size = 233048, upload-time = "2025-10-06T05:36:32.531Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/c0/8746afb90f17b73ca5979c7a3958116e105ff796e718575175319b5bb4ce/frozenlist-1.8.0-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:03ae967b4e297f58f8c774c7eabcce57fe3c2434817d4385c50661845a058121", size = 226549, upload-time = "2025-10-06T05:36:33.706Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/eb/4c7eefc718ff72f9b6c4893291abaae5fbc0c82226a32dcd8ef4f7a5dbef/frozenlist-1.8.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:f6292f1de555ffcc675941d65fffffb0a5bcd992905015f85d0592201793e0e5", size = 239833, upload-time = "2025-10-06T05:36:34.947Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/4e/e5c02187cf704224f8b21bee886f3d713ca379535f16893233b9d672ea71/frozenlist-1.8.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:29548f9b5b5e3460ce7378144c3010363d8035cea44bc0bf02d57f5a685e084e", size = 245363, upload-time = "2025-10-06T05:36:36.534Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/96/cb85ec608464472e82ad37a17f844889c36100eed57bea094518bf270692/frozenlist-1.8.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:ec3cc8c5d4084591b4237c0a272cc4f50a5b03396a47d9caaf76f5d7b38a4f11", size = 229314, upload-time = "2025-10-06T05:36:38.582Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/6f/4ae69c550e4cee66b57887daeebe006fe985917c01d0fff9caab9883f6d0/frozenlist-1.8.0-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:517279f58009d0b1f2e7c1b130b377a349405da3f7621ed6bfae50b10adf20c1", size = 243365, upload-time = "2025-10-06T05:36:40.152Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/58/afd56de246cf11780a40a2c28dc7cbabbf06337cc8ddb1c780a2d97e88d8/frozenlist-1.8.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:db1e72ede2d0d7ccb213f218df6a078a9c09a7de257c2fe8fcef16d5925230b1", size = 237763, upload-time = "2025-10-06T05:36:41.355Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/36/cdfaf6ed42e2644740d4a10452d8e97fa1c062e2a8006e4b09f1b5fd7d63/frozenlist-1.8.0-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:b4dec9482a65c54a5044486847b8a66bf10c9cb4926d42927ec4e8fd5db7fed8", size = 240110, upload-time = "2025-10-06T05:36:42.716Z" },
+    { url = "https://files.pythonhosted.org/packages/03/a8/9ea226fbefad669f11b52e864c55f0bd57d3c8d7eb07e9f2e9a0b39502e1/frozenlist-1.8.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:21900c48ae04d13d416f0e1e0c4d81f7931f73a9dfa0b7a8746fb2fe7dd970ed", size = 233717, upload-time = "2025-10-06T05:36:44.251Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/0b/1b5531611e83ba7d13ccc9988967ea1b51186af64c42b7a7af465dcc9568/frozenlist-1.8.0-cp313-cp313-win32.whl", hash = "sha256:8b7b94a067d1c504ee0b16def57ad5738701e4ba10cec90529f13fa03c833496", size = 39628, upload-time = "2025-10-06T05:36:45.423Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/cf/174c91dbc9cc49bc7b7aab74d8b734e974d1faa8f191c74af9b7e80848e6/frozenlist-1.8.0-cp313-cp313-win_amd64.whl", hash = "sha256:878be833caa6a3821caf85eb39c5ba92d28e85df26d57afb06b35b2efd937231", size = 43882, upload-time = "2025-10-06T05:36:46.796Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/17/502cd212cbfa96eb1388614fe39a3fc9ab87dbbe042b66f97acb57474834/frozenlist-1.8.0-cp313-cp313-win_arm64.whl", hash = "sha256:44389d135b3ff43ba8cc89ff7f51f5a0bb6b63d829c8300f79a2fe4fe61bcc62", size = 39676, upload-time = "2025-10-06T05:36:47.8Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/5c/3bbfaa920dfab09e76946a5d2833a7cbdf7b9b4a91c714666ac4855b88b4/frozenlist-1.8.0-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:e25ac20a2ef37e91c1b39938b591457666a0fa835c7783c3a8f33ea42870db94", size = 89235, upload-time = "2025-10-06T05:36:48.78Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/d6/f03961ef72166cec1687e84e8925838442b615bd0b8854b54923ce5b7b8a/frozenlist-1.8.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:07cdca25a91a4386d2e76ad992916a85038a9b97561bf7a3fd12d5d9ce31870c", size = 50742, upload-time = "2025-10-06T05:36:49.837Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/bb/a6d12b7ba4c3337667d0e421f7181c82dda448ce4e7ad7ecd249a16fa806/frozenlist-1.8.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:4e0c11f2cc6717e0a741f84a527c52616140741cd812a50422f83dc31749fb52", size = 51725, upload-time = "2025-10-06T05:36:50.851Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/71/d1fed0ffe2c2ccd70b43714c6cab0f4188f09f8a67a7914a6b46ee30f274/frozenlist-1.8.0-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:b3210649ee28062ea6099cfda39e147fa1bc039583c8ee4481cb7811e2448c51", size = 284533, upload-time = "2025-10-06T05:36:51.898Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/1f/fb1685a7b009d89f9bf78a42d94461bc06581f6e718c39344754a5d9bada/frozenlist-1.8.0-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:581ef5194c48035a7de2aefc72ac6539823bb71508189e5de01d60c9dcd5fa65", size = 292506, upload-time = "2025-10-06T05:36:53.101Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/3b/b991fe1612703f7e0d05c0cf734c1b77aaf7c7d321df4572e8d36e7048c8/frozenlist-1.8.0-cp313-cp313t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:3ef2d026f16a2b1866e1d86fc4e1291e1ed8a387b2c333809419a2f8b3a77b82", size = 274161, upload-time = "2025-10-06T05:36:54.309Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/ec/c5c618767bcdf66e88945ec0157d7f6c4a1322f1473392319b7a2501ded7/frozenlist-1.8.0-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:5500ef82073f599ac84d888e3a8c1f77ac831183244bfd7f11eaa0289fb30714", size = 294676, upload-time = "2025-10-06T05:36:55.566Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/ce/3934758637d8f8a88d11f0585d6495ef54b2044ed6ec84492a91fa3b27aa/frozenlist-1.8.0-cp313-cp313t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:50066c3997d0091c411a66e710f4e11752251e6d2d73d70d8d5d4c76442a199d", size = 300638, upload-time = "2025-10-06T05:36:56.758Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/4f/a7e4d0d467298f42de4b41cbc7ddaf19d3cfeabaf9ff97c20c6c7ee409f9/frozenlist-1.8.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:5c1c8e78426e59b3f8005e9b19f6ff46e5845895adbde20ece9218319eca6506", size = 283067, upload-time = "2025-10-06T05:36:57.965Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/48/c7b163063d55a83772b268e6d1affb960771b0e203b632cfe09522d67ea5/frozenlist-1.8.0-cp313-cp313t-musllinux_1_2_armv7l.whl", hash = "sha256:eefdba20de0d938cec6a89bd4d70f346a03108a19b9df4248d3cf0d88f1b0f51", size = 292101, upload-time = "2025-10-06T05:36:59.237Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/d0/2366d3c4ecdc2fd391e0afa6e11500bfba0ea772764d631bbf82f0136c9d/frozenlist-1.8.0-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:cf253e0e1c3ceb4aaff6df637ce033ff6535fb8c70a764a8f46aafd3d6ab798e", size = 289901, upload-time = "2025-10-06T05:37:00.811Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/94/daff920e82c1b70e3618a2ac39fbc01ae3e2ff6124e80739ce5d71c9b920/frozenlist-1.8.0-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:032efa2674356903cd0261c4317a561a6850f3ac864a63fc1583147fb05a79b0", size = 289395, upload-time = "2025-10-06T05:37:02.115Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/20/bba307ab4235a09fdcd3cc5508dbabd17c4634a1af4b96e0f69bfe551ebd/frozenlist-1.8.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:6da155091429aeba16851ecb10a9104a108bcd32f6c1642867eadaee401c1c41", size = 283659, upload-time = "2025-10-06T05:37:03.711Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/00/04ca1c3a7a124b6de4f8a9a17cc2fcad138b4608e7a3fc5877804b8715d7/frozenlist-1.8.0-cp313-cp313t-win32.whl", hash = "sha256:0f96534f8bfebc1a394209427d0f8a63d343c9779cda6fc25e8e121b5fd8555b", size = 43492, upload-time = "2025-10-06T05:37:04.915Z" },
+    { url = "https://files.pythonhosted.org/packages/59/5e/c69f733a86a94ab10f68e496dc6b7e8bc078ebb415281d5698313e3af3a1/frozenlist-1.8.0-cp313-cp313t-win_amd64.whl", hash = "sha256:5d63a068f978fc69421fb0e6eb91a9603187527c86b7cd3f534a5b77a592b888", size = 48034, upload-time = "2025-10-06T05:37:06.343Z" },
+    { url = "https://files.pythonhosted.org/packages/16/6c/be9d79775d8abe79b05fa6d23da99ad6e7763a1d080fbae7290b286093fd/frozenlist-1.8.0-cp313-cp313t-win_arm64.whl", hash = "sha256:bf0a7e10b077bf5fb9380ad3ae8ce20ef919a6ad93b4552896419ac7e1d8e042", size = 41749, upload-time = "2025-10-06T05:37:07.431Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/c8/85da824b7e7b9b6e7f7705b2ecaf9591ba6f79c1177f324c2735e41d36a2/frozenlist-1.8.0-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:cee686f1f4cadeb2136007ddedd0aaf928ab95216e7691c63e50a8ec066336d0", size = 86127, upload-time = "2025-10-06T05:37:08.438Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/e8/a1185e236ec66c20afd72399522f142c3724c785789255202d27ae992818/frozenlist-1.8.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:119fb2a1bd47307e899c2fac7f28e85b9a543864df47aa7ec9d3c1b4545f096f", size = 49698, upload-time = "2025-10-06T05:37:09.48Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/93/72b1736d68f03fda5fdf0f2180fb6caaae3894f1b854d006ac61ecc727ee/frozenlist-1.8.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:4970ece02dbc8c3a92fcc5228e36a3e933a01a999f7094ff7c23fbd2beeaa67c", size = 49749, upload-time = "2025-10-06T05:37:10.569Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/b2/fabede9fafd976b991e9f1b9c8c873ed86f202889b864756f240ce6dd855/frozenlist-1.8.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:cba69cb73723c3f329622e34bdbf5ce1f80c21c290ff04256cff1cd3c2036ed2", size = 231298, upload-time = "2025-10-06T05:37:11.993Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/3b/d9b1e0b0eed36e70477ffb8360c49c85c8ca8ef9700a4e6711f39a6e8b45/frozenlist-1.8.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:778a11b15673f6f1df23d9586f83c4846c471a8af693a22e066508b77d201ec8", size = 232015, upload-time = "2025-10-06T05:37:13.194Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/94/be719d2766c1138148564a3960fc2c06eb688da592bdc25adcf856101be7/frozenlist-1.8.0-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:0325024fe97f94c41c08872db482cf8ac4800d80e79222c6b0b7b162d5b13686", size = 225038, upload-time = "2025-10-06T05:37:14.577Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/09/6712b6c5465f083f52f50cf74167b92d4ea2f50e46a9eea0523d658454ae/frozenlist-1.8.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:97260ff46b207a82a7567b581ab4190bd4dfa09f4db8a8b49d1a958f6aa4940e", size = 240130, upload-time = "2025-10-06T05:37:15.781Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/d4/cd065cdcf21550b54f3ce6a22e143ac9e4836ca42a0de1022da8498eac89/frozenlist-1.8.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:54b2077180eb7f83dd52c40b2750d0a9f175e06a42e3213ce047219de902717a", size = 242845, upload-time = "2025-10-06T05:37:17.037Z" },
+    { url = "https://files.pythonhosted.org/packages/62/c3/f57a5c8c70cd1ead3d5d5f776f89d33110b1addae0ab010ad774d9a44fb9/frozenlist-1.8.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:2f05983daecab868a31e1da44462873306d3cbfd76d1f0b5b69c473d21dbb128", size = 229131, upload-time = "2025-10-06T05:37:18.221Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/52/232476fe9cb64f0742f3fde2b7d26c1dac18b6d62071c74d4ded55e0ef94/frozenlist-1.8.0-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:33f48f51a446114bc5d251fb2954ab0164d5be02ad3382abcbfe07e2531d650f", size = 240542, upload-time = "2025-10-06T05:37:19.771Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/85/07bf3f5d0fb5414aee5f47d33c6f5c77bfe49aac680bfece33d4fdf6a246/frozenlist-1.8.0-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:154e55ec0655291b5dd1b8731c637ecdb50975a2ae70c606d100750a540082f7", size = 237308, upload-time = "2025-10-06T05:37:20.969Z" },
+    { url = "https://files.pythonhosted.org/packages/11/99/ae3a33d5befd41ac0ca2cc7fd3aa707c9c324de2e89db0e0f45db9a64c26/frozenlist-1.8.0-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:4314debad13beb564b708b4a496020e5306c7333fa9a3ab90374169a20ffab30", size = 238210, upload-time = "2025-10-06T05:37:22.252Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/60/b1d2da22f4970e7a155f0adde9b1435712ece01b3cd45ba63702aea33938/frozenlist-1.8.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:073f8bf8becba60aa931eb3bc420b217bb7d5b8f4750e6f8b3be7f3da85d38b7", size = 231972, upload-time = "2025-10-06T05:37:23.5Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/ab/945b2f32de889993b9c9133216c068b7fcf257d8595a0ac420ac8677cab0/frozenlist-1.8.0-cp314-cp314-win32.whl", hash = "sha256:bac9c42ba2ac65ddc115d930c78d24ab8d4f465fd3fc473cdedfccadb9429806", size = 40536, upload-time = "2025-10-06T05:37:25.581Z" },
+    { url = "https://files.pythonhosted.org/packages/59/ad/9caa9b9c836d9ad6f067157a531ac48b7d36499f5036d4141ce78c230b1b/frozenlist-1.8.0-cp314-cp314-win_amd64.whl", hash = "sha256:3e0761f4d1a44f1d1a47996511752cf3dcec5bbdd9cc2b4fe595caf97754b7a0", size = 44330, upload-time = "2025-10-06T05:37:26.928Z" },
+    { url = "https://files.pythonhosted.org/packages/82/13/e6950121764f2676f43534c555249f57030150260aee9dcf7d64efda11dd/frozenlist-1.8.0-cp314-cp314-win_arm64.whl", hash = "sha256:d1eaff1d00c7751b7c6662e9c5ba6eb2c17a2306ba5e2a37f24ddf3cc953402b", size = 40627, upload-time = "2025-10-06T05:37:28.075Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/c7/43200656ecc4e02d3f8bc248df68256cd9572b3f0017f0a0c4e93440ae23/frozenlist-1.8.0-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:d3bb933317c52d7ea5004a1c442eef86f426886fba134ef8cf4226ea6ee1821d", size = 89238, upload-time = "2025-10-06T05:37:29.373Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/29/55c5f0689b9c0fb765055629f472c0de484dcaf0acee2f7707266ae3583c/frozenlist-1.8.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:8009897cdef112072f93a0efdce29cd819e717fd2f649ee3016efd3cd885a7ed", size = 50738, upload-time = "2025-10-06T05:37:30.792Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/7d/b7282a445956506fa11da8c2db7d276adcbf2b17d8bb8407a47685263f90/frozenlist-1.8.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:2c5dcbbc55383e5883246d11fd179782a9d07a986c40f49abe89ddf865913930", size = 51739, upload-time = "2025-10-06T05:37:32.127Z" },
+    { url = "https://files.pythonhosted.org/packages/62/1c/3d8622e60d0b767a5510d1d3cf21065b9db874696a51ea6d7a43180a259c/frozenlist-1.8.0-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:39ecbc32f1390387d2aa4f5a995e465e9e2f79ba3adcac92d68e3e0afae6657c", size = 284186, upload-time = "2025-10-06T05:37:33.21Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/14/aa36d5f85a89679a85a1d44cd7a6657e0b1c75f61e7cad987b203d2daca8/frozenlist-1.8.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:92db2bf818d5cc8d9c1f1fc56b897662e24ea5adb36ad1f1d82875bd64e03c24", size = 292196, upload-time = "2025-10-06T05:37:36.107Z" },
+    { url = "https://files.pythonhosted.org/packages/05/23/6bde59eb55abd407d34f77d39a5126fb7b4f109a3f611d3929f14b700c66/frozenlist-1.8.0-cp314-cp314t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:2dc43a022e555de94c3b68a4ef0b11c4f747d12c024a520c7101709a2144fb37", size = 273830, upload-time = "2025-10-06T05:37:37.663Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/3f/22cff331bfad7a8afa616289000ba793347fcd7bc275f3b28ecea2a27909/frozenlist-1.8.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:cb89a7f2de3602cfed448095bab3f178399646ab7c61454315089787df07733a", size = 294289, upload-time = "2025-10-06T05:37:39.261Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/89/5b057c799de4838b6c69aa82b79705f2027615e01be996d2486a69ca99c4/frozenlist-1.8.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:33139dc858c580ea50e7e60a1b0ea003efa1fd42e6ec7fdbad78fff65fad2fd2", size = 300318, upload-time = "2025-10-06T05:37:43.213Z" },
+    { url = "https://files.pythonhosted.org/packages/30/de/2c22ab3eb2a8af6d69dc799e48455813bab3690c760de58e1bf43b36da3e/frozenlist-1.8.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:168c0969a329b416119507ba30b9ea13688fafffac1b7822802537569a1cb0ef", size = 282814, upload-time = "2025-10-06T05:37:45.337Z" },
+    { url = "https://files.pythonhosted.org/packages/59/f7/970141a6a8dbd7f556d94977858cfb36fa9b66e0892c6dd780d2219d8cd8/frozenlist-1.8.0-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:28bd570e8e189d7f7b001966435f9dac6718324b5be2990ac496cf1ea9ddb7fe", size = 291762, upload-time = "2025-10-06T05:37:46.657Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/15/ca1adae83a719f82df9116d66f5bb28bb95557b3951903d39135620ef157/frozenlist-1.8.0-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:b2a095d45c5d46e5e79ba1e5b9cb787f541a8dee0433836cea4b96a2c439dcd8", size = 289470, upload-time = "2025-10-06T05:37:47.946Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/83/dca6dc53bf657d371fbc88ddeb21b79891e747189c5de990b9dfff2ccba1/frozenlist-1.8.0-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:eab8145831a0d56ec9c4139b6c3e594c7a83c2c8be25d5bcf2d86136a532287a", size = 289042, upload-time = "2025-10-06T05:37:49.499Z" },
+    { url = "https://files.pythonhosted.org/packages/96/52/abddd34ca99be142f354398700536c5bd315880ed0a213812bc491cff5e4/frozenlist-1.8.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:974b28cf63cc99dfb2188d8d222bc6843656188164848c4f679e63dae4b0708e", size = 283148, upload-time = "2025-10-06T05:37:50.745Z" },
+    { url = "https://files.pythonhosted.org/packages/af/d3/76bd4ed4317e7119c2b7f57c3f6934aba26d277acc6309f873341640e21f/frozenlist-1.8.0-cp314-cp314t-win32.whl", hash = "sha256:342c97bf697ac5480c0a7ec73cd700ecfa5a8a40ac923bd035484616efecc2df", size = 44676, upload-time = "2025-10-06T05:37:52.222Z" },
+    { url = "https://files.pythonhosted.org/packages/89/76/c615883b7b521ead2944bb3480398cbb07e12b7b4e4d073d3752eb721558/frozenlist-1.8.0-cp314-cp314t-win_amd64.whl", hash = "sha256:06be8f67f39c8b1dc671f5d83aaefd3358ae5cdcf8314552c57e7ed3e6475bdd", size = 49451, upload-time = "2025-10-06T05:37:53.425Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/a3/5982da14e113d07b325230f95060e2169f5311b1017ea8af2a29b374c289/frozenlist-1.8.0-cp314-cp314t-win_arm64.whl", hash = "sha256:102e6314ca4da683dca92e3b1355490fed5f313b768500084fbe6371fddfdb79", size = 42507, upload-time = "2025-10-06T05:37:54.513Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/9a/e35b4a917281c0b8419d4207f4334c8e8c5dbf4f3f5f9ada73958d937dcc/frozenlist-1.8.0-py3-none-any.whl", hash = "sha256:0c18a16eab41e82c295618a77502e17b195883241c563b00f0aa5106fc4eaa0d", size = 13409, upload-time = "2025-10-06T05:38:16.721Z" },
+]
+
+[[package]]
+name = "furl"
+version = "2.1.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "orderedmultidict", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "six", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/53/e4/203a76fa2ef46cdb0a618295cc115220cbb874229d4d8721068335eb87f0/furl-2.1.4.tar.gz", hash = "sha256:877657501266c929269739fb5f5980534a41abd6bbabcb367c136d1d3b2a6015", size = 57526, upload-time = "2025-03-09T05:36:21.175Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/61/8c/dce3b1b7593858eba995b2dfdb833f872c7f863e3da92aab7128a6b11af4/furl-2.1.4-py2.py3-none-any.whl", hash = "sha256:da34d0b34e53ffe2d2e6851a7085a05d96922b5b578620a37377ff1dbeeb11c8", size = 27550, upload-time = "2025-03-09T05:36:19.928Z" },
+]
+
+[[package]]
 name = "grpcio"
 version = "1.82.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/90/bc/656b89387d6f4ed7e0686c7b64c2ae7e554a759aa58122c8e5fb99392c32/grpcio-1.82.1.tar.gz", hash = "sha256:707b24abd90fcb1e45bcc080577da1dbf9971d107490589b9539af8e1e77b4b5", size = 13187300, upload-time = "2026-07-08T12:36:16.588Z" }
 wheels = [
@@ -992,8 +1331,8 @@ name = "httpcore"
 version = "1.0.9"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "certifi" },
-    { name = "h11" },
+    { name = "certifi", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "h11", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
 wheels = [
@@ -1055,10 +1394,10 @@ name = "httpx"
 version = "0.28.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio" },
-    { name = "certifi" },
-    { name = "httpcore" },
-    { name = "idna" },
+    { name = "anyio", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "certifi", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "httpcore", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "idna", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
 wheels = [
@@ -1106,11 +1445,11 @@ name = "jsonschema"
 version = "4.26.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "attrs" },
-    { name = "jsonschema-specifications" },
-    { name = "referencing" },
-    { name = "rpds-py", version = "0.30.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "rpds-py", version = "2026.6.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "attrs", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "jsonschema-specifications", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "referencing", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "rpds-py", version = "0.30.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and sys_platform == 'darwin') or (python_full_version < '3.11' and sys_platform == 'linux') or (python_full_version < '3.11' and sys_platform == 'win32')" },
+    { name = "rpds-py", version = "2026.6.3", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and sys_platform == 'darwin') or (python_full_version >= '3.11' and sys_platform == 'linux') or (python_full_version >= '3.11' and sys_platform == 'win32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b3/fc/e067678238fa451312d4c62bf6e6cf5ec56375422aee02f9cb5f909b3047/jsonschema-4.26.0.tar.gz", hash = "sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326", size = 366583, upload-time = "2026-01-07T13:41:07.246Z" }
 wheels = [
@@ -1122,7 +1461,7 @@ name = "jsonschema-specifications"
 version = "2025.9.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "referencing" },
+    { name = "referencing", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
 wheels = [
@@ -1221,7 +1560,7 @@ name = "markdown-it-py"
 version = "4.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "mdurl" },
+    { name = "mdurl", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/06/ff/7841249c247aa650a76b9ee4bbaeae59370dc8bfd2f6c01f3630c35eb134/markdown_it_py-4.2.0.tar.gz", hash = "sha256:04a21681d6fbb623de53f6f364d352309d4094dd4194040a10fd51833e418d49", size = 82454, upload-time = "2026-05-07T12:08:28.36Z" }
 wheels = [
@@ -1229,24 +1568,109 @@ wheels = [
 ]
 
 [[package]]
+name = "markupsafe"
+version = "3.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/99/7690b6d4034fffd95959cbe0c02de8deb3098cc577c67bb6a24fe5d7caa7/markupsafe-3.0.3.tar.gz", hash = "sha256:722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698", size = 80313, upload-time = "2025-09-27T18:37:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e8/4b/3541d44f3937ba468b75da9eebcae497dcf67adb65caa16760b0a6807ebb/markupsafe-3.0.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:2f981d352f04553a7171b8e44369f2af4055f888dfb147d55e42d29e29e74559", size = 11631, upload-time = "2025-09-27T18:36:05.558Z" },
+    { url = "https://files.pythonhosted.org/packages/98/1b/fbd8eed11021cabd9226c37342fa6ca4e8a98d8188a8d9b66740494960e4/markupsafe-3.0.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:e1c1493fb6e50ab01d20a22826e57520f1284df32f2d8601fdd90b6304601419", size = 12057, upload-time = "2025-09-27T18:36:07.165Z" },
+    { url = "https://files.pythonhosted.org/packages/40/01/e560d658dc0bb8ab762670ece35281dec7b6c1b33f5fbc09ebb57a185519/markupsafe-3.0.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1ba88449deb3de88bd40044603fafffb7bc2b055d626a330323a9ed736661695", size = 22050, upload-time = "2025-09-27T18:36:08.005Z" },
+    { url = "https://files.pythonhosted.org/packages/af/cd/ce6e848bbf2c32314c9b237839119c5a564a59725b53157c856e90937b7a/markupsafe-3.0.3-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f42d0984e947b8adf7dd6dde396e720934d12c506ce84eea8476409563607591", size = 20681, upload-time = "2025-09-27T18:36:08.881Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/2a/b5c12c809f1c3045c4d580b035a743d12fcde53cf685dbc44660826308da/markupsafe-3.0.3-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c0c0b3ade1c0b13b936d7970b1d37a57acde9199dc2aecc4c336773e1d86049c", size = 20705, upload-time = "2025-09-27T18:36:10.131Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/e3/9427a68c82728d0a88c50f890d0fc072a1484de2f3ac1ad0bfc1a7214fd5/markupsafe-3.0.3-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:0303439a41979d9e74d18ff5e2dd8c43ed6c6001fd40e5bf2e43f7bd9bbc523f", size = 21524, upload-time = "2025-09-27T18:36:11.324Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/36/23578f29e9e582a4d0278e009b38081dbe363c5e7165113fad546918a232/markupsafe-3.0.3-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:d2ee202e79d8ed691ceebae8e0486bd9a2cd4794cec4824e1c99b6f5009502f6", size = 20282, upload-time = "2025-09-27T18:36:12.573Z" },
+    { url = "https://files.pythonhosted.org/packages/56/21/dca11354e756ebd03e036bd8ad58d6d7168c80ce1fe5e75218e4945cbab7/markupsafe-3.0.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:177b5253b2834fe3678cb4a5f0059808258584c559193998be2601324fdeafb1", size = 20745, upload-time = "2025-09-27T18:36:13.504Z" },
+    { url = "https://files.pythonhosted.org/packages/87/99/faba9369a7ad6e4d10b6a5fbf71fa2a188fe4a593b15f0963b73859a1bbd/markupsafe-3.0.3-cp310-cp310-win32.whl", hash = "sha256:2a15a08b17dd94c53a1da0438822d70ebcd13f8c3a95abe3a9ef9f11a94830aa", size = 14571, upload-time = "2025-09-27T18:36:14.779Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/25/55dc3ab959917602c96985cb1253efaa4ff42f71194bddeb61eb7278b8be/markupsafe-3.0.3-cp310-cp310-win_amd64.whl", hash = "sha256:c4ffb7ebf07cfe8931028e3e4c85f0357459a3f9f9490886198848f4fa002ec8", size = 15056, upload-time = "2025-09-27T18:36:16.125Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/9e/0a02226640c255d1da0b8d12e24ac2aa6734da68bff14c05dd53b94a0fc3/markupsafe-3.0.3-cp310-cp310-win_arm64.whl", hash = "sha256:e2103a929dfa2fcaf9bb4e7c091983a49c9ac3b19c9061b6d5427dd7d14d81a1", size = 13932, upload-time = "2025-09-27T18:36:17.311Z" },
+    { url = "https://files.pythonhosted.org/packages/08/db/fefacb2136439fc8dd20e797950e749aa1f4997ed584c62cfb8ef7c2be0e/markupsafe-3.0.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:1cc7ea17a6824959616c525620e387f6dd30fec8cb44f649e31712db02123dad", size = 11631, upload-time = "2025-09-27T18:36:18.185Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/2e/5898933336b61975ce9dc04decbc0a7f2fee78c30353c5efba7f2d6ff27a/markupsafe-3.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4bd4cd07944443f5a265608cc6aab442e4f74dff8088b0dfc8238647b8f6ae9a", size = 12058, upload-time = "2025-09-27T18:36:19.444Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/09/adf2df3699d87d1d8184038df46a9c80d78c0148492323f4693df54e17bb/markupsafe-3.0.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6b5420a1d9450023228968e7e6a9ce57f65d148ab56d2313fcd589eee96a7a50", size = 24287, upload-time = "2025-09-27T18:36:20.768Z" },
+    { url = "https://files.pythonhosted.org/packages/30/ac/0273f6fcb5f42e314c6d8cd99effae6a5354604d461b8d392b5ec9530a54/markupsafe-3.0.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0bf2a864d67e76e5c9a34dc26ec616a66b9888e25e7b9460e1c76d3293bd9dbf", size = 22940, upload-time = "2025-09-27T18:36:22.249Z" },
+    { url = "https://files.pythonhosted.org/packages/19/ae/31c1be199ef767124c042c6c3e904da327a2f7f0cd63a0337e1eca2967a8/markupsafe-3.0.3-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:bc51efed119bc9cfdf792cdeaa4d67e8f6fcccab66ed4bfdd6bde3e59bfcbb2f", size = 21887, upload-time = "2025-09-27T18:36:23.535Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/76/7edcab99d5349a4532a459e1fe64f0b0467a3365056ae550d3bcf3f79e1e/markupsafe-3.0.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:068f375c472b3e7acbe2d5318dea141359e6900156b5b2ba06a30b169086b91a", size = 23692, upload-time = "2025-09-27T18:36:24.823Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/28/6e74cdd26d7514849143d69f0bf2399f929c37dc2b31e6829fd2045b2765/markupsafe-3.0.3-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:7be7b61bb172e1ed687f1754f8e7484f1c8019780f6f6b0786e76bb01c2ae115", size = 21471, upload-time = "2025-09-27T18:36:25.95Z" },
+    { url = "https://files.pythonhosted.org/packages/62/7e/a145f36a5c2945673e590850a6f8014318d5577ed7e5920a4b3448e0865d/markupsafe-3.0.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:f9e130248f4462aaa8e2552d547f36ddadbeaa573879158d721bbd33dfe4743a", size = 22923, upload-time = "2025-09-27T18:36:27.109Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/62/d9c46a7f5c9adbeeeda52f5b8d802e1094e9717705a645efc71b0913a0a8/markupsafe-3.0.3-cp311-cp311-win32.whl", hash = "sha256:0db14f5dafddbb6d9208827849fad01f1a2609380add406671a26386cdf15a19", size = 14572, upload-time = "2025-09-27T18:36:28.045Z" },
+    { url = "https://files.pythonhosted.org/packages/83/8a/4414c03d3f891739326e1783338e48fb49781cc915b2e0ee052aa490d586/markupsafe-3.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:de8a88e63464af587c950061a5e6a67d3632e36df62b986892331d4620a35c01", size = 15077, upload-time = "2025-09-27T18:36:29.025Z" },
+    { url = "https://files.pythonhosted.org/packages/35/73/893072b42e6862f319b5207adc9ae06070f095b358655f077f69a35601f0/markupsafe-3.0.3-cp311-cp311-win_arm64.whl", hash = "sha256:3b562dd9e9ea93f13d53989d23a7e775fdfd1066c33494ff43f5418bc8c58a5c", size = 13876, upload-time = "2025-09-27T18:36:29.954Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/72/147da192e38635ada20e0a2e1a51cf8823d2119ce8883f7053879c2199b5/markupsafe-3.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d53197da72cc091b024dd97249dfc7794d6a56530370992a5e1a08983ad9230e", size = 11615, upload-time = "2025-09-27T18:36:30.854Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/81/7e4e08678a1f98521201c3079f77db69fb552acd56067661f8c2f534a718/markupsafe-3.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1872df69a4de6aead3491198eaf13810b565bdbeec3ae2dc8780f14458ec73ce", size = 12020, upload-time = "2025-09-27T18:36:31.971Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/2c/799f4742efc39633a1b54a92eec4082e4f815314869865d876824c257c1e/markupsafe-3.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3a7e8ae81ae39e62a41ec302f972ba6ae23a5c5396c8e60113e9066ef893da0d", size = 24332, upload-time = "2025-09-27T18:36:32.813Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/2e/8d0c2ab90a8c1d9a24f0399058ab8519a3279d1bd4289511d74e909f060e/markupsafe-3.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d6dd0be5b5b189d31db7cda48b91d7e0a9795f31430b7f271219ab30f1d3ac9d", size = 22947, upload-time = "2025-09-27T18:36:33.86Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/54/887f3092a85238093a0b2154bd629c89444f395618842e8b0c41783898ea/markupsafe-3.0.3-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:94c6f0bb423f739146aec64595853541634bde58b2135f27f61c1ffd1cd4d16a", size = 21962, upload-time = "2025-09-27T18:36:35.099Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/2f/336b8c7b6f4a4d95e91119dc8521402461b74a485558d8f238a68312f11c/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:be8813b57049a7dc738189df53d69395eba14fb99345e0a5994914a3864c8a4b", size = 23760, upload-time = "2025-09-27T18:36:36.001Z" },
+    { url = "https://files.pythonhosted.org/packages/32/43/67935f2b7e4982ffb50a4d169b724d74b62a3964bc1a9a527f5ac4f1ee2b/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:83891d0e9fb81a825d9a6d61e3f07550ca70a076484292a70fde82c4b807286f", size = 21529, upload-time = "2025-09-27T18:36:36.906Z" },
+    { url = "https://files.pythonhosted.org/packages/89/e0/4486f11e51bbba8b0c041098859e869e304d1c261e59244baa3d295d47b7/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:77f0643abe7495da77fb436f50f8dab76dbc6e5fd25d39589a0f1fe6548bfa2b", size = 23015, upload-time = "2025-09-27T18:36:37.868Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/e1/78ee7a023dac597a5825441ebd17170785a9dab23de95d2c7508ade94e0e/markupsafe-3.0.3-cp312-cp312-win32.whl", hash = "sha256:d88b440e37a16e651bda4c7c2b930eb586fd15ca7406cb39e211fcff3bf3017d", size = 14540, upload-time = "2025-09-27T18:36:38.761Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/5b/bec5aa9bbbb2c946ca2733ef9c4ca91c91b6a24580193e891b5f7dbe8e1e/markupsafe-3.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:26a5784ded40c9e318cfc2bdb30fe164bdb8665ded9cd64d500a34fb42067b1c", size = 15105, upload-time = "2025-09-27T18:36:39.701Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/f1/216fc1bbfd74011693a4fd837e7026152e89c4bcf3e77b6692fba9923123/markupsafe-3.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:35add3b638a5d900e807944a078b51922212fb3dedb01633a8defc4b01a3c85f", size = 13906, upload-time = "2025-09-27T18:36:40.689Z" },
+    { url = "https://files.pythonhosted.org/packages/38/2f/907b9c7bbba283e68f20259574b13d005c121a0fa4c175f9bed27c4597ff/markupsafe-3.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e1cf1972137e83c5d4c136c43ced9ac51d0e124706ee1c8aa8532c1287fa8795", size = 11622, upload-time = "2025-09-27T18:36:41.777Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/d9/5f7756922cdd676869eca1c4e3c0cd0df60ed30199ffd775e319089cb3ed/markupsafe-3.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:116bb52f642a37c115f517494ea5feb03889e04df47eeff5b130b1808ce7c219", size = 12029, upload-time = "2025-09-27T18:36:43.257Z" },
+    { url = "https://files.pythonhosted.org/packages/00/07/575a68c754943058c78f30db02ee03a64b3c638586fba6a6dd56830b30a3/markupsafe-3.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:133a43e73a802c5562be9bbcd03d090aa5a1fe899db609c29e8c8d815c5f6de6", size = 24374, upload-time = "2025-09-27T18:36:44.508Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/21/9b05698b46f218fc0e118e1f8168395c65c8a2c750ae2bab54fc4bd4e0e8/markupsafe-3.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ccfcd093f13f0f0b7fdd0f198b90053bf7b2f02a3927a30e63f3ccc9df56b676", size = 22980, upload-time = "2025-09-27T18:36:45.385Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/71/544260864f893f18b6827315b988c146b559391e6e7e8f7252839b1b846a/markupsafe-3.0.3-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:509fa21c6deb7a7a273d629cf5ec029bc209d1a51178615ddf718f5918992ab9", size = 21990, upload-time = "2025-09-27T18:36:46.916Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/28/b50fc2f74d1ad761af2f5dcce7492648b983d00a65b8c0e0cb457c82ebbe/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a4afe79fb3de0b7097d81da19090f4df4f8d3a2b3adaa8764138aac2e44f3af1", size = 23784, upload-time = "2025-09-27T18:36:47.884Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/76/104b2aa106a208da8b17a2fb72e033a5a9d7073c68f7e508b94916ed47a9/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:795e7751525cae078558e679d646ae45574b47ed6e7771863fcc079a6171a0fc", size = 21588, upload-time = "2025-09-27T18:36:48.82Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/99/16a5eb2d140087ebd97180d95249b00a03aa87e29cc224056274f2e45fd6/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8485f406a96febb5140bfeca44a73e3ce5116b2501ac54fe953e488fb1d03b12", size = 23041, upload-time = "2025-09-27T18:36:49.797Z" },
+    { url = "https://files.pythonhosted.org/packages/19/bc/e7140ed90c5d61d77cea142eed9f9c303f4c4806f60a1044c13e3f1471d0/markupsafe-3.0.3-cp313-cp313-win32.whl", hash = "sha256:bdd37121970bfd8be76c5fb069c7751683bdf373db1ed6c010162b2a130248ed", size = 14543, upload-time = "2025-09-27T18:36:51.584Z" },
+    { url = "https://files.pythonhosted.org/packages/05/73/c4abe620b841b6b791f2edc248f556900667a5a1cf023a6646967ae98335/markupsafe-3.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:9a1abfdc021a164803f4d485104931fb8f8c1efd55bc6b748d2f5774e78b62c5", size = 15113, upload-time = "2025-09-27T18:36:52.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/3a/fa34a0f7cfef23cf9500d68cb7c32dd64ffd58a12b09225fb03dd37d5b80/markupsafe-3.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:7e68f88e5b8799aa49c85cd116c932a1ac15caaa3f5db09087854d218359e485", size = 13911, upload-time = "2025-09-27T18:36:53.513Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/d7/e05cd7efe43a88a17a37b3ae96e79a19e846f3f456fe79c57ca61356ef01/markupsafe-3.0.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:218551f6df4868a8d527e3062d0fb968682fe92054e89978594c28e642c43a73", size = 11658, upload-time = "2025-09-27T18:36:54.819Z" },
+    { url = "https://files.pythonhosted.org/packages/99/9e/e412117548182ce2148bdeacdda3bb494260c0b0184360fe0d56389b523b/markupsafe-3.0.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:3524b778fe5cfb3452a09d31e7b5adefeea8c5be1d43c4f810ba09f2ceb29d37", size = 12066, upload-time = "2025-09-27T18:36:55.714Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/e6/fa0ffcda717ef64a5108eaa7b4f5ed28d56122c9a6d70ab8b72f9f715c80/markupsafe-3.0.3-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4e885a3d1efa2eadc93c894a21770e4bc67899e3543680313b09f139e149ab19", size = 25639, upload-time = "2025-09-27T18:36:56.908Z" },
+    { url = "https://files.pythonhosted.org/packages/96/ec/2102e881fe9d25fc16cb4b25d5f5cde50970967ffa5dddafdb771237062d/markupsafe-3.0.3-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8709b08f4a89aa7586de0aadc8da56180242ee0ada3999749b183aa23df95025", size = 23569, upload-time = "2025-09-27T18:36:57.913Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/30/6f2fce1f1f205fc9323255b216ca8a235b15860c34b6798f810f05828e32/markupsafe-3.0.3-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b8512a91625c9b3da6f127803b166b629725e68af71f8184ae7e7d54686a56d6", size = 23284, upload-time = "2025-09-27T18:36:58.833Z" },
+    { url = "https://files.pythonhosted.org/packages/58/47/4a0ccea4ab9f5dcb6f79c0236d954acb382202721e704223a8aafa38b5c8/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9b79b7a16f7fedff2495d684f2b59b0457c3b493778c9eed31111be64d58279f", size = 24801, upload-time = "2025-09-27T18:36:59.739Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/70/3780e9b72180b6fecb83a4814d84c3bf4b4ae4bf0b19c27196104149734c/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:12c63dfb4a98206f045aa9563db46507995f7ef6d83b2f68eda65c307c6829eb", size = 22769, upload-time = "2025-09-27T18:37:00.719Z" },
+    { url = "https://files.pythonhosted.org/packages/98/c5/c03c7f4125180fc215220c035beac6b9cb684bc7a067c84fc69414d315f5/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:8f71bc33915be5186016f675cd83a1e08523649b0e33efdb898db577ef5bb009", size = 23642, upload-time = "2025-09-27T18:37:01.673Z" },
+    { url = "https://files.pythonhosted.org/packages/80/d6/2d1b89f6ca4bff1036499b1e29a1d02d282259f3681540e16563f27ebc23/markupsafe-3.0.3-cp313-cp313t-win32.whl", hash = "sha256:69c0b73548bc525c8cb9a251cddf1931d1db4d2258e9599c28c07ef3580ef354", size = 14612, upload-time = "2025-09-27T18:37:02.639Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/98/e48a4bfba0a0ffcf9925fe2d69240bfaa19c6f7507b8cd09c70684a53c1e/markupsafe-3.0.3-cp313-cp313t-win_amd64.whl", hash = "sha256:1b4b79e8ebf6b55351f0d91fe80f893b4743f104bff22e90697db1590e47a218", size = 15200, upload-time = "2025-09-27T18:37:03.582Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/72/e3cc540f351f316e9ed0f092757459afbc595824ca724cbc5a5d4263713f/markupsafe-3.0.3-cp313-cp313t-win_arm64.whl", hash = "sha256:ad2cf8aa28b8c020ab2fc8287b0f823d0a7d8630784c31e9ee5edea20f406287", size = 13973, upload-time = "2025-09-27T18:37:04.929Z" },
+    { url = "https://files.pythonhosted.org/packages/33/8a/8e42d4838cd89b7dde187011e97fe6c3af66d8c044997d2183fbd6d31352/markupsafe-3.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:eaa9599de571d72e2daf60164784109f19978b327a3910d3e9de8c97b5b70cfe", size = 11619, upload-time = "2025-09-27T18:37:06.342Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/64/7660f8a4a8e53c924d0fa05dc3a55c9cee10bbd82b11c5afb27d44b096ce/markupsafe-3.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c47a551199eb8eb2121d4f0f15ae0f923d31350ab9280078d1e5f12b249e0026", size = 12029, upload-time = "2025-09-27T18:37:07.213Z" },
+    { url = "https://files.pythonhosted.org/packages/da/ef/e648bfd021127bef5fa12e1720ffed0c6cbb8310c8d9bea7266337ff06de/markupsafe-3.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f34c41761022dd093b4b6896d4810782ffbabe30f2d443ff5f083e0cbbb8c737", size = 24408, upload-time = "2025-09-27T18:37:09.572Z" },
+    { url = "https://files.pythonhosted.org/packages/41/3c/a36c2450754618e62008bf7435ccb0f88053e07592e6028a34776213d877/markupsafe-3.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:457a69a9577064c05a97c41f4e65148652db078a3a509039e64d3467b9e7ef97", size = 23005, upload-time = "2025-09-27T18:37:10.58Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/20/b7fdf89a8456b099837cd1dc21974632a02a999ec9bf7ca3e490aacd98e7/markupsafe-3.0.3-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e8afc3f2ccfa24215f8cb28dcf43f0113ac3c37c2f0f0806d8c70e4228c5cf4d", size = 22048, upload-time = "2025-09-27T18:37:11.547Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/a7/591f592afdc734f47db08a75793a55d7fbcc6902a723ae4cfbab61010cc5/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ec15a59cf5af7be74194f7ab02d0f59a62bdcf1a537677ce67a2537c9b87fcda", size = 23821, upload-time = "2025-09-27T18:37:12.48Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/33/45b24e4f44195b26521bc6f1a82197118f74df348556594bd2262bda1038/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:0eb9ff8191e8498cca014656ae6b8d61f39da5f95b488805da4bb029cccbfbaf", size = 21606, upload-time = "2025-09-27T18:37:13.485Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/0e/53dfaca23a69fbfbbf17a4b64072090e70717344c52eaaaa9c5ddff1e5f0/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2713baf880df847f2bece4230d4d094280f4e67b1e813eec43b4c0e144a34ffe", size = 23043, upload-time = "2025-09-27T18:37:14.408Z" },
+    { url = "https://files.pythonhosted.org/packages/46/11/f333a06fc16236d5238bfe74daccbca41459dcd8d1fa952e8fbd5dccfb70/markupsafe-3.0.3-cp314-cp314-win32.whl", hash = "sha256:729586769a26dbceff69f7a7dbbf59ab6572b99d94576a5592625d5b411576b9", size = 14747, upload-time = "2025-09-27T18:37:15.36Z" },
+    { url = "https://files.pythonhosted.org/packages/28/52/182836104b33b444e400b14f797212f720cbc9ed6ba34c800639d154e821/markupsafe-3.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:bdc919ead48f234740ad807933cdf545180bfbe9342c2bb451556db2ed958581", size = 15341, upload-time = "2025-09-27T18:37:16.496Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/18/acf23e91bd94fd7b3031558b1f013adfa21a8e407a3fdb32745538730382/markupsafe-3.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:5a7d5dc5140555cf21a6fefbdbf8723f06fcd2f63ef108f2854de715e4422cb4", size = 14073, upload-time = "2025-09-27T18:37:17.476Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/f0/57689aa4076e1b43b15fdfa646b04653969d50cf30c32a102762be2485da/markupsafe-3.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:1353ef0c1b138e1907ae78e2f6c63ff67501122006b0f9abad68fda5f4ffc6ab", size = 11661, upload-time = "2025-09-27T18:37:18.453Z" },
+    { url = "https://files.pythonhosted.org/packages/89/c3/2e67a7ca217c6912985ec766c6393b636fb0c2344443ff9d91404dc4c79f/markupsafe-3.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1085e7fbddd3be5f89cc898938f42c0b3c711fdcb37d75221de2666af647c175", size = 12069, upload-time = "2025-09-27T18:37:19.332Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/00/be561dce4e6ca66b15276e184ce4b8aec61fe83662cce2f7d72bd3249d28/markupsafe-3.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1b52b4fb9df4eb9ae465f8d0c228a00624de2334f216f178a995ccdcf82c4634", size = 25670, upload-time = "2025-09-27T18:37:20.245Z" },
+    { url = "https://files.pythonhosted.org/packages/50/09/c419f6f5a92e5fadde27efd190eca90f05e1261b10dbd8cbcb39cd8ea1dc/markupsafe-3.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fed51ac40f757d41b7c48425901843666a6677e3e8eb0abcff09e4ba6e664f50", size = 23598, upload-time = "2025-09-27T18:37:21.177Z" },
+    { url = "https://files.pythonhosted.org/packages/22/44/a0681611106e0b2921b3033fc19bc53323e0b50bc70cffdd19f7d679bb66/markupsafe-3.0.3-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f190daf01f13c72eac4efd5c430a8de82489d9cff23c364c3ea822545032993e", size = 23261, upload-time = "2025-09-27T18:37:22.167Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/57/1b0b3f100259dc9fffe780cfb60d4be71375510e435efec3d116b6436d43/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e56b7d45a839a697b5eb268c82a71bd8c7f6c94d6fd50c3d577fa39a9f1409f5", size = 24835, upload-time = "2025-09-27T18:37:23.296Z" },
+    { url = "https://files.pythonhosted.org/packages/26/6a/4bf6d0c97c4920f1597cc14dd720705eca0bf7c787aebc6bb4d1bead5388/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:f3e98bb3798ead92273dc0e5fd0f31ade220f59a266ffd8a4f6065e0a3ce0523", size = 22733, upload-time = "2025-09-27T18:37:24.237Z" },
+    { url = "https://files.pythonhosted.org/packages/14/c7/ca723101509b518797fedc2fdf79ba57f886b4aca8a7d31857ba3ee8281f/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5678211cb9333a6468fb8d8be0305520aa073f50d17f089b5b4b477ea6e67fdc", size = 23672, upload-time = "2025-09-27T18:37:25.271Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
+    { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
+]
+
+[[package]]
 name = "mcp"
 version = "1.28.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio" },
-    { name = "httpx" },
-    { name = "httpx-sse" },
-    { name = "jsonschema" },
-    { name = "pydantic" },
-    { name = "pydantic-settings" },
-    { name = "pyjwt", extra = ["crypto"] },
-    { name = "python-multipart" },
+    { name = "anyio", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "httpx", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "httpx-sse", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "jsonschema", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "pydantic", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "pydantic-settings", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "pyjwt", extra = ["crypto"], marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "python-multipart", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "pywin32", marker = "sys_platform == 'win32'" },
-    { name = "sse-starlette" },
-    { name = "starlette" },
-    { name = "typing-extensions" },
-    { name = "typing-inspection" },
-    { name = "uvicorn", extra = ["standard"] },
+    { name = "sse-starlette", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "starlette", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "typing-extensions", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "typing-inspection", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "uvicorn", extra = ["standard"], marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/6e/77/9450b8f251a13affb6281997d0523c4615f8a8b35d0b21ff30db3a5aac9d/mcp-1.28.1.tar.gz", hash = "sha256:d51e36a5f5644faea4f85ea649bfffa6bc6c26770d42798ad6a3de3d2ba69683", size = 638501, upload-time = "2026-06-26T12:57:29.093Z" }
 wheels = [
@@ -1255,7 +1679,7 @@ wheels = [
 
 [package.optional-dependencies]
 ws = [
-    { name = "websockets" },
+    { name = "websockets", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 
 [[package]]
@@ -1272,9 +1696,9 @@ name = "msal"
 version = "1.37.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography" },
-    { name = "pyjwt", extra = ["crypto"] },
-    { name = "requests" },
+    { name = "cryptography", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "pyjwt", extra = ["crypto"], marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "requests", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/9a/99/d840198ecf6e8057bbc937f129ae940404485d736cda73253bbff9537f01/msal-1.37.0.tar.gz", hash = "sha256:1b1672a33ee467c1d70b341bb16cafd51bb3c817147a95b93263794b03971bec", size = 182444, upload-time = "2026-05-29T19:49:05.561Z" }
 wheels = [
@@ -1286,7 +1710,7 @@ name = "msal-extensions"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "msal" },
+    { name = "msal", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/01/99/5d239b6156eddf761a636bded1118414d161bd6b7b37a9335549ed159396/msal_extensions-1.3.1.tar.gz", hash = "sha256:c5b0fd10f65ef62b5f1d62f4251d51cbcaf003fcedae8c91b040a488614be1a4", size = 23315, upload-time = "2025-03-14T23:51:03.902Z" }
 wheels = [
@@ -1298,11 +1722,11 @@ name = "msrest"
 version = "0.7.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "azure-core" },
-    { name = "certifi" },
-    { name = "isodate" },
-    { name = "requests" },
-    { name = "requests-oauthlib" },
+    { name = "azure-core", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "certifi", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "isodate", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "requests", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "requests-oauthlib", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/68/77/8397c8fb8fc257d8ea0fa66f8068e073278c65f05acb17dcb22a02bfdc42/msrest-0.7.1.zip", hash = "sha256:6e7661f46f3afd88b75667b7187a92829924446c7ea1d169be8c4bb7eeb788b9", size = 175332, upload-time = "2022-06-13T22:41:25.111Z" }
 wheels = [
@@ -1310,16 +1734,154 @@ wheels = [
 ]
 
 [[package]]
+name = "multidict"
+version = "6.7.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "(python_full_version < '3.11' and sys_platform == 'darwin') or (python_full_version < '3.11' and sys_platform == 'linux') or (python_full_version < '3.11' and sys_platform == 'win32')" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1a/c2/c2d94cbe6ac1753f3fc980da97b3d930efe1da3af3c9f5125354436c073d/multidict-6.7.1.tar.gz", hash = "sha256:ec6652a1bee61c53a3e5776b6049172c53b6aaba34f18c9ad04f82712bac623d", size = 102010, upload-time = "2026-01-26T02:46:45.979Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/0b/19348d4c98980c4851d2f943f8ebafdece2ae7ef737adcfa5994ce8e5f10/multidict-6.7.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:c93c3db7ea657dd4637d57e74ab73de31bccefe144d3d4ce370052035bc85fb5", size = 77176, upload-time = "2026-01-26T02:42:59.784Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/04/9de3f8077852e3d438215c81e9b691244532d2e05b4270e89ce67b7d103c/multidict-6.7.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:974e72a2474600827abaeda71af0c53d9ebbc3c2eb7da37b37d7829ae31232d8", size = 44996, upload-time = "2026-01-26T02:43:01.674Z" },
+    { url = "https://files.pythonhosted.org/packages/31/5c/08c7f7fe311f32e83f7621cd3f99d805f45519cd06fafb247628b861da7d/multidict-6.7.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:cdea2e7b2456cfb6694fb113066fd0ec7ea4d67e3a35e1f4cbeea0b448bf5872", size = 44631, upload-time = "2026-01-26T02:43:03.169Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/7f/0e3b1390ae772f27501199996b94b52ceeb64fe6f9120a32c6c3f6b781be/multidict-6.7.1-cp310-cp310-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:17207077e29342fdc2c9a82e4b306f1127bf1ea91f8b71e02d4798a70bb99991", size = 242561, upload-time = "2026-01-26T02:43:04.733Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/f4/8719f4f167586af317b69dd3e90f913416c91ca610cac79a45c53f590312/multidict-6.7.1-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d4f49cb5661344764e4c7c7973e92a47a59b8fc19b6523649ec9dc4960e58a03", size = 242223, upload-time = "2026-01-26T02:43:06.695Z" },
+    { url = "https://files.pythonhosted.org/packages/47/ab/7c36164cce64a6ad19c6d9a85377b7178ecf3b89f8fd589c73381a5eedfd/multidict-6.7.1-cp310-cp310-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:a9fc4caa29e2e6ae408d1c450ac8bf19892c5fca83ee634ecd88a53332c59981", size = 222322, upload-time = "2026-01-26T02:43:08.472Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/79/a25add6fb38035b5337bc5734f296d9afc99163403bbcf56d4170f97eb62/multidict-6.7.1-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c5f0c21549ab432b57dcc82130f388d84ad8179824cc3f223d5e7cfbfd4143f6", size = 254005, upload-time = "2026-01-26T02:43:10.127Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/7b/64a87cf98e12f756fc8bd444b001232ffff2be37288f018ad0d3f0aae931/multidict-6.7.1-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:7dfb78d966b2c906ae1d28ccf6e6712a3cd04407ee5088cd276fe8cb42186190", size = 251173, upload-time = "2026-01-26T02:43:11.731Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/ac/b605473de2bb404e742f2cc3583d12aedb2352a70e49ae8fce455b50c5aa/multidict-6.7.1-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9b0d9b91d1aa44db9c1f1ecd0d9d2ae610b2f4f856448664e01a3b35899f3f92", size = 243273, upload-time = "2026-01-26T02:43:13.063Z" },
+    { url = "https://files.pythonhosted.org/packages/03/65/11492d6a0e259783720f3bc1d9ea55579a76f1407e31ed44045c99542004/multidict-6.7.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:dd96c01a9dcd4889dcfcf9eb5544ca0c77603f239e3ffab0524ec17aea9a93ee", size = 238956, upload-time = "2026-01-26T02:43:14.843Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/a7/7ee591302af64e7c196fb63fe856c788993c1372df765102bd0448e7e165/multidict-6.7.1-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:067343c68cd6612d375710f895337b3a98a033c94f14b9a99eff902f205424e2", size = 233477, upload-time = "2026-01-26T02:43:16.025Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/99/c109962d58756c35fd9992fed7f2355303846ea2ff054bb5f5e9d6b888de/multidict-6.7.1-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:5884a04f4ff56c6120f6ccf703bdeb8b5079d808ba604d4d53aec0d55dc33568", size = 243615, upload-time = "2026-01-26T02:43:17.84Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/5f/1973e7c771c86e93dcfe1c9cc55a5481b610f6614acfc28c0d326fe6bfad/multidict-6.7.1-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:8affcf1c98b82bc901702eb73b6947a1bfa170823c153fe8a47b5f5f02e48e40", size = 249930, upload-time = "2026-01-26T02:43:19.06Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/a5/f170fc2268c3243853580203378cd522446b2df632061e0a5409817854c7/multidict-6.7.1-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:0d17522c37d03e85c8098ec8431636309b2682cf12e58f4dbc76121fb50e4962", size = 243807, upload-time = "2026-01-26T02:43:20.286Z" },
+    { url = "https://files.pythonhosted.org/packages/de/01/73856fab6d125e5bc652c3986b90e8699a95e84b48d72f39ade6c0e74a8c/multidict-6.7.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:24c0cf81544ca5e17cfcb6e482e7a82cd475925242b308b890c9452a074d4505", size = 239103, upload-time = "2026-01-26T02:43:21.508Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/46/f1220bd9944d8aa40d8ccff100eeeee19b505b857b6f603d6078cb5315b0/multidict-6.7.1-cp310-cp310-win32.whl", hash = "sha256:d82dd730a95e6643802f4454b8fdecdf08667881a9c5670db85bc5a56693f122", size = 41416, upload-time = "2026-01-26T02:43:22.703Z" },
+    { url = "https://files.pythonhosted.org/packages/68/00/9b38e272a770303692fc406c36e1a4c740f401522d5787691eb38a8925a8/multidict-6.7.1-cp310-cp310-win_amd64.whl", hash = "sha256:cf37cbe5ced48d417ba045aca1b21bafca67489452debcde94778a576666a1df", size = 46022, upload-time = "2026-01-26T02:43:23.77Z" },
+    { url = "https://files.pythonhosted.org/packages/64/65/d8d42490c02ee07b6bbe00f7190d70bb4738b3cce7629aaf9f213ef730dd/multidict-6.7.1-cp310-cp310-win_arm64.whl", hash = "sha256:59bc83d3f66b41dac1e7460aac1d196edc70c9ba3094965c467715a70ecb46db", size = 43238, upload-time = "2026-01-26T02:43:24.882Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/f1/a90635c4f88fb913fbf4ce660b83b7445b7a02615bda034b2f8eb38fd597/multidict-6.7.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:7ff981b266af91d7b4b3793ca3382e53229088d193a85dfad6f5f4c27fc73e5d", size = 76626, upload-time = "2026-01-26T02:43:26.485Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/9b/267e64eaf6fc637a15b35f5de31a566634a2740f97d8d094a69d34f524a4/multidict-6.7.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:844c5bca0b5444adb44a623fb0a1310c2f4cd41f402126bb269cd44c9b3f3e1e", size = 44706, upload-time = "2026-01-26T02:43:27.607Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/a4/d45caf2b97b035c57267791ecfaafbd59c68212004b3842830954bb4b02e/multidict-6.7.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:f2a0a924d4c2e9afcd7ec64f9de35fcd96915149b2216e1cb2c10a56df483855", size = 44356, upload-time = "2026-01-26T02:43:28.661Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/d2/0a36c8473f0cbaeadd5db6c8b72d15bbceeec275807772bfcd059bef487d/multidict-6.7.1-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:8be1802715a8e892c784c0197c2ace276ea52702a0ede98b6310c8f255a5afb3", size = 244355, upload-time = "2026-01-26T02:43:31.165Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/16/8c65be997fd7dd311b7d39c7b6e71a0cb449bad093761481eccbbe4b42a2/multidict-6.7.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2e2d2ed645ea29f31c4c7ea1552fcfd7cb7ba656e1eafd4134a6620c9f5fdd9e", size = 246433, upload-time = "2026-01-26T02:43:32.581Z" },
+    { url = "https://files.pythonhosted.org/packages/01/fb/4dbd7e848d2799c6a026ec88ad39cf2b8416aa167fcc903baa55ecaa045c/multidict-6.7.1-cp311-cp311-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:95922cee9a778659e91db6497596435777bd25ed116701a4c034f8e46544955a", size = 225376, upload-time = "2026-01-26T02:43:34.417Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/8a/4a3a6341eac3830f6053062f8fbc9a9e54407c80755b3f05bc427295c2d0/multidict-6.7.1-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:6b83cabdc375ffaaa15edd97eb7c0c672ad788e2687004990074d7d6c9b140c8", size = 257365, upload-time = "2026-01-26T02:43:35.741Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/a2/dd575a69c1aa206e12d27d0770cdf9b92434b48a9ef0cd0d1afdecaa93c4/multidict-6.7.1-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:38fb49540705369bab8484db0689d86c0a33a0a9f2c1b197f506b71b4b6c19b0", size = 254747, upload-time = "2026-01-26T02:43:36.976Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/56/21b27c560c13822ed93133f08aa6372c53a8e067f11fbed37b4adcdac922/multidict-6.7.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:439cbebd499f92e9aa6793016a8acaa161dfa749ae86d20960189f5398a19144", size = 246293, upload-time = "2026-01-26T02:43:38.258Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/a4/23466059dc3854763423d0ad6c0f3683a379d97673b1b89ec33826e46728/multidict-6.7.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:6d3bc717b6fe763b8be3f2bee2701d3c8eb1b2a8ae9f60910f1b2860c82b6c49", size = 242962, upload-time = "2026-01-26T02:43:40.034Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/67/51dd754a3524d685958001e8fa20a0f5f90a6a856e0a9dcabff69be3dbb7/multidict-6.7.1-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:619e5a1ac57986dbfec9f0b301d865dddf763696435e2962f6d9cf2fdff2bb71", size = 237360, upload-time = "2026-01-26T02:43:41.752Z" },
+    { url = "https://files.pythonhosted.org/packages/64/3f/036dfc8c174934d4b55d86ff4f978e558b0e585cef70cfc1ad01adc6bf18/multidict-6.7.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:0b38ebffd9be37c1170d33bc0f36f4f262e0a09bc1aac1c34c7aa51a7293f0b3", size = 245940, upload-time = "2026-01-26T02:43:43.042Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/20/6214d3c105928ebc353a1c644a6ef1408bc5794fcb4f170bb524a3c16311/multidict-6.7.1-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:10ae39c9cfe6adedcdb764f5e8411d4a92b055e35573a2eaa88d3323289ef93c", size = 253502, upload-time = "2026-01-26T02:43:44.371Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/e2/c653bc4ae1be70a0f836b82172d643fcf1dade042ba2676ab08ec08bff0f/multidict-6.7.1-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:25167cc263257660290fba06b9318d2026e3c910be240a146e1f66dd114af2b0", size = 247065, upload-time = "2026-01-26T02:43:45.745Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/11/a854b4154cd3bd8b1fd375e8a8ca9d73be37610c361543d56f764109509b/multidict-6.7.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:128441d052254f42989ef98b7b6a6ecb1e6f708aa962c7984235316db59f50fa", size = 241870, upload-time = "2026-01-26T02:43:47.054Z" },
+    { url = "https://files.pythonhosted.org/packages/13/bf/9676c0392309b5fdae322333d22a829715b570edb9baa8016a517b55b558/multidict-6.7.1-cp311-cp311-win32.whl", hash = "sha256:d62b7f64ffde3b99d06b707a280db04fb3855b55f5a06df387236051d0668f4a", size = 41302, upload-time = "2026-01-26T02:43:48.753Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/68/f16a3a8ba6f7b6dc92a1f19669c0810bd2c43fc5a02da13b1cbf8e253845/multidict-6.7.1-cp311-cp311-win_amd64.whl", hash = "sha256:bdbf9f3b332abd0cdb306e7c2113818ab1e922dc84b8f8fd06ec89ed2a19ab8b", size = 45981, upload-time = "2026-01-26T02:43:49.921Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/ad/9dd5305253fa00cd3c7555dbef69d5bf4133debc53b87ab8d6a44d411665/multidict-6.7.1-cp311-cp311-win_arm64.whl", hash = "sha256:b8c990b037d2fff2f4e33d3f21b9b531c5745b33a49a7d6dbe7a177266af44f6", size = 43159, upload-time = "2026-01-26T02:43:51.635Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/9c/f20e0e2cf80e4b2e4b1c365bf5fe104ee633c751a724246262db8f1a0b13/multidict-6.7.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:a90f75c956e32891a4eda3639ce6dd86e87105271f43d43442a3aedf3cddf172", size = 76893, upload-time = "2026-01-26T02:43:52.754Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/cf/18ef143a81610136d3da8193da9d80bfe1cb548a1e2d1c775f26b23d024a/multidict-6.7.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:3fccb473e87eaa1382689053e4a4618e7ba7b9b9b8d6adf2027ee474597128cd", size = 45456, upload-time = "2026-01-26T02:43:53.893Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/65/1caac9d4cd32e8433908683446eebc953e82d22b03d10d41a5f0fefe991b/multidict-6.7.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:b0fa96985700739c4c7853a43c0b3e169360d6855780021bfc6d0f1ce7c123e7", size = 43872, upload-time = "2026-01-26T02:43:55.041Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/3b/d6bd75dc4f3ff7c73766e04e705b00ed6dbbaccf670d9e05a12b006f5a21/multidict-6.7.1-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:cb2a55f408c3043e42b40cc8eecd575afa27b7e0b956dfb190de0f8499a57a53", size = 251018, upload-time = "2026-01-26T02:43:56.198Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/80/c959c5933adedb9ac15152e4067c702a808ea183a8b64cf8f31af8ad3155/multidict-6.7.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:eb0ce7b2a32d09892b3dd6cc44877a0d02a33241fafca5f25c8b6b62374f8b75", size = 258883, upload-time = "2026-01-26T02:43:57.499Z" },
+    { url = "https://files.pythonhosted.org/packages/86/85/7ed40adafea3d4f1c8b916e3b5cc3a8e07dfcdcb9cd72800f4ed3ca1b387/multidict-6.7.1-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:c3a32d23520ee37bf327d1e1a656fec76a2edd5c038bf43eddfa0572ec49c60b", size = 242413, upload-time = "2026-01-26T02:43:58.755Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/57/b8565ff533e48595503c785f8361ff9a4fde4d67de25c207cd0ba3befd03/multidict-6.7.1-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:9c90fed18bffc0189ba814749fdcc102b536e83a9f738a9003e569acd540a733", size = 268404, upload-time = "2026-01-26T02:44:00.216Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/50/9810c5c29350f7258180dfdcb2e52783a0632862eb334c4896ac717cebcb/multidict-6.7.1-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:da62917e6076f512daccfbbde27f46fed1c98fee202f0559adec8ee0de67f71a", size = 269456, upload-time = "2026-01-26T02:44:02.202Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/8d/5e5be3ced1d12966fefb5c4ea3b2a5b480afcea36406559442c6e31d4a48/multidict-6.7.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bfde23ef6ed9db7eaee6c37dcec08524cb43903c60b285b172b6c094711b3961", size = 256322, upload-time = "2026-01-26T02:44:03.56Z" },
+    { url = "https://files.pythonhosted.org/packages/31/6e/d8a26d81ac166a5592782d208dd90dfdc0a7a218adaa52b45a672b46c122/multidict-6.7.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3758692429e4e32f1ba0df23219cd0b4fc0a52f476726fff9337d1a57676a582", size = 253955, upload-time = "2026-01-26T02:44:04.845Z" },
+    { url = "https://files.pythonhosted.org/packages/59/4c/7c672c8aad41534ba619bcd4ade7a0dc87ed6b8b5c06149b85d3dd03f0cd/multidict-6.7.1-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:398c1478926eca669f2fd6a5856b6de9c0acf23a2cb59a14c0ba5844fa38077e", size = 251254, upload-time = "2026-01-26T02:44:06.133Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/bd/84c24de512cbafbdbc39439f74e967f19570ce7924e3007174a29c348916/multidict-6.7.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:c102791b1c4f3ab36ce4101154549105a53dc828f016356b3e3bcae2e3a039d3", size = 252059, upload-time = "2026-01-26T02:44:07.518Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/ba/f5449385510825b73d01c2d4087bf6d2fccc20a2d42ac34df93191d3dd03/multidict-6.7.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:a088b62bd733e2ad12c50dad01b7d0166c30287c166e137433d3b410add807a6", size = 263588, upload-time = "2026-01-26T02:44:09.382Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/11/afc7c677f68f75c84a69fe37184f0f82fce13ce4b92f49f3db280b7e92b3/multidict-6.7.1-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:3d51ff4785d58d3f6c91bdbffcb5e1f7ddfda557727043aa20d20ec4f65e324a", size = 259642, upload-time = "2026-01-26T02:44:10.73Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/17/ebb9644da78c4ab36403739e0e6e0e30ebb135b9caf3440825001a0bddcb/multidict-6.7.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fc5907494fccf3e7d3f94f95c91d6336b092b5fc83811720fae5e2765890dfba", size = 251377, upload-time = "2026-01-26T02:44:12.042Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/a4/840f5b97339e27846c46307f2530a2805d9d537d8b8bd416af031cad7fa0/multidict-6.7.1-cp312-cp312-win32.whl", hash = "sha256:28ca5ce2fd9716631133d0e9a9b9a745ad7f60bac2bccafb56aa380fc0b6c511", size = 41887, upload-time = "2026-01-26T02:44:14.245Z" },
+    { url = "https://files.pythonhosted.org/packages/80/31/0b2517913687895f5904325c2069d6a3b78f66cc641a86a2baf75a05dcbb/multidict-6.7.1-cp312-cp312-win_amd64.whl", hash = "sha256:fcee94dfbd638784645b066074b338bc9cc155d4b4bffa4adce1615c5a426c19", size = 46053, upload-time = "2026-01-26T02:44:15.371Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/5b/aba28e4ee4006ae4c7df8d327d31025d760ffa992ea23812a601d226e682/multidict-6.7.1-cp312-cp312-win_arm64.whl", hash = "sha256:ba0a9fb644d0c1a2194cf7ffb043bd852cea63a57f66fbd33959f7dae18517bf", size = 43307, upload-time = "2026-01-26T02:44:16.852Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/22/929c141d6c0dba87d3e1d38fbdf1ba8baba86b7776469f2bc2d3227a1e67/multidict-6.7.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:2b41f5fed0ed563624f1c17630cb9941cf2309d4df00e494b551b5f3e3d67a23", size = 76174, upload-time = "2026-01-26T02:44:18.509Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/75/bc704ae15fee974f8fccd871305e254754167dce5f9e42d88a2def741a1d/multidict-6.7.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:84e61e3af5463c19b67ced91f6c634effb89ef8bfc5ca0267f954451ed4bb6a2", size = 45116, upload-time = "2026-01-26T02:44:19.745Z" },
+    { url = "https://files.pythonhosted.org/packages/79/76/55cd7186f498ed080a18440c9013011eb548f77ae1b297206d030eb1180a/multidict-6.7.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:935434b9853c7c112eee7ac891bc4cb86455aa631269ae35442cb316790c1445", size = 43524, upload-time = "2026-01-26T02:44:21.571Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/3c/414842ef8d5a1628d68edee29ba0e5bcf235dbfb3ccd3ea303a7fe8c72ff/multidict-6.7.1-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:432feb25a1cb67fe82a9680b4d65fb542e4635cb3166cd9c01560651ad60f177", size = 249368, upload-time = "2026-01-26T02:44:22.803Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/32/befed7f74c458b4a525e60519fe8d87eef72bb1e99924fa2b0f9d97a221e/multidict-6.7.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e82d14e3c948952a1a85503817e038cba5905a3352de76b9a465075d072fba23", size = 256952, upload-time = "2026-01-26T02:44:24.306Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d6/c878a44ba877f366630c860fdf74bfb203c33778f12b6ac274936853c451/multidict-6.7.1-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:4cfb48c6ea66c83bcaaf7e4dfa7ec1b6bbcf751b7db85a328902796dfde4c060", size = 240317, upload-time = "2026-01-26T02:44:25.772Z" },
+    { url = "https://files.pythonhosted.org/packages/68/49/57421b4d7ad2e9e60e25922b08ceb37e077b90444bde6ead629095327a6f/multidict-6.7.1-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1d540e51b7e8e170174555edecddbd5538105443754539193e3e1061864d444d", size = 267132, upload-time = "2026-01-26T02:44:27.648Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/fe/ec0edd52ddbcea2a2e89e174f0206444a61440b40f39704e64dc807a70bd/multidict-6.7.1-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:273d23f4b40f3dce4d6c8a821c741a86dec62cded82e1175ba3d99be128147ed", size = 268140, upload-time = "2026-01-26T02:44:29.588Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/73/6e1b01cbeb458807aa0831742232dbdd1fa92bfa33f52a3f176b4ff3dc11/multidict-6.7.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9d624335fd4fa1c08a53f8b4be7676ebde19cd092b3895c421045ca87895b429", size = 254277, upload-time = "2026-01-26T02:44:30.902Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/b2/5fb8c124d7561a4974c342bc8c778b471ebbeb3cc17df696f034a7e9afe7/multidict-6.7.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:12fad252f8b267cc75b66e8fc51b3079604e8d43a75428ffe193cd9e2195dfd6", size = 252291, upload-time = "2026-01-26T02:44:32.31Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/96/51d4e4e06bcce92577fcd488e22600bd38e4fd59c20cb49434d054903bd2/multidict-6.7.1-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:03ede2a6ffbe8ef936b92cb4529f27f42be7f56afcdab5ab739cd5f27fb1cbf9", size = 250156, upload-time = "2026-01-26T02:44:33.734Z" },
+    { url = "https://files.pythonhosted.org/packages/db/6b/420e173eec5fba721a50e2a9f89eda89d9c98fded1124f8d5c675f7a0c0f/multidict-6.7.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:90efbcf47dbe33dcf643a1e400d67d59abeac5db07dc3f27d6bdeae497a2198c", size = 249742, upload-time = "2026-01-26T02:44:35.222Z" },
+    { url = "https://files.pythonhosted.org/packages/44/a3/ec5b5bd98f306bc2aa297b8c6f11a46714a56b1e6ef5ebda50a4f5d7c5fb/multidict-6.7.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:5c4b9bfc148f5a91be9244d6264c53035c8a0dcd2f51f1c3c6e30e30ebaa1c84", size = 262221, upload-time = "2026-01-26T02:44:36.604Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/f7/e8c0d0da0cd1e28d10e624604e1a36bcc3353aaebdfdc3a43c72bc683a12/multidict-6.7.1-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:401c5a650f3add2472d1d288c26deebc540f99e2fb83e9525007a74cd2116f1d", size = 258664, upload-time = "2026-01-26T02:44:38.008Z" },
+    { url = "https://files.pythonhosted.org/packages/52/da/151a44e8016dd33feed44f730bd856a66257c1ee7aed4f44b649fb7edeb3/multidict-6.7.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:97891f3b1b3ffbded884e2916cacf3c6fc87b66bb0dde46f7357404750559f33", size = 249490, upload-time = "2026-01-26T02:44:39.386Z" },
+    { url = "https://files.pythonhosted.org/packages/87/af/a3b86bf9630b732897f6fc3f4c4714b90aa4361983ccbdcd6c0339b21b0c/multidict-6.7.1-cp313-cp313-win32.whl", hash = "sha256:e1c5988359516095535c4301af38d8a8838534158f649c05dd1050222321bcb3", size = 41695, upload-time = "2026-01-26T02:44:41.318Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/35/e994121b0e90e46134673422dd564623f93304614f5d11886b1b3e06f503/multidict-6.7.1-cp313-cp313-win_amd64.whl", hash = "sha256:960c83bf01a95b12b08fd54324a4eb1d5b52c88932b5cba5d6e712bb3ed12eb5", size = 45884, upload-time = "2026-01-26T02:44:42.488Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/61/42d3e5dbf661242a69c97ea363f2d7b46c567da8eadef8890022be6e2ab0/multidict-6.7.1-cp313-cp313-win_arm64.whl", hash = "sha256:563fe25c678aaba333d5399408f5ec3c383ca5b663e7f774dd179a520b8144df", size = 43122, upload-time = "2026-01-26T02:44:43.664Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/b3/e6b21c6c4f314bb956016b0b3ef2162590a529b84cb831c257519e7fde44/multidict-6.7.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:c76c4bec1538375dad9d452d246ca5368ad6e1c9039dadcf007ae59c70619ea1", size = 83175, upload-time = "2026-01-26T02:44:44.894Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/76/23ecd2abfe0957b234f6c960f4ade497f55f2c16aeb684d4ecdbf1c95791/multidict-6.7.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:57b46b24b5d5ebcc978da4ec23a819a9402b4228b8a90d9c656422b4bdd8a963", size = 48460, upload-time = "2026-01-26T02:44:46.106Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/57/a0ed92b23f3a042c36bc4227b72b97eca803f5f1801c1ab77c8a212d455e/multidict-6.7.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e954b24433c768ce78ab7929e84ccf3422e46deb45a4dc9f93438f8217fa2d34", size = 46930, upload-time = "2026-01-26T02:44:47.278Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/66/02ec7ace29162e447f6382c495dc95826bf931d3818799bbef11e8f7df1a/multidict-6.7.1-cp313-cp313t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:3bd231490fa7217cc832528e1cd8752a96f0125ddd2b5749390f7c3ec8721b65", size = 242582, upload-time = "2026-01-26T02:44:48.604Z" },
+    { url = "https://files.pythonhosted.org/packages/58/18/64f5a795e7677670e872673aca234162514696274597b3708b2c0d276cce/multidict-6.7.1-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:253282d70d67885a15c8a7716f3a73edf2d635793ceda8173b9ecc21f2fb8292", size = 250031, upload-time = "2026-01-26T02:44:50.544Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/ed/e192291dbbe51a8290c5686f482084d31bcd9d09af24f63358c3d42fd284/multidict-6.7.1-cp313-cp313t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:0b4c48648d7649c9335cf1927a8b87fa692de3dcb15faa676c6a6f1f1aabda43", size = 228596, upload-time = "2026-01-26T02:44:51.951Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/7e/3562a15a60cf747397e7f2180b0a11dc0c38d9175a650e75fa1b4d325e15/multidict-6.7.1-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:98bc624954ec4d2c7cb074b8eefc2b5d0ce7d482e410df446414355d158fe4ca", size = 257492, upload-time = "2026-01-26T02:44:53.902Z" },
+    { url = "https://files.pythonhosted.org/packages/24/02/7d0f9eae92b5249bb50ac1595b295f10e263dd0078ebb55115c31e0eaccd/multidict-6.7.1-cp313-cp313t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:1b99af4d9eec0b49927b4402bcbb58dea89d3e0db8806a4086117019939ad3dd", size = 255899, upload-time = "2026-01-26T02:44:55.316Z" },
+    { url = "https://files.pythonhosted.org/packages/00/e3/9b60ed9e23e64c73a5cde95269ef1330678e9c6e34dd4eb6b431b85b5a10/multidict-6.7.1-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6aac4f16b472d5b7dc6f66a0d49dd57b0e0902090be16594dc9ebfd3d17c47e7", size = 247970, upload-time = "2026-01-26T02:44:56.783Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/06/538e58a63ed5cfb0bd4517e346b91da32fde409d839720f664e9a4ae4f9d/multidict-6.7.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:21f830fe223215dffd51f538e78c172ed7c7f60c9b96a2bf05c4848ad49921c3", size = 245060, upload-time = "2026-01-26T02:44:58.195Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/2f/d743a3045a97c895d401e9bd29aaa09b94f5cbdf1bd561609e5a6c431c70/multidict-6.7.1-cp313-cp313t-musllinux_1_2_armv7l.whl", hash = "sha256:f5dd81c45b05518b9aa4da4aa74e1c93d715efa234fd3e8a179df611cc85e5f4", size = 235888, upload-time = "2026-01-26T02:44:59.57Z" },
+    { url = "https://files.pythonhosted.org/packages/38/83/5a325cac191ab28b63c52f14f1131f3b0a55ba3b9aa65a6d0bf2a9b921a0/multidict-6.7.1-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:eb304767bca2bb92fb9c5bd33cedc95baee5bb5f6c88e63706533a1c06ad08c8", size = 243554, upload-time = "2026-01-26T02:45:01.054Z" },
+    { url = "https://files.pythonhosted.org/packages/20/1f/9d2327086bd15da2725ef6aae624208e2ef828ed99892b17f60c344e57ed/multidict-6.7.1-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:c9035dde0f916702850ef66460bc4239d89d08df4d02023a5926e7446724212c", size = 252341, upload-time = "2026-01-26T02:45:02.484Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/2c/2a1aa0280cf579d0f6eed8ee5211c4f1730bd7e06c636ba2ee6aafda302e/multidict-6.7.1-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:af959b9beeb66c822380f222f0e0a1889331597e81f1ded7f374f3ecb0fd6c52", size = 246391, upload-time = "2026-01-26T02:45:03.862Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/03/7ca022ffc36c5a3f6e03b179a5ceb829be9da5783e6fe395f347c0794680/multidict-6.7.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:41f2952231456154ee479651491e94118229844dd7226541788be783be2b5108", size = 243422, upload-time = "2026-01-26T02:45:05.296Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/1d/b31650eab6c5778aceed46ba735bd97f7c7d2f54b319fa916c0f96e7805b/multidict-6.7.1-cp313-cp313t-win32.whl", hash = "sha256:df9f19c28adcb40b6aae30bbaa1478c389efd50c28d541d76760199fc1037c32", size = 47770, upload-time = "2026-01-26T02:45:06.754Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/5b/2d2d1d522e51285bd61b1e20df8f47ae1a9d80839db0b24ea783b3832832/multidict-6.7.1-cp313-cp313t-win_amd64.whl", hash = "sha256:d54ecf9f301853f2c5e802da559604b3e95bb7a3b01a9c295c6ee591b9882de8", size = 53109, upload-time = "2026-01-26T02:45:08.044Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/a3/cc409ba012c83ca024a308516703cf339bdc4b696195644a7215a5164a24/multidict-6.7.1-cp313-cp313t-win_arm64.whl", hash = "sha256:5a37ca18e360377cfda1d62f5f382ff41f2b8c4ccb329ed974cc2e1643440118", size = 45573, upload-time = "2026-01-26T02:45:09.349Z" },
+    { url = "https://files.pythonhosted.org/packages/91/cc/db74228a8be41884a567e88a62fd589a913708fcf180d029898c17a9a371/multidict-6.7.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:8f333ec9c5eb1b7105e3b84b53141e66ca05a19a605368c55450b6ba208cb9ee", size = 75190, upload-time = "2026-01-26T02:45:10.651Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/22/492f2246bb5b534abd44804292e81eeaf835388901f0c574bac4eeec73c5/multidict-6.7.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:a407f13c188f804c759fc6a9f88286a565c242a76b27626594c133b82883b5c2", size = 44486, upload-time = "2026-01-26T02:45:11.938Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/4f/733c48f270565d78b4544f2baddc2fb2a245e5a8640254b12c36ac7ac68e/multidict-6.7.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:0e161ddf326db5577c3a4cc2d8648f81456e8a20d40415541587a71620d7a7d1", size = 43219, upload-time = "2026-01-26T02:45:14.346Z" },
+    { url = "https://files.pythonhosted.org/packages/24/bb/2c0c2287963f4259c85e8bcbba9182ced8d7fca65c780c38e99e61629d11/multidict-6.7.1-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:1e3a8bb24342a8201d178c3b4984c26ba81a577c80d4d525727427460a50c22d", size = 245132, upload-time = "2026-01-26T02:45:15.712Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/f9/44d4b3064c65079d2467888794dea218d1601898ac50222ab8a9a8094460/multidict-6.7.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:97231140a50f5d447d3164f994b86a0bed7cd016e2682f8650d6a9158e14fd31", size = 252420, upload-time = "2026-01-26T02:45:17.293Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/13/78f7275e73fa17b24c9a51b0bd9d73ba64bb32d0ed51b02a746eb876abe7/multidict-6.7.1-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:6b10359683bd8806a200fd2909e7c8ca3a7b24ec1d8132e483d58e791d881048", size = 233510, upload-time = "2026-01-26T02:45:19.356Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/25/8167187f62ae3cbd52da7893f58cb036b47ea3fb67138787c76800158982/multidict-6.7.1-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:283ddac99f7ac25a4acadbf004cb5ae34480bbeb063520f70ce397b281859362", size = 264094, upload-time = "2026-01-26T02:45:20.834Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/e7/69a3a83b7b030cf283fb06ce074a05a02322359783424d7edf0f15fe5022/multidict-6.7.1-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:538cec1e18c067d0e6103aa9a74f9e832904c957adc260e61cd9d8cf0c3b3d37", size = 260786, upload-time = "2026-01-26T02:45:22.818Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/3b/8ec5074bcfc450fe84273713b4b0a0dd47c0249358f5d82eb8104ffe2520/multidict-6.7.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7eee46ccb30ff48a1e35bb818cc90846c6be2b68240e42a78599166722cea709", size = 248483, upload-time = "2026-01-26T02:45:24.368Z" },
+    { url = "https://files.pythonhosted.org/packages/48/5a/d5a99e3acbca0e29c5d9cba8f92ceb15dce78bab963b308ae692981e3a5d/multidict-6.7.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:fa263a02f4f2dd2d11a7b1bb4362aa7cb1049f84a9235d31adf63f30143469a0", size = 248403, upload-time = "2026-01-26T02:45:25.982Z" },
+    { url = "https://files.pythonhosted.org/packages/35/48/e58cd31f6c7d5102f2a4bf89f96b9cf7e00b6c6f3d04ecc44417c00a5a3c/multidict-6.7.1-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:2e1425e2f99ec5bd36c15a01b690a1a2456209c5deed58f95469ffb46039ccbb", size = 240315, upload-time = "2026-01-26T02:45:27.487Z" },
+    { url = "https://files.pythonhosted.org/packages/94/33/1cd210229559cb90b6786c30676bb0c58249ff42f942765f88793b41fdce/multidict-6.7.1-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:497394b3239fc6f0e13a78a3e1b61296e72bf1c5f94b4c4eb80b265c37a131cd", size = 245528, upload-time = "2026-01-26T02:45:28.991Z" },
+    { url = "https://files.pythonhosted.org/packages/64/f2/6e1107d226278c876c783056b7db43d800bb64c6131cec9c8dfb6903698e/multidict-6.7.1-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:233b398c29d3f1b9676b4b6f75c518a06fcb2ea0b925119fb2c1bc35c05e1601", size = 258784, upload-time = "2026-01-26T02:45:30.503Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/c1/11f664f14d525e4a1b5327a82d4de61a1db604ab34c6603bb3c2cc63ad34/multidict-6.7.1-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:93b1818e4a6e0930454f0f2af7dfce69307ca03cdcfb3739bf4d91241967b6c1", size = 251980, upload-time = "2026-01-26T02:45:32.603Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/9f/75a9ac888121d0c5bbd4ecf4eead45668b1766f6baabfb3b7f66a410e231/multidict-6.7.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:f33dc2a3abe9249ea5d8360f969ec7f4142e7ac45ee7014d8f8d5acddf178b7b", size = 243602, upload-time = "2026-01-26T02:45:34.043Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/e7/50bf7b004cc8525d80dbbbedfdc7aed3e4c323810890be4413e589074032/multidict-6.7.1-cp314-cp314-win32.whl", hash = "sha256:3ab8b9d8b75aef9df299595d5388b14530839f6422333357af1339443cff777d", size = 40930, upload-time = "2026-01-26T02:45:36.278Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/bf/52f25716bbe93745595800f36fb17b73711f14da59ed0bb2eba141bc9f0f/multidict-6.7.1-cp314-cp314-win_amd64.whl", hash = "sha256:5e01429a929600e7dab7b166062d9bb54a5eed752384c7384c968c2afab8f50f", size = 45074, upload-time = "2026-01-26T02:45:37.546Z" },
+    { url = "https://files.pythonhosted.org/packages/97/ab/22803b03285fa3a525f48217963da3a65ae40f6a1b6f6cf2768879e208f9/multidict-6.7.1-cp314-cp314-win_arm64.whl", hash = "sha256:4885cb0e817aef5d00a2e8451d4665c1808378dc27c2705f1bf4ef8505c0d2e5", size = 42471, upload-time = "2026-01-26T02:45:38.889Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/6d/f9293baa6146ba9507e360ea0292b6422b016907c393e2f63fc40ab7b7b5/multidict-6.7.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:0458c978acd8e6ea53c81eefaddbbee9c6c5e591f41b3f5e8e194780fe026581", size = 82401, upload-time = "2026-01-26T02:45:40.254Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/68/53b5494738d83558d87c3c71a486504d8373421c3e0dbb6d0db48ad42ee0/multidict-6.7.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:c0abd12629b0af3cf590982c0b413b1e7395cd4ec026f30986818ab95bfaa94a", size = 48143, upload-time = "2026-01-26T02:45:41.635Z" },
+    { url = "https://files.pythonhosted.org/packages/37/e8/5284c53310dcdc99ce5d66563f6e5773531a9b9fe9ec7a615e9bc306b05f/multidict-6.7.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:14525a5f61d7d0c94b368a42cff4c9a4e7ba2d52e2672a7b23d84dc86fb02b0c", size = 46507, upload-time = "2026-01-26T02:45:42.99Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/fc/6800d0e5b3875568b4083ecf5f310dcf91d86d52573160834fb4bfcf5e4f/multidict-6.7.1-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:17307b22c217b4cf05033dabefe68255a534d637c6c9b0cc8382718f87be4262", size = 239358, upload-time = "2026-01-26T02:45:44.376Z" },
+    { url = "https://files.pythonhosted.org/packages/41/75/4ad0973179361cdf3a113905e6e088173198349131be2b390f9fa4da5fc6/multidict-6.7.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7a7e590ff876a3eaf1c02a4dfe0724b6e69a9e9de6d8f556816f29c496046e59", size = 246884, upload-time = "2026-01-26T02:45:47.167Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/9c/095bb28b5da139bd41fb9a5d5caff412584f377914bd8787c2aa98717130/multidict-6.7.1-cp314-cp314t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:5fa6a95dfee63893d80a34758cd0e0c118a30b8dcb46372bf75106c591b77889", size = 225878, upload-time = "2026-01-26T02:45:48.698Z" },
+    { url = "https://files.pythonhosted.org/packages/07/d0/c0a72000243756e8f5a277b6b514fa005f2c73d481b7d9e47cd4568aa2e4/multidict-6.7.1-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a0543217a6a017692aa6ae5cc39adb75e587af0f3a82288b1492eb73dd6cc2a4", size = 253542, upload-time = "2026-01-26T02:45:50.164Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/6b/f69da15289e384ecf2a68837ec8b5ad8c33e973aa18b266f50fe55f24b8c/multidict-6.7.1-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:f99fe611c312b3c1c0ace793f92464d8cd263cc3b26b5721950d977b006b6c4d", size = 252403, upload-time = "2026-01-26T02:45:51.779Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/76/b9669547afa5a1a25cd93eaca91c0da1c095b06b6d2d8ec25b713588d3a1/multidict-6.7.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9004d8386d133b7e6135679424c91b0b854d2d164af6ea3f289f8f2761064609", size = 244889, upload-time = "2026-01-26T02:45:53.27Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/a9/a50d2669e506dad33cfc45b5d574a205587b7b8a5f426f2fbb2e90882588/multidict-6.7.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e628ef0e6859ffd8273c69412a2465c4be4a9517d07261b33334b5ec6f3c7489", size = 241982, upload-time = "2026-01-26T02:45:54.919Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/bb/1609558ad8b456b4827d3c5a5b775c93b87878fd3117ed3db3423dfbce1b/multidict-6.7.1-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:841189848ba629c3552035a6a7f5bf3b02eb304e9fea7492ca220a8eda6b0e5c", size = 232415, upload-time = "2026-01-26T02:45:56.981Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/59/6f61039d2aa9261871e03ab9dc058a550d240f25859b05b67fd70f80d4b3/multidict-6.7.1-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:ce1bbd7d780bb5a0da032e095c951f7014d6b0a205f8318308140f1a6aba159e", size = 240337, upload-time = "2026-01-26T02:45:58.698Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/29/fdc6a43c203890dc2ae9249971ecd0c41deaedfe00d25cb6564b2edd99eb/multidict-6.7.1-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:b26684587228afed0d50cf804cc71062cc9c1cdf55051c4c6345d372947b268c", size = 248788, upload-time = "2026-01-26T02:46:00.862Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/14/a153a06101323e4cf086ecee3faadba52ff71633d471f9685c42e3736163/multidict-6.7.1-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:9f9af11306994335398293f9958071019e3ab95e9a707dc1383a35613f6abcb9", size = 242842, upload-time = "2026-01-26T02:46:02.824Z" },
+    { url = "https://files.pythonhosted.org/packages/41/5f/604ae839e64a4a6efc80db94465348d3b328ee955e37acb24badbcd24d83/multidict-6.7.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:b4938326284c4f1224178a560987b6cf8b4d38458b113d9b8c1db1a836e640a2", size = 240237, upload-time = "2026-01-26T02:46:05.898Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/60/c3a5187bf66f6fb546ff4ab8fb5a077cbdd832d7b1908d4365c7f74a1917/multidict-6.7.1-cp314-cp314t-win32.whl", hash = "sha256:98655c737850c064a65e006a3df7c997cd3b220be4ec8fe26215760b9697d4d7", size = 48008, upload-time = "2026-01-26T02:46:07.468Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/f7/addf1087b860ac60e6f382240f64fb99f8bfb532bb06f7c542b83c29ca61/multidict-6.7.1-cp314-cp314t-win_amd64.whl", hash = "sha256:497bde6223c212ba11d462853cfa4f0ae6ef97465033e7dc9940cdb3ab5b48e5", size = 53542, upload-time = "2026-01-26T02:46:08.809Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/81/4629d0aa32302ef7b2ec65c75a728cc5ff4fa410c50096174c1632e70b3e/multidict-6.7.1-cp314-cp314t-win_arm64.whl", hash = "sha256:2bbd113e0d4af5db41d5ebfe9ccaff89de2120578164f86a5d17d5a576d1e5b2", size = 44719, upload-time = "2026-01-26T02:46:11.146Z" },
+    { url = "https://files.pythonhosted.org/packages/81/08/7036c080d7117f28a4af526d794aab6a84463126db031b007717c1a6676e/multidict-6.7.1-py3-none-any.whl", hash = "sha256:55d97cc6dae627efa6a6e548885712d4864b81110ac76fa4e534c03819fa4a56", size = 12319, upload-time = "2026-01-26T02:46:44.004Z" },
+]
+
+[[package]]
 name = "mypy"
 version = "2.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ast-serialize" },
-    { name = "librt", marker = "platform_python_implementation != 'PyPy'" },
-    { name = "mypy-extensions" },
-    { name = "pathspec" },
-    { name = "tomli", marker = "python_full_version < '3.11'" },
-    { name = "typing-extensions" },
+    { name = "ast-serialize", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "librt", marker = "(platform_python_implementation != 'PyPy' and sys_platform == 'darwin') or (platform_python_implementation != 'PyPy' and sys_platform == 'linux') or (platform_python_implementation != 'PyPy' and sys_platform == 'win32')" },
+    { name = "mypy-extensions", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "pathspec", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "tomli", marker = "(python_full_version < '3.11' and sys_platform == 'darwin') or (python_full_version < '3.11' and sys_platform == 'linux') or (python_full_version < '3.11' and sys_platform == 'win32')" },
+    { name = "typing-extensions", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e9/7e/be536678c6ae49ef058aba4b483d8c7bc104f471479016066f345bc1f5f8/mypy-2.2.0.tar.gz", hash = "sha256:2cdd99d48590dce6f6b7f1961eda75386364398fcdaad86923bc0f0231bf9baf", size = 3950939, upload-time = "2026-07-08T01:37:27.335Z" }
 wheels = [
@@ -1401,7 +1963,7 @@ name = "opentelemetry-api"
 version = "1.43.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ae/cc/e4c9584181f86494df0f6bdec1a4f3280c50db44704dc2a407e994fc87bb/opentelemetry_api-1.43.0.tar.gz", hash = "sha256:107d0d03857ea8fc7c5fcbbbd83f800c281f0d560553d61c1d675fccfd1761c1", size = 73476, upload-time = "2026-06-24T15:19:55.323Z" }
 wheels = [
@@ -1413,10 +1975,10 @@ name = "opentelemetry-instrumentation"
 version = "0.64b0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "opentelemetry-api" },
-    { name = "opentelemetry-semantic-conventions" },
-    { name = "packaging" },
-    { name = "wrapt" },
+    { name = "opentelemetry-api", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "opentelemetry-semantic-conventions", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "packaging", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "wrapt", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7e/97/02fe6e1c8b1ffac42d0b429c18080edb24e0e0d18c86612edf72b5752382/opentelemetry_instrumentation-0.64b0.tar.gz", hash = "sha256:b47d528dead6271d7743114417eb67fc915bd9258111c48dbf9a4951d2efa88d", size = 41935, upload-time = "2026-06-24T15:19:12.951Z" }
 wheels = [
@@ -1428,11 +1990,11 @@ name = "opentelemetry-instrumentation-asgi"
 version = "0.64b0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "asgiref" },
-    { name = "opentelemetry-api" },
-    { name = "opentelemetry-instrumentation" },
-    { name = "opentelemetry-semantic-conventions" },
-    { name = "opentelemetry-util-http" },
+    { name = "asgiref", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "opentelemetry-api", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "opentelemetry-instrumentation", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "opentelemetry-semantic-conventions", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "opentelemetry-util-http", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/85/0c/71c696fccb86d37af383ea1604af4729fabad0af2fabaf203e4c79c1e859/opentelemetry_instrumentation_asgi-0.64b0.tar.gz", hash = "sha256:4dd3eee566a4303f8e6b9b84f2a0a7abc57a6640df768926c68a3868bf5b2090", size = 26136, upload-time = "2026-06-24T15:19:17.003Z" }
 wheels = [
@@ -1444,10 +2006,10 @@ name = "opentelemetry-instrumentation-dbapi"
 version = "0.64b0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "opentelemetry-api" },
-    { name = "opentelemetry-instrumentation" },
-    { name = "opentelemetry-semantic-conventions" },
-    { name = "wrapt" },
+    { name = "opentelemetry-api", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "opentelemetry-instrumentation", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "opentelemetry-semantic-conventions", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "wrapt", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b9/9f/3c6ce6f4394faa1540f48b7d442f455582ca76449952506ce767a54f09bf/opentelemetry_instrumentation_dbapi-0.64b0.tar.gz", hash = "sha256:8e3a1528fc9753a04190a7e7bf0180c5abd059f3aa68ec3857edb363c9847c44", size = 20138, upload-time = "2026-06-24T15:19:24.097Z" }
 wheels = [
@@ -1459,11 +2021,11 @@ name = "opentelemetry-instrumentation-django"
 version = "0.64b0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "opentelemetry-api" },
-    { name = "opentelemetry-instrumentation" },
-    { name = "opentelemetry-instrumentation-wsgi" },
-    { name = "opentelemetry-semantic-conventions" },
-    { name = "opentelemetry-util-http" },
+    { name = "opentelemetry-api", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "opentelemetry-instrumentation", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "opentelemetry-instrumentation-wsgi", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "opentelemetry-semantic-conventions", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "opentelemetry-util-http", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ce/2e/8f6084eab186533b0574683a8c39e51803e6c34c21fc33e194f58352d704/opentelemetry_instrumentation_django-0.64b0.tar.gz", hash = "sha256:3d2673b4f77156b15b1b119c8849b50e3644cfc325f7a24c03602596de2dbba4", size = 25387, upload-time = "2026-06-24T15:19:24.795Z" }
 wheels = [
@@ -1475,11 +2037,11 @@ name = "opentelemetry-instrumentation-fastapi"
 version = "0.64b0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "opentelemetry-api" },
-    { name = "opentelemetry-instrumentation" },
-    { name = "opentelemetry-instrumentation-asgi" },
-    { name = "opentelemetry-semantic-conventions" },
-    { name = "opentelemetry-util-http" },
+    { name = "opentelemetry-api", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "opentelemetry-instrumentation", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "opentelemetry-instrumentation-asgi", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "opentelemetry-semantic-conventions", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "opentelemetry-util-http", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/db/a1/52282e2cc5c08f4df13b087896d9907258fe2ff4f34035d3b21aa92684c3/opentelemetry_instrumentation_fastapi-0.64b0.tar.gz", hash = "sha256:05f75149929e433c1630de381688e650bf651c1e1cce7f9a7b649a807dac8a98", size = 26236, upload-time = "2026-06-24T15:19:27.219Z" }
 wheels = [
@@ -1491,12 +2053,12 @@ name = "opentelemetry-instrumentation-flask"
 version = "0.64b0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "opentelemetry-api" },
-    { name = "opentelemetry-instrumentation" },
-    { name = "opentelemetry-instrumentation-wsgi" },
-    { name = "opentelemetry-semantic-conventions" },
-    { name = "opentelemetry-util-http" },
-    { name = "packaging" },
+    { name = "opentelemetry-api", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "opentelemetry-instrumentation", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "opentelemetry-instrumentation-wsgi", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "opentelemetry-semantic-conventions", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "opentelemetry-util-http", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "packaging", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/4a/6d/cf9a9cf18603e3aaebba96633ec3c1ced463706f545d8672419b715c1e59/opentelemetry_instrumentation_flask-0.64b0.tar.gz", hash = "sha256:74d07edba426beae1214bd0aec69bd31a9d0d22c29747b497d5d94c516d1c860", size = 24150, upload-time = "2026-06-24T15:19:27.847Z" }
 wheels = [
@@ -1508,9 +2070,9 @@ name = "opentelemetry-instrumentation-logging"
 version = "0.64b0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "opentelemetry-api" },
-    { name = "opentelemetry-instrumentation" },
-    { name = "opentelemetry-semantic-conventions" },
+    { name = "opentelemetry-api", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "opentelemetry-instrumentation", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "opentelemetry-semantic-conventions", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/88/8e/3b7191ba5817f139867612e960fbe06a69fe0d522d3b2c5e9c8e89b3ef8c/opentelemetry_instrumentation_logging-0.64b0.tar.gz", hash = "sha256:6435b4d215bf8183e15f7e3416a10ebe1c411810d3411fbfc62667daae3abacb", size = 20000, upload-time = "2026-06-24T15:19:30.946Z" }
 wheels = [
@@ -1522,9 +2084,9 @@ name = "opentelemetry-instrumentation-psycopg2"
 version = "0.64b0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "opentelemetry-api" },
-    { name = "opentelemetry-instrumentation" },
-    { name = "opentelemetry-instrumentation-dbapi" },
+    { name = "opentelemetry-api", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "opentelemetry-instrumentation", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "opentelemetry-instrumentation-dbapi", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/79/2d/0062ecf86b6bd407398820ae34d8acf7259f2b32531fa22e1c3b7748c6d0/opentelemetry_instrumentation_psycopg2-0.64b0.tar.gz", hash = "sha256:57df449718297b93e7bb57c76d3439c475eb5a5451600fcd6a9024d74822d972", size = 12065, upload-time = "2026-06-24T15:19:33.994Z" }
 wheels = [
@@ -1536,10 +2098,10 @@ name = "opentelemetry-instrumentation-requests"
 version = "0.64b0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "opentelemetry-api" },
-    { name = "opentelemetry-instrumentation" },
-    { name = "opentelemetry-semantic-conventions" },
-    { name = "opentelemetry-util-http" },
+    { name = "opentelemetry-api", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "opentelemetry-instrumentation", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "opentelemetry-semantic-conventions", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "opentelemetry-util-http", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a1/97/d5fb7b3f329c24ff2f6478f1a0c0c516ba942d3df2acbb197d276af31816/opentelemetry_instrumentation_requests-0.64b0.tar.gz", hash = "sha256:8213a20b6578c41aa05cc5b48419aea75e1584924a4904dfcf36524597e7cc96", size = 18106, upload-time = "2026-06-24T15:19:39.522Z" }
 wheels = [
@@ -1551,10 +2113,10 @@ name = "opentelemetry-instrumentation-urllib"
 version = "0.64b0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "opentelemetry-api" },
-    { name = "opentelemetry-instrumentation" },
-    { name = "opentelemetry-semantic-conventions" },
-    { name = "opentelemetry-util-http" },
+    { name = "opentelemetry-api", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "opentelemetry-instrumentation", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "opentelemetry-semantic-conventions", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "opentelemetry-util-http", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/87/20/547126ab1706e65629c2079cdbb956ef06ccc58a7cbad520c3505886e4cc/opentelemetry_instrumentation_urllib-0.64b0.tar.gz", hash = "sha256:954ab9908f08dc9127ca3d259f88a37b52f54c03f6fa4c384fd9fcfe9c85cd76", size = 16668, upload-time = "2026-06-24T15:19:45.096Z" }
 wheels = [
@@ -1566,11 +2128,11 @@ name = "opentelemetry-instrumentation-urllib3"
 version = "0.64b0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "opentelemetry-api" },
-    { name = "opentelemetry-instrumentation" },
-    { name = "opentelemetry-semantic-conventions" },
-    { name = "opentelemetry-util-http" },
-    { name = "wrapt" },
+    { name = "opentelemetry-api", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "opentelemetry-instrumentation", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "opentelemetry-semantic-conventions", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "opentelemetry-util-http", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "wrapt", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/30/e2/9e6f747018f639b9ffed97f715f1eb16c95dd87ba572c880ce451a65a18f/opentelemetry_instrumentation_urllib3-0.64b0.tar.gz", hash = "sha256:647c6d1b012e14168323b18d4e60fca9a5d280764821b99ea0a5639450fbd74e", size = 18945, upload-time = "2026-06-24T15:19:45.738Z" }
 wheels = [
@@ -1582,10 +2144,10 @@ name = "opentelemetry-instrumentation-wsgi"
 version = "0.64b0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "opentelemetry-api" },
-    { name = "opentelemetry-instrumentation" },
-    { name = "opentelemetry-semantic-conventions" },
-    { name = "opentelemetry-util-http" },
+    { name = "opentelemetry-api", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "opentelemetry-instrumentation", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "opentelemetry-semantic-conventions", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "opentelemetry-util-http", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/95/4f/0b5232a0d635eee5da7c85af503d2f00fdcac61cc6d4d4a69aadf1fa7a0e/opentelemetry_instrumentation_wsgi-0.64b0.tar.gz", hash = "sha256:1cce6ea28d1800c154e6ccdf52f05bae2f05c5e28ee44f0dddb17ada26208986", size = 19667, upload-time = "2026-06-24T15:19:46.407Z" }
 wheels = [
@@ -1597,7 +2159,7 @@ name = "opentelemetry-resource-detector-azure"
 version = "0.1.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "opentelemetry-sdk" },
+    { name = "opentelemetry-sdk", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/67/e4/0d359d48d03d447225b30c3dd889d5d454e3b413763ff721f9b0e4ac2e59/opentelemetry_resource_detector_azure-0.1.5.tar.gz", hash = "sha256:e0ba658a87c69eebc806e75398cd0e9f68a8898ea62de99bc1b7083136403710", size = 11503, upload-time = "2024-05-16T21:54:58.994Z" }
 wheels = [
@@ -1609,9 +2171,9 @@ name = "opentelemetry-sdk"
 version = "1.43.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "opentelemetry-api" },
-    { name = "opentelemetry-semantic-conventions" },
-    { name = "typing-extensions" },
+    { name = "opentelemetry-api", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "opentelemetry-semantic-conventions", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "typing-extensions", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3e/eb/5041074274ac0956b03637cc039d434569112468e875eddfcc9a0674ce06/opentelemetry_sdk-1.43.0.tar.gz", hash = "sha256:d8187c81c162df9913e4003dd6485f7390d9a24fc17026ec7387b8b8218b08e9", size = 254744, upload-time = "2026-06-24T15:20:08.467Z" }
 wheels = [
@@ -1623,8 +2185,8 @@ name = "opentelemetry-semantic-conventions"
 version = "0.64b0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "opentelemetry-api" },
-    { name = "typing-extensions" },
+    { name = "opentelemetry-api", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "typing-extensions", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5a/30/5f26df29509eccd86b99b481ac9ffa39da49ba9577cc69071c552ae30447/opentelemetry_semantic_conventions-0.64b0.tar.gz", hash = "sha256:72f76fb2d1582d9d033dd1fcd84532e961e6ff3d90d24ba6fabc72975a83864c", size = 148340, upload-time = "2026-06-24T15:20:09.267Z" }
 wheels = [
@@ -1638,6 +2200,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c3/1b/1029a805fd7242f7dfce91633b244c3b14a94d703232878f71e01ce862b1/opentelemetry_util_http-0.64b0.tar.gz", hash = "sha256:8a86a220dbfc56d736f47f1e5c4e7932a21fcf69052312e1bcf166444dc79322", size = 11102, upload-time = "2026-06-24T15:19:48.974Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1c/c7/5f8ec5b30546f2dc22cd5fc5759bce2ab5be6e89a2e710a405ac9ef64ed3/opentelemetry_util_http-0.64b0-py3-none-any.whl", hash = "sha256:c1e5350d25507c1afcd6076cf9ac062485a0a4f79cd9971366996fd3056bacdb", size = 8204, upload-time = "2026-06-24T15:19:09.02Z" },
+]
+
+[[package]]
+name = "orderedmultidict"
+version = "1.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5c/62/61ad51f6c19d495970230a7747147ce7ed3c3a63c2af4ebfdb1f6d738703/orderedmultidict-1.0.2.tar.gz", hash = "sha256:16a7ae8432e02cc987d2d6d5af2df5938258f87c870675c73ee77a0920e6f4a6", size = 13973, upload-time = "2025-11-18T08:00:42.649Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b2/6c/d8a02ffb24876b5f51fbd781f479fc6525a518553a4196bd0433dae9ff8e/orderedmultidict-1.0.2-py2.py3-none-any.whl", hash = "sha256:ab5044c1dca4226ae4c28524cfc5cc4c939f0b49e978efa46a6ad6468049f79b", size = 11897, upload-time = "2025-11-18T08:00:41.44Z" },
 ]
 
 [[package]]
@@ -1690,9 +2264,9 @@ name = "poethepoet"
 version = "0.48.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pastel" },
-    { name = "pyyaml" },
-    { name = "tomli", marker = "python_full_version < '3.11'" },
+    { name = "pastel", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "pyyaml", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "tomli", marker = "(python_full_version < '3.11' and sys_platform == 'darwin') or (python_full_version < '3.11' and sys_platform == 'linux') or (python_full_version < '3.11' and sys_platform == 'win32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5c/92/93a4af9511b8c7c647874521d9e6c904266be98067c2ee1eb2e74520d208/poethepoet-0.48.0.tar.gz", hash = "sha256:a06f49d244fadfc2e2e7faa78b54e64a9694727e4ce1d50e08f23cea3ded74f1", size = 148679, upload-time = "2026-07-05T21:48:30.106Z" }
 wheels = [
@@ -1721,6 +2295,134 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/b2/2a/ce5cbfaad36866134a21754640a05ecdba641fcd7ad15aa74cf3443f34f6/prek-0.4.8-py3-none-win32.whl", hash = "sha256:2602e46c8c5da7dfa69f60fcf88c2b57132ac623f49fb08bfb3094298c5f07e3", size = 5354388, upload-time = "2026-07-04T12:05:05.587Z" },
     { url = "https://files.pythonhosted.org/packages/df/03/3bc908bc5f7e430315553e47dfa055f19923a3888f9afe4da19f244b5cbf/prek-0.4.8-py3-none-win_amd64.whl", hash = "sha256:7cb22da60bee41b89c4978c0bea7126a3c0ccc003dae6748cf29b53947815edc", size = 5748221, upload-time = "2026-07-04T12:05:07.559Z" },
     { url = "https://files.pythonhosted.org/packages/dd/a7/4295e6d5f5028171dfeb115ad38ab76bf3fe0c8df91b70d73c79aa760a94/prek-0.4.8-py3-none-win_arm64.whl", hash = "sha256:da70057f577b15d4bd121bf9dd29ee205fd4b4d75a0cafba062e84d7e8b4378b", size = 5574425, upload-time = "2026-07-04T12:05:09.595Z" },
+]
+
+[[package]]
+name = "propcache"
+version = "0.5.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ec/44/c87281c333769159c50594f22610f77398a47ccbfbbf23074e744e86f87c/propcache-0.5.2.tar.gz", hash = "sha256:01c4fc7480cd0598bb4b57022df55b9ca296da7fc5a8760bd8451a7e63a7d427", size = 50208, upload-time = "2026-05-08T21:02:12.199Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5b/56/030b7b4719d53085722893e0009dffb9236aa10bca1b12121bdc5626ef16/propcache-0.5.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:d5a81be28596d6559f6131ef33e10200de6e17643b3c74ce03f9eb103be6ae8b", size = 93417, upload-time = "2026-05-08T20:59:15.597Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/55/1140a8e067b8ec093a18a4ae7bb0045d9db65da38a08618ddc5e2f1994aa/propcache-0.5.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:29cbaac5ea0212663e6845e04b5e188d5a6ae6dd919810ac835bf1d3b42c3f4c", size = 53847, upload-time = "2026-05-08T20:59:17.096Z" },
+    { url = "https://files.pythonhosted.org/packages/20/42/0e7443c90310498561addf346e7d57fe3c6ba1914e1ba938b5464c7bbfd2/propcache-0.5.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:6bf3be92233808fcd338eba0fb4d0b59ec5772af4f4ecfcec450d1bfc0f8b5eb", size = 53512, upload-time = "2026-05-08T20:59:18.64Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/db/cf51a71bab2009517d1a7f0ee07657e3bd446c4d69f67e6966cf17bcf956/propcache-0.5.2-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2f8ea531c794b9d6274acd4e8d2c2ebcac590a4361d27482edd3010b79f1325e", size = 58068, upload-time = "2026-05-08T20:59:20.683Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/43/39b6bdee9699fa1e1641c519feeb64a67e2a9f93bb465c70776b37a7333f/propcache-0.5.2-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:decfca4c79dd53ebab484b00cc4b6717d8c369f86e74aa4ca395a64ac651495e", size = 61020, upload-time = "2026-05-08T20:59:22.112Z" },
+    { url = "https://files.pythonhosted.org/packages/26/0b/843726fbb0a29a8c5684fdb25971823638399f31e52e9d1f06a02dc9aa6b/propcache-0.5.2-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:4621064bbf28fa77ff64dd5d94367c04684c67d3a5bf1dff25f0cd0d98a38f3b", size = 62732, upload-time = "2026-05-08T20:59:23.805Z" },
+    { url = "https://files.pythonhosted.org/packages/39/6e/899fed76dc1942b8a64193a4f059d7f1a2c7ef65085e8a9366ed8ec0d199/propcache-0.5.2-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b96db7141a592cbc968daf1feea83a118e6ab378af4abbc72b248c895414c22d", size = 60140, upload-time = "2026-05-08T20:59:25.389Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/09/3da4be9b5b879219ad234aa535b3dd4a080ed1ad48d3a73ca07a9e798f22/propcache-0.5.2-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:1ca071adabaab6e9219924bbe00af821f1ee7de113a9eca1cdc292de3d120f4d", size = 60400, upload-time = "2026-05-08T20:59:27.238Z" },
+    { url = "https://files.pythonhosted.org/packages/60/2f/09b72b874a9aa0044faf52a69807a6ed618e267ceaa9ec4a63195fa5b504/propcache-0.5.2-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:e4294d04a94dcab1b3bccd8b66d962dcad411a1d19414b2a41d1445f1de32ad0", size = 58155, upload-time = "2026-05-08T20:59:28.48Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/37/97489848c54c95578045473954f10956d619ce6a09e7ac137b71cdcb698b/propcache-0.5.2-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:a0e399a2eccb91ed18721f86aa85757727400b6865c89e88934781deb9c8498b", size = 57037, upload-time = "2026-05-08T20:59:30.146Z" },
+    { url = "https://files.pythonhosted.org/packages/22/db/6c695285ccfc49012743ee9c98212b8c5dd0aed7b63cfd816d4a0f7a1601/propcache-0.5.2-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:823581fd5cb08b12a48bfa11fe962a7916766b6170c17b028fbdf762b85eb9bf", size = 61103, upload-time = "2026-05-08T20:59:31.626Z" },
+    { url = "https://files.pythonhosted.org/packages/98/a9/1e500401ca593b0bdb6bf75a70bc2d723835fd53360edff6af70692c7546/propcache-0.5.2-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:949c91d1a990cf3b2e8188dfcfb25005e0b834a06c63fa4ef9f360878ce21ecf", size = 60394, upload-time = "2026-05-08T20:59:32.829Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/87/f638b6e375eae0f30a1a2325d8b34fd85fdc785bb9960cf805f3bf1ec69a/propcache-0.5.2-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:cc1177027eda740fdb152706bd215a3f124e3eea15afc39f2cb9fe351b50619e", size = 63084, upload-time = "2026-05-08T20:59:35.964Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/18/884573f5d97b6d9eba68de759a82c901b7e39d7904d30f7b8d58d42d2a12/propcache-0.5.2-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:b05d643f944a8c3c4bd86d65ffd87bf3264b617f87791940302bc474d2ff5274", size = 60999, upload-time = "2026-05-08T20:59:38.481Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/1a/c3915eb059ceec9e758a56e4cfd955292bc0f201be2176a46b76d94b303a/propcache-0.5.2-cp310-cp310-win32.whl", hash = "sha256:8114f28879e0904748e831c3a7774261bd9e75f49be089f389a76f959dcd13fe", size = 39036, upload-time = "2026-05-08T20:59:40.323Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/02/1dfd5607501a602d19c1c449d2d193b7d1c611f9246b4059026a1189a80e/propcache-0.5.2-cp310-cp310-win_amd64.whl", hash = "sha256:5fcb98e7598b1ee0addab320d90f65b530297a867dbfe9de52ea838077e16e3d", size = 42190, upload-time = "2026-05-08T20:59:42.232Z" },
+    { url = "https://files.pythonhosted.org/packages/57/93/f71588ad08b3e6f4b555b5ef215808a3c02b042d0151ad82fa6f15be677a/propcache-0.5.2-cp310-cp310-win_arm64.whl", hash = "sha256:04dc2390d9edbbaef7461f33322555976ffddf0b650a038649d026358714e6c5", size = 38545, upload-time = "2026-05-08T20:59:44.087Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/f1/8a8cc1c2c7e7934ab77e0163414f736fadbc0f5e8dd9673b952355ac175b/propcache-0.5.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:74b70780220e2dd89175ca24b81b68b67c83db499ae611e7f2313cb329801c78", size = 90744, upload-time = "2026-05-08T20:59:45.799Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/f4/651b1225e976bd1a2ba5cfba0c29d096581c2636b437e3a9a7ab6276270a/propcache-0.5.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:a4840ab0ae0216d952f4b53dc6d0b992bfc2bedbfe360bdd9b548bc184c08959", size = 52033, upload-time = "2026-05-08T20:59:47.408Z" },
+    { url = "https://files.pythonhosted.org/packages/15/a8/8ede85d6aa1f79fc7dc2f8fd2c8d65920b8272c3892903c8a1affde48cfb/propcache-0.5.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:c6844ba6364fb12f403928a82cfd295ab103a2b315c77c747b2dbe4a41894ea7", size = 52754, upload-time = "2026-05-08T20:59:49.202Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/fe/b3551b41bbc2f5b5bb088fc6920567cd43101253e68fbaa261339eb96fe1/propcache-0.5.2-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2293949b855ce597f2826452d17c2d545fb5622379c4ea6fdf525e9b8e8a2511", size = 57573, upload-time = "2026-05-08T20:59:50.778Z" },
+    { url = "https://files.pythonhosted.org/packages/83/27/ab851ebd1b7172e3e161f5f8d39e315d54a91bea246f01f4d872d3376aef/propcache-0.5.2-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:0fd59b5af35f74da48d905dcbad55449ba13be91823cb05a9bd590bbf5b61660", size = 60645, upload-time = "2026-05-08T20:59:52.227Z" },
+    { url = "https://files.pythonhosted.org/packages/95/7d/466b3d18022e9897cbda9c735c493c5bd747d7a4c6f5ea1480b4cec434b6/propcache-0.5.2-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:29f9309a2e42b0d273be006fdb4be2d6c39a47f6f57d8fb1cf9f81481df81b66", size = 61563, upload-time = "2026-05-08T20:59:53.866Z" },
+    { url = "https://files.pythonhosted.org/packages/27/1b/16ab7f2cf2041da2f60d156ba64c2484eadf9168075b4ff43c3ef60045af/propcache-0.5.2-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5aaa2b923c1944ac8febd6609cb373540a5563e7cbcb0fd770f75dace2eb817b", size = 58888, upload-time = "2026-05-08T20:59:55.457Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/67/bb777ffd907633563bf35fd859c4ce97b0512c32f4633cf5d1eb7c33512b/propcache-0.5.2-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:66ea454f095ddf5b6b14f56c064c0941c4788be11e18d2464cf643bf7203ff67", size = 59253, upload-time = "2026-05-08T20:59:57.075Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/42/64f8d90b73fd9cdc1499b48057ff6d9cd2a98a25734c9bb62ecf07e87061/propcache-0.5.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:95f1e3f4760d404b13c9976c0229b2b49a3c8e2c62a9ce92efdd2b11ada75e3f", size = 57558, upload-time = "2026-05-08T20:59:58.602Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/02/dba5bc03c9041f2092ea55a449caf5dfe68352c6654511b29ba0654ddb69/propcache-0.5.2-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:85341b12b9d55bad0bded24cac341bb34289469e03a11f3f583ea1cc1db0326c", size = 55007, upload-time = "2026-05-08T20:59:59.837Z" },
+    { url = "https://files.pythonhosted.org/packages/14/c0/43f649c7aa2a77a3b100d84e9dea3a483120ecb608bfe36ce49eaff517fe/propcache-0.5.2-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:26a4dca084132874e639895c3135dfad5eb20bae209f62d1aeb31b03e601c3c0", size = 60355, upload-time = "2026-05-08T21:00:01.144Z" },
+    { url = "https://files.pythonhosted.org/packages/83/c0/435dafd27f1cb4a495381dae60e25883ccfe4020bb72818e8184c1678092/propcache-0.5.2-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:3b199b9b2b3d6a7edf3183ba8a9a137a22b97f7df525feb5ae1eccf026d2a9c6", size = 59057, upload-time = "2026-05-08T21:00:02.401Z" },
+    { url = "https://files.pythonhosted.org/packages/53/ae/6e292df9135d659944e96cb3389258e4a663e5b2b5f6c217ef0ddc8d2f73/propcache-0.5.2-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:e59bc9e66329185b93dab73f210f1a37f81cb40f321501db8017c9aea15dba27", size = 61938, upload-time = "2026-05-08T21:00:03.638Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/42/314ebc50d8159055411fd6b0bda322ff510e4b1f7d2e4927940ad0f6af20/propcache-0.5.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:552ffadf6ad409844bc5919c42a0a83d88314cedddaea0e41e80a8b8fffe881f", size = 59731, upload-time = "2026-05-08T21:00:04.881Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/9b/2da6dee38871c3c8772fabc2758325a5c9077d6d18c597737dc04dd884cd/propcache-0.5.2-cp311-cp311-win32.whl", hash = "sha256:cd416c1de191973c52ff1a12a57446bfc7642797b282d7caf2162d7d1b8aa9a0", size = 38966, upload-time = "2026-05-08T21:00:06.511Z" },
+    { url = "https://files.pythonhosted.org/packages/42/4e/f17363fb58c0afe05b067361cb6d86ed2d29de6506779a27547c4d183075/propcache-0.5.2-cp311-cp311-win_amd64.whl", hash = "sha256:44e488ef40dbb452700b2b1f8188934121f6648f52c295055662d2191959ff82", size = 42135, upload-time = "2026-05-08T21:00:08.088Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/eb/6af6685077d22e8b33358d3c548e3282706a0b3cd85044ffba4e5dd08e3b/propcache-0.5.2-cp311-cp311-win_arm64.whl", hash = "sha256:54adaa85a22078d1e306304a40984dc5be99d599bf3dc0a24dc98f7daeab89ab", size = 38381, upload-time = "2026-05-08T21:00:09.692Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/cb/e27bc2b2737a0bb49962b275efa051e8f1c35a936df7d5139b6b658b7dc9/propcache-0.5.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:806719138ecd720339a12410fb9614ac9b2b2d3a5fdf8235d56981c36f4039ba", size = 95887, upload-time = "2026-05-08T21:00:11.277Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/13/b8ae04c59392f8d11c6cd9fb4011d1dc7c86b81225c770280300e259ffe1/propcache-0.5.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:db2b80ea58eab4f86b2beec3cc8b39e8ff9276ac20e96b7cce43c8ae84cd6b5a", size = 54654, upload-time = "2026-05-08T21:00:12.604Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/7d/49777a3e20b55863d4794384a38acd460c04157b0a00f8602b0d508b8431/propcache-0.5.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:e5cbfac9f61484f7e9f3597775500cd3ebe8274e9b050c38f9525c77c97520bf", size = 55190, upload-time = "2026-05-08T21:00:13.935Z" },
+    { url = "https://files.pythonhosted.org/packages/44/c7/085d0cd63062e84044e3f05797749c3f8e3938ff3aeb0eb2f69d43fafc91/propcache-0.5.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5dbc581d2814337da56222fab8dc5f161cd798a434e49bac27930aaef798e144", size = 59995, upload-time = "2026-05-08T21:00:15.526Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/42/32cf8e3009e92b2645cf1e944f701e8ea4e924dffde1ee26db860bcbf7e4/propcache-0.5.2-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:857187f381f88c8e2fa2fe56ab94879d011b883d5a2ee5a1b60a8cd2a06846d9", size = 63422, upload-time = "2026-05-08T21:00:16.824Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/1b/f112433f99fc979431b87a39ef169e3f8df070d99a72792c56d6937ac48b/propcache-0.5.2-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:178b4a2cdaac1818e2bf1c5a99b94383fa73ea5382e032a48dec07dc5668dc42", size = 64342, upload-time = "2026-05-08T21:00:18.362Z" },
+    { url = "https://files.pythonhosted.org/packages/14/15/5574111ae50dd6e879456888c0eadd4c5a869959775854e18e18a6b345f3/propcache-0.5.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6f328175a2cde1f0ff2c4ed8ce968b9dcfb55f3a7153f39e2957ed994da13476", size = 61639, upload-time = "2026-05-08T21:00:19.692Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/da/4d775080b1490c0ae604acda868bd71aabe3a89ed16f2aa4339eb8a283e7/propcache-0.5.2-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:5671d09a36b06d0fd4a3da0fccbcae360e9b1570924171a15e9e0997f0249fba", size = 61588, upload-time = "2026-05-08T21:00:21.155Z" },
+    { url = "https://files.pythonhosted.org/packages/04/ac/f076982cbe2195ee9cf32de5a1e46951d9fb399fc207f390562dd0fd8fb2/propcache-0.5.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:80168e2ebe4d3ec6599d10ad8f520304ae1cad9b6c5a95372aef1b66b7bfb53a", size = 60029, upload-time = "2026-05-08T21:00:22.713Z" },
+    { url = "https://files.pythonhosted.org/packages/70/60/189be62e0dd898dce3b331e1b8c7a543cd3a405ac0c81fe8ee8a9d5d77e1/propcache-0.5.2-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:45f11346f884bc47444f6e6647131055844134c3175b629f84952e2b5cd62b64", size = 56774, upload-time = "2026-05-08T21:00:24.001Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/9e/93377b9c7939c1ffae98f878dee955efadfd638078bc86dbc21f9d52f651/propcache-0.5.2-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:8e778ebd44ef4f66ed60a0416b06b489687db264a9c0b3620362f26489492913", size = 63532, upload-time = "2026-05-08T21:00:25.545Z" },
+    { url = "https://files.pythonhosted.org/packages/14/f9/590ef6cfb9b8028d516d287812ece32bb0bc5f11fbb9c8bf6b2e6313fec8/propcache-0.5.2-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:c0cb9ed24c8964e172768d455a38254c2dd8a552905729ce006cad3d3dda59b1", size = 61592, upload-time = "2026-05-08T21:00:27.186Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/5e/70958b3034c297a630bba2f17ca7abc2d5f39a803ad7e370ab79d1ecd022/propcache-0.5.2-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:1d1ad32d9d4355e2be65574fd0bfd3677e7066b009cd5b9b2dee8aa6a6393b33", size = 64788, upload-time = "2026-05-08T21:00:28.8Z" },
+    { url = "https://files.pythonhosted.org/packages/12/fd/77fe5936d8c3086ca9048f7f415f122ed82e53884a9ec193646b42deef06/propcache-0.5.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:c80f4ba3e8f00189165999a742ee526ebeccedf6c3f7beb0c7df821e9772435a", size = 62514, upload-time = "2026-05-08T21:00:30.098Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/74/66bd798b5b3be70aa1b391f5cc9d6a0a5532d7fd3b19ec0b213e72e6ad9d/propcache-0.5.2-cp312-cp312-win32.whl", hash = "sha256:8c7972d8f193740d9175f0998ab38717e6cd322d5935c5b0fef8c0d323fd9031", size = 39018, upload-time = "2026-05-08T21:00:31.622Z" },
+    { url = "https://files.pythonhosted.org/packages/61/7c/5c0d34aa3024694d6dcb9271cdbdd08c4e47c1c0ad95ec7e7bc74cdea145/propcache-0.5.2-cp312-cp312-win_amd64.whl", hash = "sha256:d9ee8826a7d47863a08ac44e1a5f611a462eefc3a194b492da242128bec75b42", size = 42322, upload-time = "2026-05-08T21:00:32.918Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/91/875812f1a3feb20ceba818ef39fbe4d92f1081e04ac815c822496d0d038b/propcache-0.5.2-cp312-cp312-win_arm64.whl", hash = "sha256:2800a4a8ead6b28cccd1ec54b59346f0def7922ee1c7598e8499c733cfbb7c84", size = 38172, upload-time = "2026-05-08T21:00:35.124Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/09/f049e45385503fe67db75a6b6186a7b9f0c3930366dc960522c312a825b1/propcache-0.5.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:099aaf4b4d1a02265b92a977edf00b5c4f63b3b17ac6de39b0d637c9cac0188a", size = 94457, upload-time = "2026-05-08T21:00:36.355Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/65/83d1d05655baf63113731bd5a1008435e14f8d1e5a06cbe4ec5b23ad7a31/propcache-0.5.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:68ce1c44c7a813a7f71ea04315a8c7b330b63db99d059a797a4651bb6f69f117", size = 53835, upload-time = "2026-05-08T21:00:38.072Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/12/a6ba6482bb5ea3260c000c9b20881c95fa11c6b30173715668259f844ed7/propcache-0.5.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:fc299c129490f55f254cd90be0deca4764e36e9a7c08b4aa588479a3bbed3098", size = 54545, upload-time = "2026-05-08T21:00:39.319Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/19/7fa086f5764c59ec8a8e157cd93aa8497acc00aba9dcdec56bfffb32602d/propcache-0.5.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a6ae2198be502c10f09b2516e7b5d019816924bc3183a43ce792a7bd6625e6f4", size = 59886, upload-time = "2026-05-08T21:00:40.621Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/e4/5d7663dc8235956c8f5281698a3af1d351d8820341ddd890f59d9a9127f2/propcache-0.5.2-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:6041d31504dc1779d700e1edcfb08eea334b357620b06681a4eabb57a74e574e", size = 63261, upload-time = "2026-05-08T21:00:41.775Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/4a/15a03adee24d6350da4292caeac44c34c033d2afe5e87eb370f38854560f/propcache-0.5.2-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:f7eabc04151c78a9f4d5bbb5f1faf571e4defeb4b585e0fe95b60ff2dbe4d3d7", size = 64184, upload-time = "2026-05-08T21:00:43.018Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/c6/979176efdaa3d239e36d503d5af63a0a773b36662ed8f52e5b6a6d9fd40e/propcache-0.5.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4db0ba63d693afd40d249bd93f842b5f144f8fcbb83de05660373bcf30517b1d", size = 61534, upload-time = "2026-05-08T21:00:44.507Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/22/63e8cd1bae4c2d2be6493b6b7d10566ddafad88137cfbc99964a1119853c/propcache-0.5.2-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:1dbcf7675229b35d31abb6547d8ebc8c27a830ac3f9a794edff6254873ec7c0a", size = 61500, upload-time = "2026-05-08T21:00:45.796Z" },
+    { url = "https://files.pythonhosted.org/packages/60/5a/28e5d9acbac1cc9ccb67045e8c1b943aa8d79fdf39c93bd73cacd68008ea/propcache-0.5.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d310c013aad2c72f1c3f2f8dd3279d460a858c551f97aeb8c63e4693cca7b4d2", size = 59994, upload-time = "2026-05-08T21:00:47.093Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/40/db650677f554a95b9c01a7c9d93d629e93a15562f5deb4573c9ee136fed2/propcache-0.5.2-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:06187263ddad280d05b4d8a8b3bb7d164cbebd469236544a42e6d9b28ac6a4fa", size = 56884, upload-time = "2026-05-08T21:00:48.376Z" },
+    { url = "https://files.pythonhosted.org/packages/80/45/70b39b89516ff8b96bf732fa6fded8cef20f293cb1508690101c3c07ec51/propcache-0.5.2-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:3115559b8effafd63b142ea5ed53d63a16ea6469cbc63dce4ee194b42db5d853", size = 63464, upload-time = "2026-05-08T21:00:49.954Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/e2/fa59d3a89eac5534293124af4f1d0d0ada091ce4a0ab4610ce03fd2bdd8d/propcache-0.5.2-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:c60462af8e6dc30c35407c7237ea908d777b22862bbee27bc4699c0d8bcdc45a", size = 61588, upload-time = "2026-05-08T21:00:51.281Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/97/efb547a55c4bc7381cfb202d6a2239ac621045277bc1ea5dfd3a7f0516c0/propcache-0.5.2-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:40314bca9ac559716fe374094fc81c11dcc34b64fd6c585360f5775690505704", size = 64667, upload-time = "2026-05-08T21:00:52.602Z" },
+    { url = "https://files.pythonhosted.org/packages/92/56/f5c7d9b4b7595d5127da38974d791b2153f3d1eae6c674af3583ace92ad3/propcache-0.5.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:cfa21e036ce1e1db2be04ba3b85d2df1bb1702fa01932d984c5464c665228ff4", size = 62463, upload-time = "2026-05-08T21:00:54.303Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/3b/484a3a65fc9f9f60c41dcd17b428bace5389544e2c680994534a20755066/propcache-0.5.2-cp313-cp313-win32.whl", hash = "sha256:f156a3529f38063b6dbaf356e15602a7f95f8055b1295a438433a6386f10463d", size = 38621, upload-time = "2026-05-08T21:00:55.808Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/fd/3f0f10dba4dabad3bf53102be007abf55481067952bde0fdddff439e7c61/propcache-0.5.2-cp313-cp313-win_amd64.whl", hash = "sha256:dfed59d0a5aeb01e242e66ff0300bc4a265a7c05f612d30016f0b60b1017d757", size = 41649, upload-time = "2026-05-08T21:00:57.061Z" },
+    { url = "https://files.pythonhosted.org/packages/90/ec/6ce619cc32bb500a482f811f9cd509368b4e58e638d13f2c68f370d6b475/propcache-0.5.2-cp313-cp313-win_arm64.whl", hash = "sha256:ba338430e87ceb9c8f0cf754de38a9860560261e56c00376debd628698a7364f", size = 37636, upload-time = "2026-05-08T21:00:58.646Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/82/c1d268bbbf2ef981c5bf0fbbe746db617c66e3bcefe431a1aa8943fbe23a/propcache-0.5.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:a592f5f3da71c8691c788c13cb6734b6d17663d2e1cb8caddf0673d01ef8847d", size = 98872, upload-time = "2026-05-08T21:00:59.889Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/d4/52c871e73e864e6b34c0e2d58ac1ec5ccd149497ddc7ad2137ae98323a35/propcache-0.5.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:6a997d0489e9668a384fcfd5061b857aa5361de73191cac204d04b889cfbbafa", size = 56257, upload-time = "2026-05-08T21:01:01.195Z" },
+    { url = "https://files.pythonhosted.org/packages/67/f0/9b90ca2a210b3d09bcfcd96ecd0f55545c091535abce2a45de2775cfd357/propcache-0.5.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:10734b5484ea113152ee25a91dccedf81631791805d2c9ccb054958e51842c94", size = 56696, upload-time = "2026-05-08T21:01:02.941Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/0e/6e9d4ba07c8e56e21ddec1e75f12148142b21ca83a51871babce095334f4/propcache-0.5.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cafca7e56c12bb02ae16d283742bef25a61122e9dab2b5b3f2ccbe589ce32164", size = 62378, upload-time = "2026-05-08T21:01:04.475Z" },
+    { url = "https://files.pythonhosted.org/packages/65/19/c10badaa463dde8a27ce884f8ee2ec37e6035b7c9f5ff0c8f74f06f08dac/propcache-0.5.2-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:f064f8d2b59177878b7615df1735cd8fe3462ed6be8c7b217d17a276489c2b7f", size = 65283, upload-time = "2026-05-08T21:01:05.959Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/b6/93bea99ca80e19cef6512a8580e5b7857bbe09422d9daa7fd4ef5723306c/propcache-0.5.2-cp313-cp313t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:f78abfa8dfc32376fd1aacf597b2f2fbbe0ea751419aee718af5d4f82537ef8c", size = 66616, upload-time = "2026-05-08T21:01:07.228Z" },
+    { url = "https://files.pythonhosted.org/packages/83/e4/5c7462e50625f051f37fb38b8224f7639f667184bbd34424ec83819bb1b7/propcache-0.5.2-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f7467da8a9822bf1a55336f877340c5bcbd3c482afc43a99771169f74a26dedc", size = 63773, upload-time = "2026-05-08T21:01:08.514Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/b6/99238894047b13c823be25027e736626cd414a52a5e30d2c3347c2733529/propcache-0.5.2-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a6ddc6ac9e25de626c1f129c1b467d7ecd33ce2237d3fd0c4e429feef0a7ee1f", size = 63664, upload-time = "2026-05-08T21:01:09.874Z" },
+    { url = "https://files.pythonhosted.org/packages/85/1e/a3a1a63116a2b8edb415a8bb9a6f0c34bd03830b1e18e8ce2904e1dc1cf4/propcache-0.5.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:2f22cbbac9e26a8e864c0985ff1268d5d939d53d9d9411a9824279097e03a2cb", size = 62643, upload-time = "2026-05-08T21:01:11.132Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/03/893cf147de2fc6543c5eaa07ad833170e7e2a2385725bbebe8c0503723bb/propcache-0.5.2-cp313-cp313t-musllinux_1_2_armv7l.whl", hash = "sha256:fc76378c62a0f04d0cd82fbb1a2cd2d7e28fcb40d5873f28a6c44e388aaa2751", size = 59595, upload-time = "2026-05-08T21:01:12.387Z" },
+    { url = "https://files.pythonhosted.org/packages/86/3b/04c1a2e12c57766568ba75ba72b3bf2042818d4c1425fab6fc07155c7cff/propcache-0.5.2-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:acd2c8edba48e31e58a363b8cf4e5c7db3b04b3f9e371f601df30d9b0d244836", size = 65711, upload-time = "2026-05-08T21:01:13.676Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/34/80f8d0099f8d6bacc4de1624c85672681c8cd1149ca2da0e38fd120b817f/propcache-0.5.2-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:452b5065457eb9991ec5eb38ff41d6cd4c991c9ac7c531c4d5849ae473a9a13f", size = 64247, upload-time = "2026-05-08T21:01:14.936Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/1a/8b08f3a5f1037e9e370c55883ceeeee0f6dd0416fb2d2d67b8bfc91f2a79/propcache-0.5.2-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:3430bb2bfe1331885c427745a751e774ee679fd4344f80b97bf879815fe8fa55", size = 67102, upload-time = "2026-05-08T21:01:16.281Z" },
+    { url = "https://files.pythonhosted.org/packages/34/68/8bdb7bb7756d76e005490649d10e4a8369e610c74d619f71e1aedf889e9c/propcache-0.5.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:cef6cea3922890dd6c9654971001fa797b526c16ab5e1e46c05fd6f877be7568", size = 64964, upload-time = "2026-05-08T21:01:17.57Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/aa/50fb0b5d3968b61a510926ff8b8465f1d6e976b3ab74496d7a4b9fc42515/propcache-0.5.2-cp313-cp313t-win32.whl", hash = "sha256:72d61e16dd78228b58c5d47be830ff3da7e5f139abdf0aef9d86cde1c5cf2191", size = 42546, upload-time = "2026-05-08T21:01:18.946Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/4c/0ddbae64321bd4a95bcbfc19307238016b5b1fee645c84626c8d539e5b74/propcache-0.5.2-cp313-cp313t-win_amd64.whl", hash = "sha256:0958834041a0166d343b8d2cedcd8bcbaeb4fdbe0cf08320c5379f143c3be6e7", size = 46330, upload-time = "2026-05-08T21:01:20.162Z" },
+    { url = "https://files.pythonhosted.org/packages/00/d9/9cddc8efb78d8af264c5ec9f6d10b62f57c515feda8d321595f56010fb23/propcache-0.5.2-cp313-cp313t-win_arm64.whl", hash = "sha256:6de8bd93ddde9b992cf2b2e0d796d501a19026b5b9fd87356d7d0779531a8d96", size = 40521, upload-time = "2026-05-08T21:01:21.399Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/ea/23ee535d90ce8bcc465a3028eb3cc0ce3bd1005f4bb27710b30587de798d/propcache-0.5.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:46088abff4cba581dea21ae0467a480526cb25aa5f3c269e909f800328bc3999", size = 94662, upload-time = "2026-05-08T21:01:22.683Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/06/c5a52f419b5d8972f8d46a7577476090d8e3263ff589ce40b5ca4968d5be/propcache-0.5.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:fc88b26f08d634f7bc819a7852e5214f5802641ab8d9fd5326892292eee1993e", size = 53928, upload-time = "2026-05-08T21:01:23.986Z" },
+    { url = "https://files.pythonhosted.org/packages/63/b1/4260d67d6bd85e58a66b72d54ce15d5de789b6f3870cc6bedf8ff9667401/propcache-0.5.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:97797ebb098e670a2f92dd66f32897e30d7615b14e7f59711de23e30a9072539", size = 54650, upload-time = "2026-05-08T21:01:25.305Z" },
+    { url = "https://files.pythonhosted.org/packages/70/06/2f46c318e3307cd7a6a7481def374ce838c0fe20084b39dd54b0879d0e99/propcache-0.5.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ba57fffe4ac99c5d30076161b5866336d97600769bad35cc68f7774b15298a4e", size = 59912, upload-time = "2026-05-08T21:01:26.545Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/29/fe1aebec2ce57ab985a9c382bded1124431f85078113aa222c5d278430d4/propcache-0.5.2-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:583c19759d9eec1e5b69e2fbef36a7d9c326041be9746cb822d335c8cedc2979", size = 63300, upload-time = "2026-05-08T21:01:27.937Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/18/2334b26768b6c82be8c69e83671b767d5ef426aa09b0cba6c2ea47816774/propcache-0.5.2-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:d0326e2e5e1f3163fa306c834e48e8d490e5fae607a097a40c0648109b47ba80", size = 64208, upload-time = "2026-05-08T21:01:29.484Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/76/7f1bfd6afff4c5e38e36a3c6d68eb5f4b7311ea80baf693db78d95b603c4/propcache-0.5.2-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e00820e192c8dbebcafb383ebbf99030895f09905e7a0eb2e0340a0bcc2bc825", size = 61633, upload-time = "2026-05-08T21:01:31.068Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/46/b3ff8aba2b4953a3e50de2cf72f1b5748b8eca93b15f3dc2c84339084c09/propcache-0.5.2-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c66afea89b1e43725731d2004732a046fe6fe955d51f952c3e95a7314a284a39", size = 61724, upload-time = "2026-05-08T21:01:32.374Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/01/814cfcafbcff954f94c01cf30e097ddc88a076b5440fbcf4570753437d40/propcache-0.5.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:d4dc37dec6c6cdad0b57881a5658fd14fbf53e333b1a86cf86559f190e1d9ec4", size = 60069, upload-time = "2026-05-08T21:01:33.67Z" },
+    { url = "https://files.pythonhosted.org/packages/da/68/5c6f7622d510cc666a300687e06fd060c1a43361c0c9b20d284f06d8096a/propcache-0.5.2-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:5570dbcc97571c15f68068e529c92715a12f8d54030e272d264b377e22bd17a5", size = 57099, upload-time = "2026-05-08T21:01:34.915Z" },
+    { url = "https://files.pythonhosted.org/packages/55/27/9cb0b4c679124085327957d42521c99dba04c88c90c3e55a6f0b633ebccc/propcache-0.5.2-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:f814362777a9f841adddb200ecdf8f5cb1e5a3c4b7a86378edbd6ccb26edd702", size = 63391, upload-time = "2026-05-08T21:01:36.231Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/9d/7258aaa5bdf60fc6f27591eef6fe52768cb0beda7140be477c8b12c9794a/propcache-0.5.2-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:196913dea116aeb5a2ba95af4ddcb7ea85559ae07d8eee8751688310d09168c3", size = 61626, upload-time = "2026-05-08T21:01:37.545Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/0d/41c602003e8a9b16fe1e7eadf62c7bfba9d5474370b24200bf48b315f45f/propcache-0.5.2-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:6e7b8719005dd1175be4ab1cd25e9b98659a5e0347331506ec6760d2773a7fb5", size = 64781, upload-time = "2026-05-08T21:01:38.83Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/f3/38e66b1856e9bd079deea015bc4a55f7767c0e4db2f7dcf69e7e680ba4ce/propcache-0.5.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:51f96d685ab16e88cab128cd37a52c5da540809c8b879fa047731bfcb4ad35a4", size = 62570, upload-time = "2026-05-08T21:01:40.415Z" },
+    { url = "https://files.pythonhosted.org/packages/95/ca/bbfe9b910ce57dde8bb4876b4520fc02a4e89497c10de26be936758a3aaa/propcache-0.5.2-cp314-cp314-win32.whl", hash = "sha256:cc6fc3cc62e8501d3ed62894425040d2728ecddb1ed072737a5c70bd537aa9f0", size = 39436, upload-time = "2026-05-08T21:01:41.654Z" },
+    { url = "https://files.pythonhosted.org/packages/61/d2/45c9defbaa1ea297035d9d4cce9e8f80daafbf19319c6007f157c6256ea9/propcache-0.5.2-cp314-cp314-win_amd64.whl", hash = "sha256:81e3a30b0bb60caa22033dd0f8a3618d1d67356212514f62c57db75cb0ef410c", size = 42373, upload-time = "2026-05-08T21:01:43.041Z" },
+    { url = "https://files.pythonhosted.org/packages/44/68/9ea5103f41d5217d7d6ec24db90018e23aebec070c3f9a6e54d12b841fd8/propcache-0.5.2-cp314-cp314-win_arm64.whl", hash = "sha256:0d2c9bf8528f135dbb805ce027567e09164f7efa51a2be07458a2c0420f292d0", size = 38554, upload-time = "2026-05-08T21:01:44.336Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/81/fadf555f42d3b762eea8a53950b0489fdc0aa9da5f8ed9e10ce0a4e01b48/propcache-0.5.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:4bc8ff1feffc6a61c7002ffe84634c41b822e104990ae009f44a0834430070bb", size = 99395, upload-time = "2026-05-08T21:01:45.883Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/c9/c61e134a686949cf7971af3a390148b1156f7be81c73bc0cd12c873e2d48/propcache-0.5.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:79aa3ff0a9b566633b642fa9caf7e21ed1c13d6feca718187873f199e1514078", size = 56653, upload-time = "2026-05-08T21:01:47.307Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/73/daf935ea7048ddd7ec8eec5345b4a40b619d2d178b3c0a0900796bc3c794/propcache-0.5.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1b31822f4474c4036bae62de9402710051d431a606d6a0f907fec79935a071aa", size = 56914, upload-time = "2026-05-08T21:01:48.573Z" },
+    { url = "https://files.pythonhosted.org/packages/79/9f/aba959b435ea18617edd7cf0a7ad0b9c574b8fc7e3d2cd55fb59cb255d33/propcache-0.5.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:13fef48778b5a2a756523fdb781326b028ca75e32858b04f2cdd19f394564917", size = 62567, upload-time = "2026-05-08T21:01:49.903Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/a1/859942de9a791ff42f6141736f5b37749b8f53e65edfa49638c67dd67e6a/propcache-0.5.2-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:8b73ab70f1a3351fbc71f663b3e645af6dd0329100c353081cf69c37433fc6fe", size = 65542, upload-time = "2026-05-08T21:01:51.204Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/61/315bc0fd6c0fc7f80a528b8afd209e5fc4a875ea79571b91b8f50f442907/propcache-0.5.2-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5538d2c13d93e4698af7e092b57bc7298fd35d1d58e656ae18f23ee0d0378e03", size = 66845, upload-time = "2026-05-08T21:01:52.539Z" },
+    { url = "https://files.pythonhosted.org/packages/47/f7/9f8122e3132e8e354ac41975ef8f1099be7d5a16bc7ae562734e993665c0/propcache-0.5.2-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:cd645f03898405cabe694fb8bc35241e3a9c332ec85627584fe3de201452b335", size = 63985, upload-time = "2026-05-08T21:01:53.847Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/54/c317819ec157cbf6f35df9df9657a6f82daf34d5faf15948b2f639c2192e/propcache-0.5.2-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a473b3440261e0c60706e732b2ed2f517857344fc21bf48fdfe211e2d98eb285", size = 63999, upload-time = "2026-05-08T21:01:55.179Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/56/387e3f7dfce0a9233df41fb888aa1c30222cb4bbbf09537c02dd9bd85fe2/propcache-0.5.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7afa37062e6650640e932e4cc9297d81f9f42d9944029cc386b8247dea4da837", size = 62779, upload-time = "2026-05-08T21:01:57.489Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/9c/596784cb5824ed61ee960d3f8655a3f0993e107c6e98ab6c818b7fb92ccb/propcache-0.5.2-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:8a90efd5777e996e42d568db9ac740b944d691e565cbfd31b2f7832f9184b2b8", size = 59796, upload-time = "2026-05-08T21:01:58.736Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/3d/1a6cfa1726a48542c1e8784a0761421476a5b68e09b7f36bf95eb954aaba/propcache-0.5.2-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:f19bb891234d72535764d703bfed1153cc34f4214d5bd7150aee1eec9e8f4366", size = 66023, upload-time = "2026-05-08T21:02:00.228Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/0e/05fd6990369477076e4e280bcb970de760fddf0161a46e988bc95f7940ec/propcache-0.5.2-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:32775082acd2d807ee3db715c7770d38767b817870acfa08c29e057f3c4d5b56", size = 64448, upload-time = "2026-05-08T21:02:01.888Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/86/5f8da315a4309c62c10c0b2516b17492d5d3bbe1bb862b96604db67e2a37/propcache-0.5.2-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:9282fb1a3bccd038da9f768b927b24a0c753e466c086b7c4f3c6982851eefb2d", size = 67329, upload-time = "2026-05-08T21:02:03.484Z" },
+    { url = "https://files.pythonhosted.org/packages/da/d3/3368efe79ab21f0cdf86ef49895811c9cc933131d4cde1f28a624e22e712/propcache-0.5.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:cc49723e2f60d6b32a0f0b08a3fd6d13203c07f1cd9566cfce0f12a917c967a2", size = 65172, upload-time = "2026-05-08T21:02:04.745Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/07/127e8b0bacfb325396196f9d976a22453049b89b9b2b08477cc3145faa44/propcache-0.5.2-cp314-cp314t-win32.whl", hash = "sha256:2d7aa89ebca5acc98cba9d1472d976e394782f587bad6661003602a619fd1821", size = 43813, upload-time = "2026-05-08T21:02:06.025Z" },
+    { url = "https://files.pythonhosted.org/packages/88/fb/46dad6c0ae49ed230ab1b16c890c2b6314e2403e6c412976f4a72d64a527/propcache-0.5.2-cp314-cp314t-win_amd64.whl", hash = "sha256:d447bb0b3054be5818458fbb171208b1d9ff11eba14e18ca18b90cbb45767370", size = 47764, upload-time = "2026-05-08T21:02:07.353Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/c4/a47d0a63aa309d10d59ede6e9d4cff03a344a79d1f0f4cd0cd74997b53e0/propcache-0.5.2-cp314-cp314t-win_arm64.whl", hash = "sha256:fe67a3d11cd9b4efabfa45c3d00ffba2b26811442a73a581a94b67c2b5faccf6", size = 41140, upload-time = "2026-05-08T21:02:09.065Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/ed/1cdcab6ba3d6ab7feca11fc14f0eeea80755bb53ef4e892079f31b10a25f/propcache-0.5.2-py3-none-any.whl", hash = "sha256:be1ddfcbb376e3de5d2e2db1d58d6d67463e6b4f9f040c000de8e300295465fe", size = 14036, upload-time = "2026-05-08T21:02:10.673Z" },
 ]
 
 [[package]]
@@ -1780,10 +2482,10 @@ name = "pydantic"
 version = "2.13.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "annotated-types" },
-    { name = "pydantic-core" },
-    { name = "typing-extensions" },
-    { name = "typing-inspection" },
+    { name = "annotated-types", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "pydantic-core", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "typing-extensions", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "typing-inspection", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/18/a5/b60d21ac674192f8ab0ba4e9fd860690f9b4a6e51ca5df118733b487d8d6/pydantic-2.13.4.tar.gz", hash = "sha256:c40756b57adaa8b1efeeced5c196f3f3b7c435f90e84ea7f443901bec8099ef6", size = 844775, upload-time = "2026-05-06T13:43:05.343Z" }
 wheels = [
@@ -1795,7 +2497,7 @@ name = "pydantic-core"
 version = "2.46.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/9d/56/921726b776ace8d8f5db44c4ef961006580d91dc52b803c489fafd1aa249/pydantic_core-2.46.4.tar.gz", hash = "sha256:62f875393d7f270851f20523dd2e29f082bcc82292d66db2b64ea71f64b6e1c1", size = 471464, upload-time = "2026-05-06T13:37:06.98Z" }
 wheels = [
@@ -1911,9 +2613,9 @@ name = "pydantic-settings"
 version = "2.14.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pydantic" },
-    { name = "python-dotenv" },
-    { name = "typing-inspection" },
+    { name = "pydantic", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "python-dotenv", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "typing-inspection", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5c/b5/8f48e906c3e0205276e8bd8cb7512217a87b2685304d64be27cad5b3019f/pydantic_settings-2.14.2.tar.gz", hash = "sha256:c19dd64b19097f1de80184f0cc7b0272a13ae6e170cbf240a3e27e381ed14a5f", size = 237700, upload-time = "2026-06-19T13:44:56.324Z" }
 wheels = [
@@ -1934,7 +2636,7 @@ name = "pyjwt"
 version = "2.13.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "(python_full_version < '3.11' and sys_platform == 'darwin') or (python_full_version < '3.11' and sys_platform == 'linux') or (python_full_version < '3.11' and sys_platform == 'win32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515, upload-time = "2026-05-21T19:54:36.618Z" }
 wheels = [
@@ -1943,7 +2645,7 @@ wheels = [
 
 [package.optional-dependencies]
 crypto = [
-    { name = "cryptography" },
+    { name = "cryptography", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 
 [[package]]
@@ -1970,8 +2672,8 @@ name = "pyright"
 version = "1.1.411"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nodeenv" },
-    { name = "typing-extensions" },
+    { name = "nodeenv", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "typing-extensions", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7e/ab/265f7dc69d28113ebba19092e57b075f41543b2ed048429c5f56e2b88eac/pyright-1.1.411.tar.gz", hash = "sha256:d885a0551f2e763b089a02702174e7f4ba77548cddabc972ab86d1f7f1b0f998", size = 4112861, upload-time = "2026-06-25T02:14:06.37Z" }
 wheels = [
@@ -1984,12 +2686,12 @@ version = "9.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
-    { name = "iniconfig" },
-    { name = "packaging" },
-    { name = "pluggy" },
-    { name = "pygments" },
-    { name = "tomli", marker = "python_full_version < '3.11'" },
+    { name = "exceptiongroup", marker = "(python_full_version < '3.11' and sys_platform == 'darwin') or (python_full_version < '3.11' and sys_platform == 'linux') or (python_full_version < '3.11' and sys_platform == 'win32')" },
+    { name = "iniconfig", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "packaging", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "pluggy", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "pygments", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "tomli", marker = "(python_full_version < '3.11' and sys_platform == 'darwin') or (python_full_version < '3.11' and sys_platform == 'linux') or (python_full_version < '3.11' and sys_platform == 'win32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
 wheels = [
@@ -2001,9 +2703,9 @@ name = "pytest-asyncio"
 version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "backports-asyncio-runner", marker = "python_full_version < '3.11'" },
-    { name = "pytest" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "backports-asyncio-runner", marker = "(python_full_version < '3.11' and sys_platform == 'darwin') or (python_full_version < '3.11' and sys_platform == 'linux') or (python_full_version < '3.11' and sys_platform == 'win32')" },
+    { name = "pytest", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "typing-extensions", marker = "(python_full_version < '3.13' and sys_platform == 'darwin') or (python_full_version < '3.13' and sys_platform == 'linux') or (python_full_version < '3.13' and sys_platform == 'win32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/43/7c/d36d04db312ecf4298932ef77e6e4a9e8ad017906e24e34f0b0c361a2473/pytest_asyncio-1.4.0.tar.gz", hash = "sha256:c6c0d2259945122819f171a32ecea2c349ead889ee28176caaf492143424be42", size = 58514, upload-time = "2026-05-26T09:56:04.083Z" }
 wheels = [
@@ -2015,9 +2717,9 @@ name = "pytest-cov"
 version = "7.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "coverage", extra = ["toml"] },
-    { name = "pluggy" },
-    { name = "pytest" },
+    { name = "coverage", extra = ["toml"], marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "pluggy", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "pytest", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
 wheels = [
@@ -2029,7 +2731,7 @@ name = "pytest-retry"
 version = "1.7.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pytest" },
+    { name = "pytest", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c5/5b/607b017994cca28de3a1ad22a3eee8418e5d428dcd8ec25b26b18e995a73/pytest_retry-1.7.0.tar.gz", hash = "sha256:f8d52339f01e949df47c11ba9ee8d5b362f5824dff580d3870ec9ae0057df80f", size = 19977, upload-time = "2025-01-19T01:56:13.115Z" }
 wheels = [
@@ -2041,7 +2743,7 @@ name = "pytest-timeout"
 version = "2.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pytest" },
+    { name = "pytest", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ac/82/4c9ecabab13363e72d880f2fb504c5f750433b2b6f16e99f4ec21ada284c/pytest_timeout-2.4.0.tar.gz", hash = "sha256:7e68e90b01f9eff71332b25001f85c75495fc4e3a836701876183c4bcfd0540a", size = 17973, upload-time = "2025-05-05T19:44:34.99Z" }
 wheels = [
@@ -2053,8 +2755,8 @@ name = "pytest-xdist"
 version = "3.8.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "execnet" },
-    { name = "pytest" },
+    { name = "execnet", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "pytest", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
 wheels = [
@@ -2063,7 +2765,7 @@ wheels = [
 
 [package.optional-dependencies]
 psutil = [
-    { name = "psutil" },
+    { name = "psutil", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 
 [[package]]
@@ -2071,7 +2773,7 @@ name = "python-dateutil"
 version = "2.9.0.post0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "six" },
+    { name = "six", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
 wheels = [
@@ -2190,7 +2892,7 @@ name = "redis"
 version = "8.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "async-timeout", marker = "python_full_version < '3.11.3'" },
+    { name = "async-timeout", marker = "(python_full_version < '3.11.3' and sys_platform == 'darwin') or (python_full_version < '3.11.3' and sys_platform == 'linux') or (python_full_version < '3.11.3' and sys_platform == 'win32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cc/c3/928b290c2c0ca99ab96eea5b4ff8f30be8112b075301a7d3ba214a3c8c12/redis-8.0.1.tar.gz", hash = "sha256:afc5a7a2f5a084f5b1880dec548dd45be17db7e43c82a30d84f952aefb05cfb0", size = 5114170, upload-time = "2026-06-23T14:52:37.728Z" }
 wheels = [
@@ -2202,10 +2904,10 @@ name = "referencing"
 version = "0.37.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "attrs" },
-    { name = "rpds-py", version = "0.30.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "rpds-py", version = "2026.6.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "attrs", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "rpds-py", version = "0.30.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and sys_platform == 'darwin') or (python_full_version < '3.11' and sys_platform == 'linux') or (python_full_version < '3.11' and sys_platform == 'win32')" },
+    { name = "rpds-py", version = "2026.6.3", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and sys_platform == 'darwin') or (python_full_version >= '3.11' and sys_platform == 'linux') or (python_full_version >= '3.11' and sys_platform == 'win32')" },
+    { name = "typing-extensions", marker = "(python_full_version < '3.13' and sys_platform == 'darwin') or (python_full_version < '3.13' and sys_platform == 'linux') or (python_full_version < '3.13' and sys_platform == 'win32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
 wheels = [
@@ -2217,10 +2919,10 @@ name = "requests"
 version = "2.34.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "certifi" },
-    { name = "charset-normalizer" },
-    { name = "idna" },
-    { name = "urllib3" },
+    { name = "certifi", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "charset-normalizer", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "idna", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "urllib3", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
 wheels = [
@@ -2232,8 +2934,8 @@ name = "requests-oauthlib"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "oauthlib" },
-    { name = "requests" },
+    { name = "oauthlib", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "requests", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/f2/05f29bc3913aea15eb670be136045bf5c5bbf4b99ecb839da9b422bb2c85/requests-oauthlib-2.0.0.tar.gz", hash = "sha256:b3dffaebd884d8cd778494369603a9e7b58d29111bf6b41bdc2dcd87203af4e9", size = 55650, upload-time = "2024-03-22T20:32:29.939Z" }
 wheels = [
@@ -2245,8 +2947,8 @@ name = "rich"
 version = "15.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "markdown-it-py" },
-    { name = "pygments" },
+    { name = "markdown-it-py", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "pygments", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
 wheels = [
@@ -2559,8 +3261,8 @@ name = "sse-starlette"
 version = "3.4.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio" },
-    { name = "starlette" },
+    { name = "anyio", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "starlette", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d2/1b/bc9e3e7a72dcdad7dc7888758f5d00f56f8909ed5cfdff822bd72bb4c520/sse_starlette-3.4.5.tar.gz", hash = "sha256:83072538bc211a2f68b7b0422226c4af3e9b62e106e07034664b832ca019842a", size = 35249, upload-time = "2026-06-20T17:36:58.322Z" }
 wheels = [
@@ -2572,8 +3274,8 @@ name = "starlette"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "anyio", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "typing-extensions", marker = "(python_full_version < '3.13' and sys_platform == 'darwin') or (python_full_version < '3.13' and sys_platform == 'linux') or (python_full_version < '3.13' and sys_platform == 'win32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/eb/e3/7c1dc7381d9f8ab7d854328ebfa884e62cb3f3d8549ddfd37c7814f42afa/starlette-1.3.1.tar.gz", hash = "sha256:05d0213193f2fbaae60e2ecb593b4add4262ad4e46536b54abe36f11a71724e0", size = 2703240, upload-time = "2026-06-12T09:23:11.602Z" }
 wheels = [
@@ -2691,7 +3393,7 @@ name = "typing-inspection"
 version = "0.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
@@ -2738,9 +3440,9 @@ name = "uvicorn"
 version = "0.51.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "click" },
-    { name = "h11" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "click", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "h11", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "typing-extensions", marker = "(python_full_version < '3.11' and sys_platform == 'darwin') or (python_full_version < '3.11' and sys_platform == 'linux') or (python_full_version < '3.11' and sys_platform == 'win32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a2/65/b7c6c443ccc58678c91e1e973bbe2a878591538655d6e1d47f24ba1c51f3/uvicorn-0.51.0.tar.gz", hash = "sha256:f6f4b69b657c312f516dd2d268ab9ae6f254b11e4bac504f37b2ab58b24dd0b0", size = 94412, upload-time = "2026-07-08T10:59:05.962Z" }
 wheels = [
@@ -2749,12 +3451,12 @@ wheels = [
 
 [package.optional-dependencies]
 standard = [
-    { name = "httptools" },
-    { name = "python-dotenv" },
-    { name = "pyyaml" },
-    { name = "uvloop", marker = "platform_python_implementation != 'PyPy' and sys_platform != 'win32'" },
-    { name = "watchfiles" },
-    { name = "websockets" },
+    { name = "httptools", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "python-dotenv", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "pyyaml", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "uvloop", marker = "(platform_python_implementation != 'PyPy' and sys_platform == 'darwin') or (platform_python_implementation != 'PyPy' and sys_platform == 'linux')" },
+    { name = "watchfiles", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "websockets", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 
 [[package]]
@@ -2806,7 +3508,7 @@ name = "watchfiles"
 version = "1.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio" },
+    { name = "anyio", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cd/41/5e1a4bb12aac5f1493fa1bdc11154eca3b258ca4eba65d39c473fe19d8e9/watchfiles-1.2.0.tar.gz", hash = "sha256:c995fba777f1ea992f090f9236e9284cf7a5d1a0130dd5a3d82c598cacd76838", size = 108252, upload-time = "2026-05-18T04:32:04.251Z" }
 wheels = [
@@ -3035,6 +3737,18 @@ wheels = [
 ]
 
 [[package]]
+name = "werkzeug"
+version = "3.1.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/dd/b2/381be8cfdee792dd117872481b6e378f85c957dd7c5bca38897b08f765fd/werkzeug-3.1.8.tar.gz", hash = "sha256:9bad61a4268dac112f1c5cd4630a56ede601b6ed420300677a869083d70a4c44", size = 875852, upload-time = "2026-04-02T18:49:14.268Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/93/8c/2e650f2afeb7ee576912636c23ddb621c91ac6a98e66dc8d29c3c69446e1/werkzeug-3.1.8-py3-none-any.whl", hash = "sha256:63a77fb8892bf28ebc3178683445222aa500e48ebad5ec77b0ad80f8726b1f50", size = 226459, upload-time = "2026-04-02T18:49:12.72Z" },
+]
+
+[[package]]
 name = "wrapt"
 version = "2.2.2"
 source = { registry = "https://pypi.org/simple" }
@@ -3118,6 +3832,122 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a0/4f/ac12fda57a55068a094ec42851fb0a40e8489d8941863d517452de62e507/wrapt-2.2.2-cp314-cp314t-win_amd64.whl", hash = "sha256:d09db0f7e8357060d3c38fc22a018aba683a796bf184360fd1a58f6fc180dc77", size = 82462, upload-time = "2026-06-20T23:49:21.631Z" },
     { url = "https://files.pythonhosted.org/packages/48/a7/df732dac86d9b2027c56bd163dbc883e037b16c3469614752e148d219c61/wrapt-2.2.2-cp314-cp314t-win_arm64.whl", hash = "sha256:f32fe639c39561ccc187bcae17e9271be0eb45f1c2952510d2f29b33ab577347", size = 81182, upload-time = "2026-06-20T23:49:23.199Z" },
     { url = "https://files.pythonhosted.org/packages/6e/d2/6317eb6d4554855bbf12d61857774af34747bf88a42c19bf306de67e2fa3/wrapt-2.2.2-py3-none-any.whl", hash = "sha256:5bad217350f19ce99ca5b5e71d406765ea86fe541628426772b657375ee1c048", size = 61460, upload-time = "2026-06-20T23:49:42.966Z" },
+]
+
+[[package]]
+name = "yarl"
+version = "1.24.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "multidict", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "propcache", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/79/12/1e8f37460ea0f7eb59c221fdaf0ed75e7ac43e97f8093b9c6f411df50a78/yarl-1.24.2.tar.gz", hash = "sha256:9ac374123c6fd7abf64d1fec93962b0bd4ee2c19751755a762a72dd96c0378f8", size = 210798, upload-time = "2026-05-19T21:31:05.599Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/df/f1c7a3de0831cd83194f1a85c5bb431b13f81e6b45079314c86d1c4ef3f2/yarl-1.24.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:5249a113065c2b7a958bc699759e359cd61cfc81e3069662208f48f191b7ed12", size = 129057, upload-time = "2026-05-19T21:27:47.564Z" },
+    { url = "https://files.pythonhosted.org/packages/48/41/7daafb32dd7562bf45b1ce56562e7e1a9146f6479b6456873eb8a3413c40/yarl-1.24.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:7f4425fa244fbf530b006d0c5f79ce920114cfff5b4f5f6056e669f8e160fdc0", size = 91545, upload-time = "2026-05-19T21:27:50.089Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/8f/7b3ec212f1ea0683f55f978e3246bc313c38818664edfc97a9f349a4901e/yarl-1.24.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:15c0b5e49d3c44e2a0b93e6a49476c5edad0a7686b92c395765a7ea775572a75", size = 91380, upload-time = "2026-05-19T21:27:51.953Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/1b/8bafab7db23b0567ae9db749099b329d91e3b82bc6028b2050ba583e116c/yarl-1.24.2-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:246d32a53a947c8f0189f5d699cbd4c7036de45d9359e13ba238d1239678c727", size = 105957, upload-time = "2026-05-19T21:27:53.98Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/77/21030c2f8d21d21559719beafc772ada2014be933418ed1eaed9cc800e42/yarl-1.24.2-cp310-cp310-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:64480fb3e4d4ed9ed71c48a91a477384fc342a50ca30071d2f8a88d51d9c9413", size = 97242, upload-time = "2026-05-19T21:27:55.981Z" },
+    { url = "https://files.pythonhosted.org/packages/50/d8/f9ea63d1b6aa910a866e089d871fff6cbd49caab29b86b35221a62dfa0d5/yarl-1.24.2-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:349de4701dc3760b6e876628423a8f147ef4f5599d10aba1e10702075d424ed9", size = 114719, upload-time = "2026-05-19T21:27:58.037Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/a3/04e0ee98ac58a249ea7ed75223f5f901ba81a834f0b4921b58e5cec11757/yarl-1.24.2-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:d162677af8d5d3d6ebab8394b021f4d041ac107a4b705873148a77a49dc9e1b2", size = 112140, upload-time = "2026-05-19T21:27:59.618Z" },
+    { url = "https://files.pythonhosted.org/packages/02/ad/0b9cc9f38a7324a7eb1d80f834eaa5283d17e9271bbda3186e598dddaeac/yarl-1.24.2-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f5f5c6ec23a9043f2d139cc072f53dd23168d202a334b9b2fda8de4c3e890d90", size = 106721, upload-time = "2026-05-19T21:28:02.586Z" },
+    { url = "https://files.pythonhosted.org/packages/65/e7/a52478ebfc66ec989e085c6ae038b9f1bfa4190baa193b133b669c709e2f/yarl-1.24.2-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:60de6742447fbbf697f16f070b8a443f1b5fe6ca3826fbef9fe70ecd5328e643", size = 106478, upload-time = "2026-05-19T21:28:04.523Z" },
+    { url = "https://files.pythonhosted.org/packages/04/d8/5508530fea8472542de00013ae280765fc938ee196fc4030c43a498afb36/yarl-1.24.2-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:acf93187c3710e422368eb768aee98db551ec7c85adc250207a95c16548ab7ac", size = 105423, upload-time = "2026-05-19T21:28:06.515Z" },
+    { url = "https://files.pythonhosted.org/packages/84/f1/ece28505e9628e8b756e11bb4f28864a17cc33b6b44db4d2aaf0622bf630/yarl-1.24.2-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:f4b0352fd41fd34b6651934606268816afd6914d09626f9bcbbf018edb0afb3f", size = 99878, upload-time = "2026-05-19T21:28:08.637Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/52/fb5d34529b46dd84013afcfb30b8d2bc2832ed03d412736f577d604fa393/yarl-1.24.2-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:6b208bb939099b4b297438da4e9b25357f0b1c791888669b963e45b203ea9f36", size = 114025, upload-time = "2026-05-19T21:28:10.64Z" },
+    { url = "https://files.pythonhosted.org/packages/43/f0/ff9d31aaab024f7a251c0ed308a98ae29bf9f7dc344e78f28b1322431ca2/yarl-1.24.2-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:4b85b8825e631295ff4bc8943f7471d54c533a9360bbe15ebb38e018b555bb8a", size = 105613, upload-time = "2026-05-19T21:28:12.784Z" },
+    { url = "https://files.pythonhosted.org/packages/31/7d/3296fb3f3ecd52bf9ae6c16b0895c1cda7e9170a2083861552b683f70264/yarl-1.24.2-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:e26acf20c26cb4fefc631fdb75aca2a6b8fa8b7b5d7f204fb6a8f1e63c706f53", size = 111665, upload-time = "2026-05-19T21:28:14.393Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/74/77aa6ddaca4fbf42e45e675a465c43956dd40702281049975a2aa04eae59/yarl-1.24.2-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:819ca24f8eafcfb683c1bd5f44f2f488cea1274eb8944731ffd2e1f10f619342", size = 106914, upload-time = "2026-05-19T21:28:15.893Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/02/7611f22cd1d4ed7373eb7f9ee21fde1046edba2e7c0e514880d760352f48/yarl-1.24.2-cp310-cp310-win_amd64.whl", hash = "sha256:5cb0f995a901c36be096ccbf4c673591c2faabbe96279598ffaec8c030f85bf4", size = 92658, upload-time = "2026-05-19T21:28:17.471Z" },
+    { url = "https://files.pythonhosted.org/packages/91/00/671d0add79938127292839ae44506ce2f7fe8909c72d5a931864f128fd0b/yarl-1.24.2-cp310-cp310-win_arm64.whl", hash = "sha256:f408eace7e22a68b467a0562e0d27d322f91fe3eaaa6f466b962c6cfaea9fa39", size = 87887, upload-time = "2026-05-19T21:28:19.021Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/c5/1ce244152ff2839645e7cae92f90e7bafcb2c52bea7ff586ac714f14f5df/yarl-1.24.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:36348bebb147b83818b9d7e673ea4debc75970afc6ffdc7e3975ad05ce5a58c1", size = 128971, upload-time = "2026-05-19T21:28:20.543Z" },
+    { url = "https://files.pythonhosted.org/packages/87/5a/00f36967203ed89cb3acd2c8ed526cc3fed9418eb70ce128160a911c8499/yarl-1.24.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:1a97e42c8a2233f2f279ecadd9e4a037bcb5d813b78435e8eedd4db5a9e9708c", size = 91507, upload-time = "2026-05-19T21:28:22.556Z" },
+    { url = "https://files.pythonhosted.org/packages/31/d0/1fb0c1cd27288f39f6974da4318c32768d72c9890984541fdf1e2e32a51d/yarl-1.24.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:8d027d56f1035e339d1001ac33eceab5b2ec8e42e449787bb75e289fb9a5cd1d", size = 91343, upload-time = "2026-05-19T21:28:24.092Z" },
+    { url = "https://files.pythonhosted.org/packages/03/ce/d4a646508bed2f8dec6435b40166fe9308dd191262033d3f307b2bbcaecd/yarl-1.24.2-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0a6377060e7927187a42b7eb202090cbe2b34933a4eeaf90e3bd9e33432e5cae", size = 105704, upload-time = "2026-05-19T21:28:25.872Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/07/b3278e82d8bc41485bcf6d856cd0433262593de615b1d3dc43bd3f5bead4/yarl-1.24.2-cp311-cp311-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:17076578bce0049a5ce57d14ad1bded391b68a3b213e9b81b0097b090244999a", size = 97281, upload-time = "2026-05-19T21:28:27.352Z" },
+    { url = "https://files.pythonhosted.org/packages/17/5b/4cee6e7c92e487bebe7afc797da0aa54a248ab4e776a68fe369ec29665a5/yarl-1.24.2-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:50713f1d4d6be6375bb178bb43d140ee1acb8abe589cd723320b7925a275be1e", size = 114020, upload-time = "2026-05-19T21:28:29.458Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/82/111076571545a7d4f9cca3fbd5c6f40615af58642be09f12328f48022468/yarl-1.24.2-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:34263e2fa8fb5bb63a0d97706cda38edbad62fddb58c7f12d6acbc092812aa50", size = 111450, upload-time = "2026-05-19T21:28:31.262Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/ec/08f671f69a444d704aeecebf92af659b67b97a869942411d0a578b08c334/yarl-1.24.2-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:49016d82f032b1bd1e10b01078a7d29ae71bf468eeae0ea22df8bab691e60003", size = 106384, upload-time = "2026-05-19T21:28:32.856Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/86/ce41e7a7a199340b2330d52b60f25c4074b6636dd0e60b1a80d31a9db042/yarl-1.24.2-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3f6d2c216318f8f32038ca3f72501ba08536f0fd18a36e858836b121b2deed9f", size = 106153, upload-time = "2026-05-19T21:28:35.222Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/5d/31be8a729531ab3e55ac3e7e5c800be8c89ea98947f418b2f6ea259fb6ee/yarl-1.24.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:08d3a33218e0c64393e7610284e770409a9c31c429b078bcb24096ed0a783b8f", size = 105322, upload-time = "2026-05-19T21:28:36.642Z" },
+    { url = "https://files.pythonhosted.org/packages/47/9b/b57afb22b386ae87ac9940f09878b98d8c333f89113e6fc96fcf4ca9eb64/yarl-1.24.2-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:5d699376c4ca3cba49bbfae3a05b5b70ded572937171ce1e0b8d87118e2ba294", size = 99057, upload-time = "2026-05-19T21:28:38.386Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/4f/06348c27c8389256c313e8a57d796808fc0264c915dd5e7cfd3c0e314dc7/yarl-1.24.2-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:a1cab588b4fa14bea2e55ebea27478adfb05372f47573738e1acc4a36c0b05d2", size = 113502, upload-time = "2026-05-19T21:28:40.091Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/1c/284f307b298e4a17b7943b07d9d7ecc4151537f8d137ba51f3bb6c31ca20/yarl-1.24.2-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:ec87ccc31bd21db7ad009d8572c127c1000f268517618a4cc09adba3c2a7f21c", size = 105253, upload-time = "2026-05-19T21:28:41.987Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/bf/0de123bec8619e45c80cbded9085f61b5b4a9eddb8abe6d25d28ee1ec866/yarl-1.24.2-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:d1dd47a22843b212baa8d74f37796815d43bd046b42a0f41e9da433386c3136b", size = 111345, upload-time = "2026-05-19T21:28:43.93Z" },
+    { url = "https://files.pythonhosted.org/packages/90/af/0248eb065e51129d2a9b2436cd1b5c772c19a6b04e5b6a186955671e3319/yarl-1.24.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:7b54b9c67c2b06bd7b9a77253d242124b9c95d2c02def5a1144001ee547dd9d5", size = 106558, upload-time = "2026-05-19T21:28:45.806Z" },
+    { url = "https://files.pythonhosted.org/packages/21/3c/f960d7a65ef97d8ba9b424fb5128796a4bc710fc6df2ddbbd7dfdc3bbd20/yarl-1.24.2-cp311-cp311-win_amd64.whl", hash = "sha256:f8fdbcff8b2c7c9284e60c196f693588598ddcee31e11c18e14949ce44519d45", size = 92808, upload-time = "2026-05-19T21:28:48.465Z" },
+    { url = "https://files.pythonhosted.org/packages/03/1a/49fb03750e4de4d2284cd5b885a383133c34eef45bd59631b2bb8b7e81e8/yarl-1.24.2-cp311-cp311-win_arm64.whl", hash = "sha256:b32c37a7a337e90822c45797bf3d79d60875cfcccd3ecc80e9f453d87026c122", size = 87610, upload-time = "2026-05-19T21:28:50.07Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/da/866bcb01076ba49d2b42b309867bed3826421f1c479655eb7a607b44f20b/yarl-1.24.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:b975866c184564c827e0877380f0dae57dcca7e52782128381b72feff6dfceb8", size = 129957, upload-time = "2026-05-19T21:28:51.695Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/1d/fcefb70922ea2268a8971d8e5874d9a8218644200fb8465f1dcad55e6851/yarl-1.24.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:3b075301a2836a0e297b1b658cb6d6135df535d62efefdd60366bd589c2c82f2", size = 92164, upload-time = "2026-05-19T21:28:53.242Z" },
+    { url = "https://files.pythonhosted.org/packages/29/b6/170e2b8d4e3bc30e6bfdcca53556537f5bf595e938632dfcb059311f3ff6/yarl-1.24.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8ae44649b00947634ab0dab2a374a638f52923a6e67083f2c156cd5cbd1a881d", size = 91688, upload-time = "2026-05-19T21:28:54.865Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/a5/c9f655d5553ea0b99fdac9d6a99ad3f9b3e73b8e5758bb46f58c9831f74c/yarl-1.24.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:507cc19f0b45454e2d6dcd62ff7d062b9f77a2812404e62dbdaec05b50faa035", size = 102902, upload-time = "2026-05-19T21:28:56.963Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/bc/6b9664d815d79af4ee553337f9d606c56bbf269186ada9172de45f1b5f60/yarl-1.24.2-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:c4c17bad5a530912d2111825d3f05e89bab2dd376aaa8cbc77e449e6db63e576", size = 97931, upload-time = "2026-05-19T21:28:58.56Z" },
+    { url = "https://files.pythonhosted.org/packages/98/ec/32ba48acae30fecd60928f5791188b80a9d6ee3840507ffda29fecd37b71/yarl-1.24.2-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:f5f0cbb112838a4a293985b6ed73948a547dadcc1ba6d2089938e7abdedceef8", size = 111030, upload-time = "2026-05-19T21:29:00.148Z" },
+    { url = "https://files.pythonhosted.org/packages/82/5a/6f4cd081e5f4934d2ae3a8ef4abe3afacc010d26f0035ee91b35cd7d7c37/yarl-1.24.2-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5ec8356b8a6afcf81fc7aeeef13b1ff7a49dec00f313394bbb9e83830d32ccd7", size = 110392, upload-time = "2026-05-19T21:29:02.155Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/da/323a01c349bd5fb01bb6652e314d9bb218cee630a736bdb810ad50e4013f/yarl-1.24.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7e7ebcdef69dec6c6451e616f32b622a6d4a2e92b445c992f7c8e5274a6bbc4c", size = 105612, upload-time = "2026-05-19T21:29:04.247Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/80/264ab684f181e1a876389374519ff05d10248725535ae2ac4e8ac4e563d6/yarl-1.24.2-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:47a55d6cf6db2f401017a9e96e5288844e5051911fb4e0c8311a3980f5e59a7d", size = 104487, upload-time = "2026-05-19T21:29:06.491Z" },
+    { url = "https://files.pythonhosted.org/packages/41/07/efabe5df87e96d7ad5959760b888344be48cd6884db127b407c6b5503adc/yarl-1.24.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3065657c80a2321225e804048597ad55658a7e76b32d6f5ee4074d04c50401db", size = 102333, upload-time = "2026-05-19T21:29:08.267Z" },
+    { url = "https://files.pythonhosted.org/packages/44/0c/bcf7c42603e1009295f586d8890f2ba032c8b53310e815adf0a202c73d9f/yarl-1.24.2-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:cb84b80d88e19ede158619b80813968713d8d008b0e2497a576e6a0557d50712", size = 99025, upload-time = "2026-05-19T21:29:10.682Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/82/84482ab1a57a0f21a08afe6a7004c61d741f8f2ecc3b05c321577c612164/yarl-1.24.2-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:990de4f680b1c217e77ff0d6aa0029f9eb79889c11fb3e9a3942c7eba29c1996", size = 110507, upload-time = "2026-05-19T21:29:12.954Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/8d/a546ba1dfe1b0f290e05fef145cd07614c0f15df1a707195e512d1e39d1d/yarl-1.24.2-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:abb8ec0323b80161e3802da3150ef660b41d0e9be2048b76a363d93eee992c2b", size = 103719, upload-time = "2026-05-19T21:29:14.893Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/b6/267f2a09213138473adfce6b8a6e17791d7fee70bd4d9003218e4dec58b0/yarl-1.24.2-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:e7977781f83638a4c73e0f88425563d70173e0dfd90ac006a45c65036293ee3c", size = 110438, upload-time = "2026-05-19T21:29:16.485Z" },
+    { url = "https://files.pythonhosted.org/packages/48/2d/1c8d89c7c5f9cad9fb2902445d94e2ab1d7aa35de029afbb8ae95c42d00f/yarl-1.24.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e30dd55825dc554ec5b66a94953b8eda8745926514c5089dfcacecb9c99b5bd1", size = 105719, upload-time = "2026-05-19T21:29:18.367Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/25/722e3b93bd687009afb2d59a35e13d30ddd8f80571445bb0c4e4ce26ec66/yarl-1.24.2-cp312-cp312-win_amd64.whl", hash = "sha256:7dafe10c12ddd4d120d528c4b5599c953bd7b12845347d507b95451195bb6cad", size = 92901, upload-time = "2026-05-19T21:29:20.014Z" },
+    { url = "https://files.pythonhosted.org/packages/39/47/4486ccfb674c04854a1ef8aa77868b6a6f765feaf69633409d7ca4f02cb8/yarl-1.24.2-cp312-cp312-win_arm64.whl", hash = "sha256:044a09d8401fcf8681977faef6d286b8ade1e2d2e9dceda175d1cfa5ca496f30", size = 87229, upload-time = "2026-05-19T21:29:22.1Z" },
+    { url = "https://files.pythonhosted.org/packages/82/62/fcf0ce677f17e5c471c06311dd25964be38a4c586993632910d2e75278bc/yarl-1.24.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:491ac9141decf49ee8030199e1ee251cdff0e131f25678817ff6aa5f837a3536", size = 128978, upload-time = "2026-05-19T21:29:23.83Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/58/8e63299bb71ed61a834121d9d3fe6c9fcf2a6a5d09754ff4f20f2d20baf5/yarl-1.24.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e89418f65eda18f99030386305bd44d7d504e328a7945db1ead514fbe03a0607", size = 91733, upload-time = "2026-05-19T21:29:25.375Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/24/16748d5dab6daec8b0ed81ccec639a1cded0f18dcc62a4f696b4fe366c37/yarl-1.24.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:cdfcce633b4a4bb8281913c57fcafd4b5933fbc19111a5e3930bbd299d6102f1", size = 91113, upload-time = "2026-05-19T21:29:26.928Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/66/b63fff7b71211e866624b21432d5943cbb633eb0c2872d9ee3070648f22c/yarl-1.24.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:863297ddede92ee49024e9a9b11ecb59f310ca85b60d8537f56bed9bbb5b1986", size = 103899, upload-time = "2026-05-19T21:29:28.842Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/ac/ba1974b8533909636f7733fe86cf677e3619527c3c2fa913e0ea89c48757/yarl-1.24.2-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:374423f70754a2c96942ede36a29d37dc6b0cb8f92f8d009ddf3ed78d3da5488", size = 97862, upload-time = "2026-05-19T21:29:31.086Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/a5/123ac993b5c2ba6f554a140305620cb8f150fa543711bbc49be3ec0a65a4/yarl-1.24.2-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:33a29b5d00ccbf3219bb3e351d7875739c19481e030779f48cc46a7a71681a9b", size = 111060, upload-time = "2026-05-19T21:29:32.657Z" },
+    { url = "https://files.pythonhosted.org/packages/23/37/c472d3af3509688392134a88a825276770a187f1daa4de3f6dc0a327a751/yarl-1.24.2-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a9532c57211730c515341af11fef6e9b61d157487272a096d0c04da445642592", size = 110613, upload-time = "2026-05-19T21:29:34.379Z" },
+    { url = "https://files.pythonhosted.org/packages/df/88/09c28dad91e662ccfaa1b78f1c57badde74fc9d0b23e74aef644750ecd73/yarl-1.24.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:91e72cf093fd833483a97ee648e0c053c7c629f51ff4a0e7edd84f806b0c5617", size = 107012, upload-time = "2026-05-19T21:29:36.216Z" },
+    { url = "https://files.pythonhosted.org/packages/07/ab/9d4f69d571a94f4d112fa7e2e007200f5a54d319f58c82ac7b7baa61f5c6/yarl-1.24.2-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b3177bc0a768ef3bacceb4f272632990b7bea352f1b2f1eee9d6d6ff16516f92", size = 105887, upload-time = "2026-05-19T21:29:38.746Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/9a/000b2b66c0d772a499fc531d21dab92dfeb73b640a12eed6ba89f49bb2d0/yarl-1.24.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:e196952aacaf3b232e265ff02980b64d483dc0972bd49bcb061171ff22ac203a", size = 103620, upload-time = "2026-05-19T21:29:40.368Z" },
+    { url = "https://files.pythonhosted.org/packages/41/7c/7c1050f73450fbdaa3f0c72017059f00ce5e13366692f3dba25275a1083d/yarl-1.24.2-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:204e7a61ce99919c0de1bf904ab5d7aa188a129ea8f690a8f76cfb6e2844dc44", size = 100599, upload-time = "2026-05-19T21:29:42.66Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/b1/29e5756b3926705f5f6089bd5b9f50a56eaac550da6e260bf713ead44d04/yarl-1.24.2-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:4b156914620f0b9d78dc1adb3751141daee561cfec796088abb89ed49d220f1a", size = 110604, upload-time = "2026-05-19T21:29:44.632Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/4b/8415bc96e9b150cde942fbac9a8182985e58f40ce5c54c34ed015407d3ee/yarl-1.24.2-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:8372a2b976cf70654b2be6619ab6068acabb35f724c0fda7b277fbf53d66a5cf", size = 105161, upload-time = "2026-05-19T21:29:46.755Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/d4/cde059abfa229553b7298a2eadde2752e723d50aeedaef86ce59da2718ee/yarl-1.24.2-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:f9a1e9b622ca284143aab5d885848686dcd85453bb1ca9abcdb7503e64dc0056", size = 110619, upload-time = "2026-05-19T21:29:48.972Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/2c/d6a6c9a61549f7b6c7e6dc6937d195bcf069582b47b7200dcd0e7b256acf/yarl-1.24.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:810e19b685c8c3c5862f6a38160a1f4e4c0916c9390024ec347b6157a45a0992", size = 107362, upload-time = "2026-05-19T21:29:51Z" },
+    { url = "https://files.pythonhosted.org/packages/92/dd/3ae5fe417e9d1c353a548553326eb9935e76b6b727161563b424cc296df3/yarl-1.24.2-cp313-cp313-win_amd64.whl", hash = "sha256:7d37fb7c38f2b6edab0f845c4f85148d4c44204f52bc127021bd2bc9fdbf1656", size = 92667, upload-time = "2026-05-19T21:29:52.743Z" },
+    { url = "https://files.pythonhosted.org/packages/10/cc/a7beb239f78f27fca1b053c8e8595e4179c02e62249b4687ec218c370c50/yarl-1.24.2-cp313-cp313-win_arm64.whl", hash = "sha256:1e831894be7c2954240e49791fa4b50c05a0dc881de2552cfe3ffd8631c7f461", size = 87069, upload-time = "2026-05-19T21:29:54.442Z" },
+    { url = "https://files.pythonhosted.org/packages/40/0e/e08087695fc12789263821c5dc0f8dc52b5b17efd0887cacf419f8a43ba3/yarl-1.24.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:f9312b3c02d9b3d23840f67952913c9c8721d7f1b7db305289faefa878f364c2", size = 129670, upload-time = "2026-05-19T21:29:56.631Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/98/ab4b5ed1b1b5cd973c8a3eb994c3a6aefb6ce6d399e21bb5f0316c33815c/yarl-1.24.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:a4f4d6cd615823bfc7fb7e9b5987c3f41666371d870d51058f77e2680fbe9630", size = 91916, upload-time = "2026-05-19T21:29:58.645Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/b1/5297bb6a7df4782f7605bffc43b31f5044070935fbbcaa6c705a07e6ac65/yarl-1.24.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:0c3063e5c0a8e8e62fae6c2596fa01da1561e4cd1da6fec5789f5cf99a8aefd8", size = 91625, upload-time = "2026-05-19T21:30:00.412Z" },
+    { url = "https://files.pythonhosted.org/packages/02/a7/45baabfff76829264e623b185cff0c340d7e11bf3e1cd9ea37e7d17934bd/yarl-1.24.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fecd17873a096036c1c87ab3486f1aef7f269ada7f23f7f856f93b1cc7744f14", size = 104574, upload-time = "2026-05-19T21:30:02.544Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/40/3a5ab144d3d650ca37d4f4b57e56169be8af3ca34c448793e064b30baaed/yarl-1.24.2-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:a46d1ab4ba4d32e6dc80daf8a28ce0bd83d08df52fbc32f3e288663427734535", size = 97534, upload-time = "2026-05-19T21:30:04.319Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/b5/5658fef3681fb5776b4513b052bec750009f47b3a592251c705d75375798/yarl-1.24.2-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:73e68edf6dfd5f73f9ca127d84e2a6f9213c65bdffb736bda19524c0564fcd14", size = 111481, upload-time = "2026-05-19T21:30:05.988Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/06/fdcd7dde037f00866dce123ed4ba23dba94beb56fc4cf561668d27be37f2/yarl-1.24.2-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a296ca617f2d25fbceafb962b88750d627e5984e75732c712154d058ae8d79a3", size = 111529, upload-time = "2026-05-19T21:30:07.738Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/53/d81269aaafccea0d33396c03035de997b743f11e648e6e27a0df99c72980/yarl-1.24.2-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e51b2cf5ec89a8b8470177641ed62a3ba22d74e1e898e06ad53aa77972487208", size = 107338, upload-time = "2026-05-19T21:30:09.713Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/04/23049463f729bd899df203a7960505a75333edd499cda8aa1d5a82b64df5/yarl-1.24.2-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:310fc687f7b2044ec54e372c8cbe923bb88f5c37bded0d3079e5791c2fc3cf50", size = 106147, upload-time = "2026-05-19T21:30:11.365Z" },
+    { url = "https://files.pythonhosted.org/packages/14/18/04a4b5830b43ed5e4c5015b40e9f6241ad91487d71611061b4e111d6ac80/yarl-1.24.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:297a2fe352ecf858b30a98f87948746ec16f001d279f84aebdbd3bd965e2f1bd", size = 104272, upload-time = "2026-05-19T21:30:12.978Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/f7/8cffdf319aee7a7c1dbd07b61d91c3e3fda460c7a93b5f93e445f3806c4c/yarl-1.24.2-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:2a263e76b97bc42bdcd7c5f4953dec1f7cd62a1112fa7f869e57255229390d67", size = 99962, upload-time = "2026-05-19T21:30:15.001Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/39/b3cce3b7dbef64ac700ad4cea156a207d01bede0f507587616c364b5468e/yarl-1.24.2-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:822519b64cf0b474f1a0aaef1dc621438ea46bb77c94df97a5b4d213a7d8a8b1", size = 111063, upload-time = "2026-05-19T21:30:16.683Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/ea/100818505e7ebf165c7242ff17fdf7d9fee79e27234aeca871c1082920d7/yarl-1.24.2-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:b6067060d9dc594899ba83e6db6c48c68d1e494a6dab158156ed86977ca7bcb1", size = 105438, upload-time = "2026-05-19T21:30:18.769Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/d2/e075a0b32aa6625087de9e653087df0759fed5de4a435fef594181102a77/yarl-1.24.2-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:0063adad533e57171b79db3943b229d40dfafeeee579767f96541f106bac5f1b", size = 111458, upload-time = "2026-05-19T21:30:21.024Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/5c/ceea7ba98b65c8eb8d947fdc52f9bedfcd43c6a57c9e3c90c17be8f324a3/yarl-1.24.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ee8e3fb34513e8dc082b586ef4910c98335d43a6fab688cd44d4851bacfce3e8", size = 107589, upload-time = "2026-05-19T21:30:23.412Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/d9/5582d57e2b2db9b85eb6663a22efdd78e08805f3f5389566e9fcad254d1b/yarl-1.24.2-cp314-cp314-win_amd64.whl", hash = "sha256:afb00d7fd8e0f285ca29a44cc50df2d622ff2f7a6d933fa641577b5f9d5f3db0", size = 94424, upload-time = "2026-05-19T21:30:25.425Z" },
+    { url = "https://files.pythonhosted.org/packages/92/10/7dc07a0e22806a9280f42a57361395506e800c64e22737cd7b0886feab42/yarl-1.24.2-cp314-cp314-win_arm64.whl", hash = "sha256:68cf6eacd6028ef1142bc4b48376b81566385ca6f9e7dde3b0fa91be08ffcb57", size = 88690, upload-time = "2026-05-19T21:30:27.623Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/13/d5b8e2c8667db955bcb3de233f18798fefe7edf1d7429c2c9d4f9c401114/yarl-1.24.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:221ce1dd921ac4f603957f17d7c18c5cc0797fbb52f156941f92e04605d1d67b", size = 136248, upload-time = "2026-05-19T21:30:29.297Z" },
+    { url = "https://files.pythonhosted.org/packages/de/46/a4a97c05c9c9b8fd266bb2a0df12992c7fbd02391eb9640583411b6dab32/yarl-1.24.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:5f3224db28173a00d7afacdee07045cc4673dfab2b15492c7ae10deddbece761", size = 95084, upload-time = "2026-05-19T21:30:31.031Z" },
+    { url = "https://files.pythonhosted.org/packages/95/b2/845cf2074a015e6fe0d0808cf1a2d9e868386c4220d657ebd8302b199043/yarl-1.24.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c557165320d6244ebe3a02431b2a201a20080e02f41f0cfa0ccc47a183765da8", size = 95272, upload-time = "2026-05-19T21:30:33.062Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/16/e69d4aa244aef45235ddfebc0e04036a6829842bc5a6a795aedc6c998d23/yarl-1.24.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:904065e6e85b1fa54d0d87438bd58c14c0bad97aad654ad1077fd9d87e8478ed", size = 101497, upload-time = "2026-05-19T21:30:34.842Z" },
+    { url = "https://files.pythonhosted.org/packages/15/94/c07107715d621076863ee88b3ddf183fa5e9d4aba5769623c9979828410a/yarl-1.24.2-cp314-cp314t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:8cec2a38d70edc10e0e856ceda886af5327a017ccbde8e1de1bd44d300357543", size = 94002, upload-time = "2026-05-19T21:30:37.724Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/35/fc1bbdd895b5e4010b8fdd037f7ed3aa289d3863e08231b30231ca9a0815/yarl-1.24.2-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e7484b9361ed222ee1ca5b4337aa4cbdcc4618ce5aff57d9ef1582fd95893fc0", size = 106524, upload-time = "2026-05-19T21:30:40.196Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/f2/32b66d0a4ba47c296cf86d03e2c67bff58399fe6d6d84d5205c04c66cc6d/yarl-1.24.2-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:84f9670b89f34db07f81e53aee83e0b938a3412329d51c8f922488be7fcc4024", size = 106165, upload-time = "2026-05-19T21:30:41.888Z" },
+    { url = "https://files.pythonhosted.org/packages/95/47/37cb5ff50c5e825d4d38e81bb04d1b7e96bf960f7ab89f9850b162f3f114/yarl-1.24.2-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:abb2759733d63a28b4956500a5dd57140f26486c92b2caedfb964ab7d9b79dbf", size = 103010, upload-time = "2026-05-19T21:30:43.985Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/d2/4597912315096f7bb359e46e13bf8b60994fcbb2db29b804c0902ef4eff5/yarl-1.24.2-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:081c2bf54efe03774d0311172bc04fedf9ca01e644d4cd8c805688e527209bdc", size = 101128, upload-time = "2026-05-19T21:30:46.291Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/d5/c8e86e120521e646013d02a8e3b8884392e28494be8f392366e50d208efc/yarl-1.24.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:86746bef442aa479107fe28132e1277237f9c24c2f00b0b0cf22b3ee0904f2bb", size = 101382, upload-time = "2026-05-19T21:30:48.085Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/98/70b229236118f89dbeb739b76f10225bbf53b5497725502594c9a01d699a/yarl-1.24.2-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:2d07d21d0bc4b17558e8de0b02fbfdf1e347d3bb3699edd00bb92e7c57925420", size = 95964, upload-time = "2026-05-19T21:30:49.785Z" },
+    { url = "https://files.pythonhosted.org/packages/87/f8/56c386981e3c8648d279fdef2397ffec577e8320fd5649745e34d54faeb7/yarl-1.24.2-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:4fb1ac3fc5fecd8ae7453ea237e4d22b49befa70266dfe1629924245c21a0c7f", size = 106204, upload-time = "2026-05-19T21:30:51.862Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/1e/765afe97811ca35933e2a7de70ac57b1997ea2e4ee895719ee7a231fb7e5/yarl-1.24.2-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:4da31a5512ed1729ca8d8aacde3f7faeb8843cde3165d6bcf7f88f74f17bb8aa", size = 101510, upload-time = "2026-05-19T21:30:53.62Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/78/393913f4b9039e1edd09ae8a9bbb9d539be909a8abf6d8a2084585bed4b7/yarl-1.24.2-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:533ded4dceb5f1f3da7906244f4e82cf46cfd40d84c69a1faf5ac506aa65ecbe", size = 105584, upload-time = "2026-05-19T21:30:55.962Z" },
+    { url = "https://files.pythonhosted.org/packages/78/87/deb17b7049bbe74ea11a713b86f8f27800cc1c8648b0b797243ebb4830ba/yarl-1.24.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:7b3a85525f6e7eeabcfdd372862b21ee1915db1b498a04e8bf0e389b607ff0bd", size = 103410, upload-time = "2026-05-19T21:30:57.962Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/be/f9f7594e23b5b93affff0318e4593c1920331bcaefda326cabcad94296a1/yarl-1.24.2-cp314-cp314t-win_amd64.whl", hash = "sha256:a7624b1ca46ca5d7b864ef0d2f8efe3091454085ee1855b4e992314529972215", size = 102980, upload-time = "2026-05-19T21:30:59.735Z" },
+    { url = "https://files.pythonhosted.org/packages/65/a4/ba80dccd3593ff1f01051a818694d07b58cb8232677ee9a22a5a1f93a9fc/yarl-1.24.2-cp314-cp314t-win_arm64.whl", hash = "sha256:e434a45ce2e7a947f951fc5a8944c8cc080b7e59f9c50ae80fd39107cf88126d", size = 91219, upload-time = "2026-05-19T21:31:01.934Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/4d/4b880086bd0d3e034d25647be1d830afc3e3f610e98c4ab3490af6b1b6d5/yarl-1.24.2-py3-none-any.whl", hash = "sha256:2783d9226db8797636cd6896e4de81feed252d1db72265686c9558d97a4d94b9", size = 53576, upload-time = "2026-05-19T21:31:03.909Z" },
 ]
 
 [[package]]

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -105,6 +105,8 @@ dev = [
     { name = "zuban", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 test = [
+    { name = "agent-framework-foundry", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "agent-framework-openai", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "azure-monitor-opentelemetry", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "mcp", extra = ["ws"], marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
     { name = "redis", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
@@ -135,6 +137,8 @@ dev = [
     { name = "zuban", specifier = "==0.8.2" },
 ]
 test = [
+    { name = "agent-framework-foundry", specifier = ">=1.10.1,<2" },
+    { name = "agent-framework-openai", specifier = ">=1.10.1,<2" },
     { name = "azure-monitor-opentelemetry" },
     { name = "mcp", extras = ["ws"] },
     { name = "redis" },
@@ -166,6 +170,35 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [{ name = "types-python-dateutil", specifier = "==2.9.0.20260518" }]
+
+[[package]]
+name = "agent-framework-foundry"
+version = "1.10.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "agent-framework-core", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "agent-framework-openai", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "aiohttp", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "azure-ai-inference", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "azure-ai-projects", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7f/8e/7c290f1e155b092f85d4042d1b8f489806a7f9350ecd01352460ded769f5/agent_framework_foundry-1.10.1.tar.gz", hash = "sha256:99384420e0bd34d526d296740594264766450acc106922fc1c40d263a3eb15ba", size = 48727, upload-time = "2026-07-10T03:42:28.968Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/72/d5/29b8beb1c0d11ee995aaa1da24e00993ef81d300b1c9cf0401607c121a5a/agent_framework_foundry-1.10.1-py3-none-any.whl", hash = "sha256:b53131ee22f1c6356ed289edbd30cfb6a0e7d88169dc2dd6386a601eb2ff11f2", size = 51175, upload-time = "2026-07-10T03:35:59.32Z" },
+]
+
+[[package]]
+name = "agent-framework-openai"
+version = "1.10.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "agent-framework-core", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "openai", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/10/fc/728e034884a8bcc2d707845a072e0ba5fa58cf1e17ec928cba9cf75b4f36/agent_framework_openai-1.10.1.tar.gz", hash = "sha256:c82e4d4da7196ee9068a8117c6036694361ef50dd9e4205b8f93e9bf86148a1e", size = 53583, upload-time = "2026-07-10T03:42:37.166Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ac/3b/065c07acf94abcd0399d0d40ce5623e85ffdac1d21cfadbe264824c7b7fd/agent_framework_openai-1.10.1-py3-none-any.whl", hash = "sha256:a4bb94577a7ecbc0d967f6dbcfa144d97da195537a5a669f3d6bbb3a70944f9c", size = 58692, upload-time = "2026-07-10T03:42:11.265Z" },
+]
 
 [[package]]
 name = "aiohappyeyeballs"
@@ -426,6 +459,37 @@ wheels = [
 ]
 
 [[package]]
+name = "azure-ai-inference"
+version = "1.0.0b9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "azure-core", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "isodate", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "typing-extensions", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4e/6a/ed85592e5c64e08c291992f58b1a94dab6869f28fb0f40fd753dced73ba6/azure_ai_inference-1.0.0b9.tar.gz", hash = "sha256:1feb496bd84b01ee2691befc04358fa25d7c344d8288e99364438859ad7cd5a4", size = 182408, upload-time = "2025-02-15T00:37:28.464Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4f/0f/27520da74769db6e58327d96c98e7b9a07ce686dff582c9a5ec60b03f9dd/azure_ai_inference-1.0.0b9-py3-none-any.whl", hash = "sha256:49823732e674092dad83bb8b0d1b65aa73111fab924d61349eb2a8cdc0493990", size = 124885, upload-time = "2025-02-15T00:37:29.964Z" },
+]
+
+[[package]]
+name = "azure-ai-projects"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "azure-core", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "azure-identity", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "azure-storage-blob", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "isodate", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "openai", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "typing-extensions", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7a/29/ab1a80ce483fcc36ec2ac0a3db8e043aa954700b34b77db43ed5f4f9c488/azure_ai_projects-2.3.0.tar.gz", hash = "sha256:6e3006b7b8aa51c6ff9db61ef4aac3717f8a712cd1a183d5a1d34e2eb33450bd", size = 27563233, upload-time = "2026-07-01T21:09:00.018Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/15/bd/7e64f2d6e43d19fc8cf464769804f947d997833eb4dce1c86c2ce76146d2/azure_ai_projects-2.3.0-py3-none-any.whl", hash = "sha256:1da20aeac9663740a97644efedbb9f59eb2a332d3e01bfde7aa03027936edf44", size = 349581, upload-time = "2026-07-01T21:09:04.32Z" },
+]
+
+[[package]]
 name = "azure-core"
 version = "1.41.0"
 source = { registry = "https://pypi.org/simple" }
@@ -536,6 +600,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ab/21/178fed00e9738e4c953e147d46f5f803bfeb3fde50b11efdb99ae016f05f/azure_monitor_opentelemetry_exporter-1.0.0b55.tar.gz", hash = "sha256:6701307124e5eeb1837b269ddafab0affb69020fdb842d7c5ff1a3122514595a", size = 342308, upload-time = "2026-07-01T23:59:14.53Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/70/80/c1e58ea1c7dd7452579ab98912e9a3aa9a5fdb22f24a676f3cdaac3ab096/azure_monitor_opentelemetry_exporter-1.0.0b55-py2.py3-none-any.whl", hash = "sha256:5f0bcfcfd36d82f3f55cf5fe894ea05c5c0a32d2e38adf571eaa0e2b655aeb9e", size = 251064, upload-time = "2026-07-01T23:59:16.305Z" },
+]
+
+[[package]]
+name = "azure-storage-blob"
+version = "12.30.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "azure-core", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "cryptography", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "isodate", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "typing-extensions", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3b/48/84a820d898267f662b5c06f7cd76fdb8a9e272b44aa9376cef3ec0f6a294/azure_storage_blob-12.30.0.tar.gz", hash = "sha256:2cd74d4d5731e5eb6b8d5c5056ee115a5e88f8fdf22517b739836fda685018be", size = 618229, upload-time = "2026-06-08T11:45:35.575Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5e/0b/e106f0fd7fa785867d9ffcc47dc9e6237c0e58f51058473b777487a98edc/azure_storage_blob-12.30.0-py3-none-any.whl", hash = "sha256:d415ac50b67a8da6b3ae7e9f1014b1b55cd7aafa0b8d4ca9b380568dc7360423", size = 435610, upload-time = "2026-06-08T11:45:37.213Z" },
 ]
 
 [[package]]
@@ -1040,6 +1119,15 @@ wheels = [
 ]
 
 [[package]]
+name = "distro"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722, upload-time = "2023-12-24T09:54:32.31Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277, upload-time = "2023-12-24T09:54:30.421Z" },
+]
+
+[[package]]
 name = "docutils"
 version = "0.23"
 source = { registry = "https://pypi.org/simple" }
@@ -1438,6 +1526,105 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/54/4d/e940025e2ce31a8ce1202635910747e5a87cc3a6a6bb2d00973375014749/isodate-0.7.2.tar.gz", hash = "sha256:4cd1aa0f43ca76f4a6c6c0292a85f40b35ec2e43e315b59f06e6d32171a953e6", size = 29705, upload-time = "2024-10-08T23:04:11.5Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/15/aa/0aca39a37d3c7eb941ba736ede56d689e7be91cab5d9ca846bde3999eba6/isodate-0.7.2-py3-none-any.whl", hash = "sha256:28009937d8031054830160fce6d409ed342816b543597cece116d966c6d99e15", size = 22320, upload-time = "2024-10-08T23:04:09.501Z" },
+]
+
+[[package]]
+name = "jiter"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1d/1f/10936e16d8860c70698a1aa939a46aa0224813b782bce4e000e637da0b2d/jiter-0.16.0.tar.gz", hash = "sha256:7b24c3492c5f4f84a37946ad9cf504910cf6a782d6a4e0689b6673c5894b4a1c", size = 176431, upload-time = "2026-06-29T13:05:13.657Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/76/d8/b959609e44012a42b1f3e5ba98ea3b33c7e41e6d4b77cd8f00fd19b1d3ad/jiter-0.16.0-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:c5fc4f8def331036a7b8e981b4347ebe409981edbc8308a5ea842b8c3614fa6c", size = 310082, upload-time = "2026-06-29T13:02:31.356Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/3d/4d7f5667ea0e0548534ba880b84bb3d12924fd133aa83ad6c6c80fca3d76/jiter-0.16.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:5a71d0d2014c3275043e1170bf3d4e771493cb0dcf07be54c567155f4d8ee64b", size = 315643, upload-time = "2026-06-29T13:02:33.204Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/83/bed2dcb5c9f3e1ccfcbc67dda48265fe7d5ad0c9cadda5fe95f6e3b87f94/jiter-0.16.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:741eed508c233a76313a1c7b001f8f21b82f14327e9196ae8bd29a2cc164ae84", size = 341363, upload-time = "2026-06-29T13:02:34.853Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/2f/6bb3c3dda668ebc0445689c81a2b0f26a82b10843d67ed9c9b2c3edc177f/jiter-0.16.0-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3fb7bc819187b56dc48aa5c833aaf92257da8e07efdb9306156667bd2eeb491c", size = 365483, upload-time = "2026-06-29T13:02:36.295Z" },
+    { url = "https://files.pythonhosted.org/packages/92/35/8a045ccb39164e70dcdae696413b661771f148b68b12b175c3a04d901937/jiter-0.16.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7c9610fd25ebccb43fca584136f5c2fbb26802447eccd430dfdbab95a0fd5126", size = 461219, upload-time = "2026-06-29T13:02:38.116Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/99/22292dbbf0ed0c610cfe5ddc7f3bd67237a412f121318f865196e62a07bd/jiter-0.16.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4a1d68ff7ca1d3b5dee20a97a3decda7d5f15003823bf6d140c81f8561d3bc5c", size = 374905, upload-time = "2026-06-29T13:02:40.357Z" },
+    { url = "https://files.pythonhosted.org/packages/29/ac/2f55ccb1f0eeafa6d89d24caf52f6f0944a59290ee199e9ade62177dca42/jiter-0.16.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fb08c276dd02dac3a284acdd02cacc630d2e3cd6572a4b85519f35cbd133c3de", size = 348320, upload-time = "2026-06-29T13:02:41.923Z" },
+    { url = "https://files.pythonhosted.org/packages/50/e3/7d88b9174c40064fabc07c84a9b62e6b10f5644562ec0e0a29392edbe978/jiter-0.16.0-cp310-cp310-manylinux_2_31_riscv64.whl", hash = "sha256:8fc4d94713c4697347e38faf7d6ef91547c142219bdcfc7220c4870879974244", size = 356519, upload-time = "2026-06-29T13:02:43.436Z" },
+    { url = "https://files.pythonhosted.org/packages/27/57/c4a33aeef513a9d5e26e31534e0bcc752d6ea0e54c94ddb7b68bade669c2/jiter-0.16.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1a0f05e229edb29e68cdd0ccb83cea13b64263416120cf943767a6fd72e6787f", size = 394204, upload-time = "2026-06-29T13:02:44.987Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/70/c6c23e76ebb3766b111bc399437bbc9f870a76e2a92e10b2a5f561d57372/jiter-0.16.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:2c842cbf374a8daf50b2c04212995bee34ca2ac2cdc29a901b4cdb072c9c4131", size = 521477, upload-time = "2026-06-29T13:02:46.724Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/d3/0001c8c0c5976af2625bb1cfb1895e8ec693b6589fe4574b8e6fc2c85501/jiter-0.16.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:5ed466aee31294d7cdcd4d37dfe5c42c97bc29d9a5f00eacf24504358309cb9b", size = 552187, upload-time = "2026-06-29T13:02:48.144Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/76/311b718e07e85740e48619c0632b36f7e0b8d113984499e436452ed13a9a/jiter-0.16.0-cp310-cp310-win32.whl", hash = "sha256:b42e9ff5376819c053da25809a8d4b6fa6e473b4856ebe42e298ac958be3d7f9", size = 206513, upload-time = "2026-06-29T13:02:49.515Z" },
+    { url = "https://files.pythonhosted.org/packages/db/7f/ac680eeb0777dc0eb7dc824800ba27880d7f6bc712e362d34ad8ee559f36/jiter-0.16.0-cp310-cp310-win_amd64.whl", hash = "sha256:10438939205546132189c8e74a2d536a707841f3a25cd7c74ee91fe503407a26", size = 199505, upload-time = "2026-06-29T13:02:50.829Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/3f/fae6cc967d120ec89e31c5418a51176d8278b3087fbb384a9176754f353c/jiter-0.16.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:67fddeda1688f0cce2d2ae83ccf8a80f79936f2d2997d6cc2261f82fdb54a4d3", size = 309289, upload-time = "2026-06-29T13:02:52.301Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/e3/97c6c3562c077f6247d6e6ce5c82562500b6316c0d928e97e106b7a1321a/jiter-0.16.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:c90c0f63df322be920eda6ce622e3083d8906ba267f8220fe7873213b8b4430e", size = 315181, upload-time = "2026-06-29T13:02:53.964Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/89/d8d073f8aa2667e46c6c0873f86fe4a512bba4293cc730f626a076211a62/jiter-0.16.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:64c0203212098470032aabcde9356fc168f377aade3e43def61dfe17e92f2037", size = 340939, upload-time = "2026-06-29T13:02:55.412Z" },
+    { url = "https://files.pythonhosted.org/packages/87/c9/db4fda3ed73fb864139305e935e5b8b38a5a24692a5a9dd356c22f1b9c8d/jiter-0.16.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:12288303c9844e61e1651d02a9a6f6633e47d39f897d6991d1427161ce6b746e", size = 364932, upload-time = "2026-06-29T13:02:57.28Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/74/52b5e86241057f52ddd7c9a580f90effb51f9d06239f6fc612279b91a838/jiter-0.16.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5cf109d010b4b05a105afb3d43be36a21322d345ad3111e13d15f680afef0e5b", size = 461132, upload-time = "2026-06-29T13:02:58.994Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/87/544a700f7447c1f31c5d7833821a4daa5683165c2d5a094fbf5b5800c3dc/jiter-0.16.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:62c1b7fe1f77925acf5af68b6140b8810fa87dfd4dc0a9c8568ec2fa2a10429c", size = 374857, upload-time = "2026-06-29T13:03:00.455Z" },
+    { url = "https://files.pythonhosted.org/packages/40/cd/0fcc3f7d39183674d5bfa9ec640faaeb506c60be7c8f94625dfba366e37c/jiter-0.16.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8597d23c87f59294f83bcb6229b9ed1fccee13dbba967b46930d2f1759466fee", size = 347053, upload-time = "2026-06-29T13:03:02.045Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/ae/c7e64e7932ad597fa395b61440b249ada6366716e25c6e08dd2afbd021e6/jiter-0.16.0-cp311-cp311-manylinux_2_31_riscv64.whl", hash = "sha256:3126a5dbad56401989ac769aca0cb56005bfb3e2366eea0ca99d1a91c3c1ee03", size = 356153, upload-time = "2026-06-29T13:03:03.706Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/1c/1c719044f14da814e1a060191ab19b96f3e99207bc5b4bfc6d6be34b3f80/jiter-0.16.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c4b4717bdb35ae456f831a6b08d01880fff399887a6bbc526a583a406e484eea", size = 393956, upload-time = "2026-06-29T13:03:05.165Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/dc/7b2f303a2847207e265503853a2d964a55354cffd62a5f2936c155486798/jiter-0.16.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:adff21bc78edfe086c15eb495b900306076de378dc2337c132401fc39bd79c91", size = 521081, upload-time = "2026-06-29T13:03:06.886Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/5f/501cf6e1e09caeb420195179ffc6f62aca603f1220ec53fd80d0d70b3e56/jiter-0.16.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:dab907db06fc593645e73109acf4581ba5b548897d28b9348dc41ddc8343b2d3", size = 552085, upload-time = "2026-06-29T13:03:08.339Z" },
+    { url = "https://files.pythonhosted.org/packages/79/54/aa5be86520113b79455c3877f3d1f07a348098df4083ba3688e9537e52dd/jiter-0.16.0-cp311-cp311-win32.whl", hash = "sha256:560b2cf3fb03240cd34f27409a238547488708f05b7c3924f571a60422251ec7", size = 206755, upload-time = "2026-06-29T13:03:09.653Z" },
+    { url = "https://files.pythonhosted.org/packages/64/ec/2feb893eb330bd69b413866f4d5daada33c3962f1c6f270c91ca2d87fdf9/jiter-0.16.0-cp311-cp311-win_amd64.whl", hash = "sha256:e431cfc9caf44c1d5459ff77d4e64cbf85fddb6a35dad836a15c6a9ec23087c1", size = 199155, upload-time = "2026-06-29T13:03:10.979Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/9c/ca040d94415048a3666fc237774df8151c96f8d2b661cbe3b184acc95876/jiter-0.16.0-cp311-cp311-win_arm64.whl", hash = "sha256:2a8e9e39cf083016137aa5cadafe3188adc2ba6ba1fbf1e5d18889ad3e9ad056", size = 194403, upload-time = "2026-06-29T13:03:12.341Z" },
+    { url = "https://files.pythonhosted.org/packages/83/2b/52ace16ed031354f0539749a49e4bf33797d82bea5137910835fa4b09793/jiter-0.16.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:67c3bc1760f8c99d805dcab4e644027142a53b1d5d861f18780ebdbd5d40b72a", size = 306943, upload-time = "2026-06-29T13:03:14.035Z" },
+    { url = "https://files.pythonhosted.org/packages/94/2e/34957c2c1b661c252ba9bcc60ae0bddc27e0f7202c6073326a13c5390eec/jiter-0.16.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:5af7780e4a26bd7d0d989592bf9ef12ebf806b74ab709223ecca37c749872ea9", size = 307779, upload-time = "2026-06-29T13:03:15.418Z" },
+    { url = "https://files.pythonhosted.org/packages/88/6c/59bd309cab4460c54cf1079f3eb7fe7af6a4c895c5c957a53378693bad2b/jiter-0.16.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d5bf78d0e05e45cfdd66558893938d59afe3d1b1a824a202039b20e607d25a72", size = 335826, upload-time = "2026-06-29T13:03:17.11Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/8c/f5ef7b65f0df47afa16596969defb281ebb86e96df346d62be6fd853d620/jiter-0.16.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f4444a83f946605990c98f625cdd3d2725bfb818158760c5748c653170a20e0e", size = 362573, upload-time = "2026-06-29T13:03:18.781Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/0b/ace4354da061ee38844a0c27dc2c21eecd27aea119e8da324bea987522d0/jiter-0.16.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3a23f0e4f957e1be65752d2dfac9a5a06b1917af8dc85deb639c3b9d02e31290", size = 457979, upload-time = "2026-06-29T13:03:20.293Z" },
+    { url = "https://files.pythonhosted.org/packages/55/40/c0253d3772eb9dcd8e6606ee9b2d53ec8e5b814589c47f140aa585f21eaa/jiter-0.16.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c22a488f7b9218e245a0025a9ba6b100e2e54700831cf4cf16833a27fba3ad01", size = 372302, upload-time = "2026-06-29T13:03:21.739Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/d2/4839422241aa12860ce597b20068727094ba0bc480723c74924ca5bad483/jiter-0.16.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:46add52f4ad47a08bfb1219f3e673da972191489a33016edefdb5ea55bfa8c48", size = 343805, upload-time = "2026-06-29T13:03:23.384Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/59/e196888a05befdda7dbe299b722d56f2f6eec65402bc34c0a3306d595feb/jiter-0.16.0-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:9c8a956fd72c2cf1e730d01ea080341f13aa0a97a4a33b51abebe725b7ae9ca9", size = 351107, upload-time = "2026-06-29T13:03:24.815Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/74/4cd9e0fca65232136400354b630fbfcd2de634e22ccbb96567725981b548/jiter-0.16.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:561926e0573ffe4a32498420a76d64b16c513e1ab413b9d28158a8764ac701e5", size = 388441, upload-time = "2026-06-29T13:03:26.266Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/8c/554691e48bc711299c0a293dd8a6179e24b2d66a54dc295421fcf64569c0/jiter-0.16.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:44d019fa8cdaf89bf29c71b39e3712143fdd0ac76725c6ef954f9957a5ea8730", size = 516354, upload-time = "2026-06-29T13:03:28.02Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/cb/01e9d69dc2cc6759d4f91e230b34489c4fdb2518992650633f9e20bece89/jiter-0.16.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:0df91907609837f33341b8e6fe73b95991fdaa57caf1a0fbd343dffe826f386f", size = 547880, upload-time = "2026-06-29T13:03:29.534Z" },
+    { url = "https://files.pythonhosted.org/packages/79/70/2953195f1c6ad00f49fa67e13df7e60acb3dd4f387101bc15abccddd905e/jiter-0.16.0-cp312-cp312-win32.whl", hash = "sha256:51d7b836acb0108d7c77df1742332cac2a1fa04a74d6dacec46e7091f0e91274", size = 203473, upload-time = "2026-06-29T13:03:31.025Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/05/2909a8b10699a4d560f8c502b6b2c5f3991b682b1922c1eedda242b225bd/jiter-0.16.0-cp312-cp312-win_amd64.whl", hash = "sha256:1878349266f8ee36ecb1375cc5ba2f115f35fd9f0a1a4119e725e379126647f7", size = 196905, upload-time = "2026-06-29T13:03:32.472Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/a9/6b82bb1c8d7790d602489b967b982a909e5d092875a6c2ade96444c8dfc5/jiter-0.16.0-cp312-cp312-win_arm64.whl", hash = "sha256:2ed5738ae4af18271a51a528b8811b0cbfa4a1858de9d83359e4169855d6a331", size = 190618, upload-time = "2026-06-29T13:03:34.672Z" },
+    { url = "https://files.pythonhosted.org/packages/91/c0/555fc60473d30d66894ba825e63615e3be7524fac23858356afa7a38906c/jiter-0.16.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:41977aa5654023948c2dae2a81cbf9c43343954bef1cd59a154dd15a4d84c195", size = 306203, upload-time = "2026-06-29T13:03:36.243Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/2b/c3eaf16f5d7c9bad66ea32f40a95bd169b29a91217fcc7f081375157e99c/jiter-0.16.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:d28bb3c26762358dadf3e5bf0bccd29ae987d65e6988d2e6f49829c76b003c09", size = 306489, upload-time = "2026-06-29T13:03:37.846Z" },
+    { url = "https://files.pythonhosted.org/packages/96/3f/02fdfc6705cad96127d883af5c34e4867f554f29ec7705ec1a46156400a9/jiter-0.16.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0542a7189c26920778658fc8fcf2af8bae05bae9924577f71804acef37996536", size = 335453, upload-time = "2026-06-29T13:03:39.221Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/a6/e4bda5920d4b0d7c5dfb7174ce4a6b2e4d3e11c9162c452ef0eab4cdbdbd/jiter-0.16.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8fb8de1e23a0cb2a7f53c335049c7b72b6db41aa6227cdcc0972a1de5cb39450", size = 361625, upload-time = "2026-06-29T13:03:40.597Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/97/4e6b59b2c6e55cbb3e183595f81ad65dcfb21c915fee5e19e335df21bc55/jiter-0.16.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b72d0b2990ca754a9102779ac98d8597b7cb31678958562214a007f909eab78e", size = 456958, upload-time = "2026-06-29T13:03:42.074Z" },
+    { url = "https://files.pythonhosted.org/packages/15/e0/97e9557686d2f94f4b93786eccb7eed28e9228ad132ea8237f44727314a7/jiter-0.16.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d5f91b1c27fc22a57993d5a5cb8a627cb8ed4b10502716fac1ffbfe1d19d84e8", size = 372017, upload-time = "2026-06-29T13:03:43.658Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/94/db768b6938e0df35c86beeba3dfbbb025c9ee5c19e1aa271f2396e50864d/jiter-0.16.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c682bea068a90b764577bdb78a60a4c1d1606daf9cd4c893832a37c7cc9d9026", size = 343320, upload-time = "2026-06-29T13:03:45.226Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/d6/5a59d938244a30735fe62d9433fd325f9021ea29d89780ea4596ea93bc89/jiter-0.16.0-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:8d031aabecc4f1b6276adfb42e3aabb77c89d468bf616600e8d3a11328929053", size = 350520, upload-time = "2026-06-29T13:03:46.671Z" },
+    { url = "https://files.pythonhosted.org/packages/67/f8/c4a857f49c9af125f6bbcac7e3eee7f7978ed89682833062e2dbf62576b1/jiter-0.16.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:eab2cd170150e70153de16896a1774e3a1dca80154c56b54d7a812c479a7165e", size = 387550, upload-time = "2026-06-29T13:03:48.361Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/d6/5fbc2f7d6b67b754caa61a993a2e626e815dec47ffc2f9e35f01adfebec7/jiter-0.16.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:6edb63a46e65a82c26800a868e49b2cac30dd5a4218b88d74bc2c848c8ad60bb", size = 515424, upload-time = "2026-06-29T13:03:49.881Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/54/284f0164b64a5fed915fea6ba7e9ba9b3d8d37c67d59cf2e3bb99d45cdfe/jiter-0.16.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:659039cc50b5addcc35fcc87ae2c1833b7c0a8e5326ef631a75e4478447bcf84", size = 546981, upload-time = "2026-06-29T13:03:51.363Z" },
+    { url = "https://files.pythonhosted.org/packages/13/c5/2a467585a576594384e1d2c43e1224deaafc085f24e243529cf98beef8e1/jiter-0.16.0-cp313-cp313-win32.whl", hash = "sha256:c9c53be232c2e206ef9cdbad81a48bfa74c3d3f08bcf8124630a8a748aad993e", size = 202853, upload-time = "2026-06-29T13:03:53.015Z" },
+    { url = "https://files.pythonhosted.org/packages/88/6a/de61d04b9eec69c71719968d2f716532a3bc121170c44a39e14979c6be81/jiter-0.16.0-cp313-cp313-win_amd64.whl", hash = "sha256:baad945ed47f163ad833314f8e3288c396118934f94e7bbb9e243ce4b341a4fd", size = 196160, upload-time = "2026-06-29T13:03:54.447Z" },
+    { url = "https://files.pythonhosted.org/packages/19/4b/b390ed59bafb3f31d008d1218578f10327714484b334439947f7e5b11e7f/jiter-0.16.0-cp313-cp313-win_arm64.whl", hash = "sha256:3c1fd2dbe1b0af19e987f03fe66c5f5bd105a2229c1aff4ab14890b24f41d21a", size = 189862, upload-time = "2026-06-29T13:03:55.754Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/89/bc4f1b57d5da938fd344a466396541e586d161320d70bffd929aaafcd8f4/jiter-0.16.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:b2c61484666ad42726029af0c00ef4541f0f3b5cdc550221f56c2343208018ee", size = 308239, upload-time = "2026-06-29T13:03:57.205Z" },
+    { url = "https://files.pythonhosted.org/packages/65/7a/c415453e5213001bf3b411ff65dec3d303b0e76a4a2cfea9768cd4960994/jiter-0.16.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:63efadc657488f45db1c676d81e704cac2abf3fdb892def1faea61db053127e2", size = 308928, upload-time = "2026-06-29T13:03:58.643Z" },
+    { url = "https://files.pythonhosted.org/packages/11/fc/1f4fb7ebf9a724c7741994f4aae18fba1e2f3133df14521a79194952c34a/jiter-0.16.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cf0d73f50e7b6935677854f6e8e31d499ca7064dd24734f703e060f5b237d883", size = 336998, upload-time = "2026-06-29T13:04:00.071Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/8d/72cadaac05ccfa7cc3a0a2232862e6c72443ca40cf300ba8b57f9f18b69b/jiter-0.16.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:bf3ea07d9bc8e7d03a9fbc051295462e6dbc295b894fd72457c3136e3e43d898", size = 362112, upload-time = "2026-06-29T13:04:01.52Z" },
+    { url = "https://files.pythonhosted.org/packages/58/4a/c4b0d5f651fda90a24ffce9f8d56cde462a2e09d31ae3de3c68cef34c04e/jiter-0.16.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:26798522707abb47d767db536e4148ceac1b14446bf028ee85e579a2e043cfe5", size = 459807, upload-time = "2026-06-29T13:04:03.214Z" },
+    { url = "https://files.pythonhosted.org/packages/80/58/ef77879ea9aa56b50824edc5a445e226422c7a8d211f3fd2a56bcb9493cf/jiter-0.16.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:bc837c1b9631be10abfe0191537fe8009838204cec7e44827401ace390ddb567", size = 373181, upload-time = "2026-06-29T13:04:04.629Z" },
+    { url = "https://files.pythonhosted.org/packages/49/2e/ffbc3f254e4d8a66da3062c624a7df4b7c2b2cf9e1fe43cf394b3e104041/jiter-0.16.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:49060fd70737fad59d33ba9dcc0d83247dc9e77187de26053a19c16c9f32bd69", size = 344927, upload-time = "2026-06-29T13:04:06.067Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/f6/0be5dc6d64a89f80aa8fec984f94dedb2973e251edcae55841d60786d578/jiter-0.16.0-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:adbb8edeadd431bc4477879d5d371ece7cb1334486584e0f252656dd7ffada29", size = 352754, upload-time = "2026-06-29T13:04:07.477Z" },
+    { url = "https://files.pythonhosted.org/packages/da/6e/7d31243b3b91cd261dd19e9d3557fc3251a80883d3d8049c86174e7ab7af/jiter-0.16.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:31aaee5b80f672c1dc21272bcfb9cbdcfc1ea04ff50f00ed5af500b80c44fa93", size = 390553, upload-time = "2026-06-29T13:04:08.92Z" },
+    { url = "https://files.pythonhosted.org/packages/25/33/51ae371fde3c88897520f62b4d5f8b27ad7103e2bb10812ff52195609853/jiter-0.16.0-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:6722bcef4ffc86c835574b1b2fac6b33b9fb4a889c781e67950e891591f3c55a", size = 516900, upload-time = "2026-06-29T13:04:10.407Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/45/6449b3d123ea439ba79507c657288f461d55049e7bcbdc2cf8eb8210f491/jiter-0.16.0-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:5ab4f50ff971b611d656554ea10b75f80097392c827bc32923c6eeb6386c8b00", size = 548754, upload-time = "2026-06-29T13:04:12.046Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/e7/fd2fb11ae3e2649333da3aa170d04d7b3000bbdc3b270f6513382fdf4e04/jiter-0.16.0-cp314-cp314-pyemscripten_2026_0_wasm32.whl", hash = "sha256:710cc51d4ebdcd3c1f70b232c1db1ea1344a075770422bbd4bede5708335acbe", size = 122381, upload-time = "2026-06-29T13:04:13.413Z" },
+    { url = "https://files.pythonhosted.org/packages/26/80/f0b147a62c315a164ed2168908286ca302310824c218d3aae52b06c0c9a9/jiter-0.16.0-cp314-cp314-win32.whl", hash = "sha256:57b37fc887a32d44798e4d8ebfa7c9683ff3da1d5bf38f08d1bb3573ccb39106", size = 204578, upload-time = "2026-06-29T13:04:14.813Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/e6/4758a14304b4523a6f5adb2419340086aa3593bd4327c2b25b5948a90548/jiter-0.16.0-cp314-cp314-win_amd64.whl", hash = "sha256:cbd18dd5e2df96b580487b5745adf57ef64ad89ba2d9662fc3c19386acce7db8", size = 198154, upload-time = "2026-06-29T13:04:16.272Z" },
+    { url = "https://files.pythonhosted.org/packages/26/be/41fa54a2e7ea41d6c99f1dc5b1f0fd4cb474680304b5d268dd518e81da3a/jiter-0.16.0-cp314-cp314-win_arm64.whl", hash = "sha256:a32d2027a9fa67f109ff245a3252ece3ccc32cc56703e1deab6cc846a59e0585", size = 191458, upload-time = "2026-06-29T13:04:17.707Z" },
+    { url = "https://files.pythonhosted.org/packages/81/6b/59127338b86d9fe4d99418f5a15118bea778103ee0fe9d9dd7e0af174e95/jiter-0.16.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:2577196f4474ef3fc4779a088a23b0897bbf86f9ea3679c372d45b8383b43207", size = 316739, upload-time = "2026-06-29T13:04:19.663Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/95/49461034d5388196d3dabf98748935f017b7785d8f3f5349f834bcc4ed0d/jiter-0.16.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:616e89e008a93c01104161c75b4988e58716b01d62307ebfe161e52a56d2a818", size = 340911, upload-time = "2026-06-29T13:04:21.257Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/97/a4369f2fb82cb3dda13b98622f31249b2e014b223fe64ee534413ad72294/jiter-0.16.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0e2e9efbe042210df657bade597f66d6d75723e3d8f45a12ea6d8167ff8bbce3", size = 361747, upload-time = "2026-06-29T13:04:22.677Z" },
+    { url = "https://files.pythonhosted.org/packages/28/51/49b6ed456261646e1906016a6760367a28aacd3c24805e4e5fe64116c1db/jiter-0.16.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3f4d9e473a5ce7d27fef8b848df4dc16e283893d3f53b4a585e72c9595f3c284", size = 460225, upload-time = "2026-06-29T13:04:24.441Z" },
+    { url = "https://files.pythonhosted.org/packages/33/b5/5689aff4f66c5b60be63106e591dbfcba2190df97d2c9c7cf052361ddb98/jiter-0.16.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8d30a4a1c87713060c8d1cc59a7b6c8fb6b8ef0a6900368014c76c87922a2929", size = 373169, upload-time = "2026-06-29T13:04:25.884Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/96/3ae1b85ee0d6d6cab254fb7f8da018272b932bbf2d69b07e98aa2a96c746/jiter-0.16.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bae96332410f866e5900d809298b1ed82735932986c672495f9701daacd80620", size = 350332, upload-time = "2026-06-29T13:04:27.302Z" },
+    { url = "https://files.pythonhosted.org/packages/15/32/c99d7bafd78986556c95bf60ce84c6cc98786eac56066c12d7f828bb6747/jiter-0.16.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:da3d7ec75dc83bb18bca888b5edfae0656a26849056c59e05a7728badd17e7af", size = 353377, upload-time = "2026-06-29T13:04:28.731Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/4b/f99a8e571287c3dec766bcc18528bbe8e8fb5365522ab5e6d64c93e87066/jiter-0.16.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:ee6162b77d49a9939229df666dfa8af3e656b6701b54c4c84966d740e189264e", size = 387746, upload-time = "2026-06-29T13:04:30.319Z" },
+    { url = "https://files.pythonhosted.org/packages/75/69/c78a5b3f71040e34eb5917df26fb7ae9a2174cad1ccbf277512507c53a6e/jiter-0.16.0-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:63ffdbdae7d4499f4cda14eadc12ddcabef0fc0c081191bdc2247489cb698077", size = 517292, upload-time = "2026-06-29T13:04:31.709Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/f7/095b38eda4c70d03651c403f29a5590f16d12ddc5d544aac9f9cddf72277/jiter-0.16.0-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:a111256a7193bea0759267b10385e5870949c239ed7b6ddbaaf57573edb38734", size = 549259, upload-time = "2026-06-29T13:04:33.721Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/c5/6a0207d90e5f656d95af98ebd0934f382d37674416f215aeda2ff8063e51/jiter-0.16.0-cp314-cp314t-win32.whl", hash = "sha256:de5ba8763e56b793561f43bed197c9ea55776daa5e9a6b91eed68a909bc9cdbf", size = 206523, upload-time = "2026-06-29T13:04:35.068Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/31/c757d5f30a8980fd945ce7b98be10be9e4ff59c7c42f5fd86804c2e87db8/jiter-0.16.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b8a3f9a6008048fe9def7bf465180564a6e458047d2ce499149cfbe73c3ae9db", size = 200366, upload-time = "2026-06-29T13:04:36.61Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/a2/d88de6d313d734a544a7901353ad5db67cb38dcfcd91713b7979dafc345d/jiter-0.16.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0fa25b09b13075c46f5bc174f2690525a925a4fc2f7c82969a2bbabff22386ce", size = 190516, upload-time = "2026-06-29T13:04:38.004Z" },
+    { url = "https://files.pythonhosted.org/packages/06/d3/8e278946d43eeca2585b4dd0834a887cd71136329b837f3a16ed86a8b4b0/jiter-0.16.0-graalpy311-graalpy242_311_native-macosx_10_12_x86_64.whl", hash = "sha256:850ccb1d7eedb4200f4014b1c0e8a577de114fc3cd88faad646dcc9bc4bb12ad", size = 304518, upload-time = "2026-06-29T13:05:00.172Z" },
+    { url = "https://files.pythonhosted.org/packages/72/43/28d4ef495028bf0506a413d4db3f4eb3e7288a382e0f065f306a17bbeb5e/jiter-0.16.0-graalpy311-graalpy242_311_native-macosx_11_0_arm64.whl", hash = "sha256:e34e97bda77eb63242a410243c071e28ac7e0d8c0948c5ee658498690a4b2f2f", size = 310207, upload-time = "2026-06-29T13:05:02.123Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/ca/c366b1012da1d640de975d9683acd44e4d150d9068845d0ca2610435253f/jiter-0.16.0-graalpy311-graalpy242_311_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b7dc85ea77d4abbae8bad0d3538678aedee75bceec4e2f6c8dfb1c74772e5aa5", size = 342771, upload-time = "2026-06-29T13:05:03.55Z" },
+    { url = "https://files.pythonhosted.org/packages/16/52/50cc4056fc1ae02e7154704e7ecc89df0afb8300222cfe8a52d3f67e4730/jiter-0.16.0-graalpy311-graalpy242_311_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:17ca7fae79f6d99cd9a042b75f917eaada7b895cfc7dd2ee3a16089dcaec7a85", size = 346468, upload-time = "2026-06-29T13:05:05.452Z" },
+    { url = "https://files.pythonhosted.org/packages/98/ab/664fd8c4be028b2bedd3d2ff08769c4ede23d0dbc87a77c62384a0515b5d/jiter-0.16.0-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:f17d61a28b4b3e0e3e2ba98490c70501403b4d196f78732439160e7fd3678127", size = 303106, upload-time = "2026-06-29T13:05:07.118Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/07/421f1d5b65493a76e16027b848aba6a7d28073ae75944fa4289cc914d39f/jiter-0.16.0-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:96e38eea538c8ddf853a35727c7be0741c76c13f04148ac5c116222f50ece3b3", size = 304658, upload-time = "2026-06-29T13:05:08.708Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/db/bba1155f01a01c3c37a89425d571da751bbedf5c54247b831a04cb971798/jiter-0.16.0-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d284fb8d94d5855d60c44fefcab4bf966f1da6fada73992b01f6f0c9bc0c6702", size = 339719, upload-time = "2026-06-29T13:05:10.41Z" },
+    { url = "https://files.pythonhosted.org/packages/78/f7/18a1afcd64f35314b68c1f23afcd9994d0bc13e65cc77517afff4e83986d/jiter-0.16.0-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:64d613743df53199b1aa256a7d328340da6d7078aac7705a7db9d7a791e9cfd2", size = 343885, upload-time = "2026-06-29T13:05:12.087Z" },
 ]
 
 [[package]]
@@ -1956,6 +2143,25 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0b/5f/19930f824ffeb0ad4372da4812c50edbd1434f678c90c2733e1188edfc63/oauthlib-3.3.1.tar.gz", hash = "sha256:0f0f8aa759826a193cf66c12ea1af1637f87b9b4622d46e866952bb022e538c9", size = 185918, upload-time = "2025-06-19T22:48:08.269Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/be/9c/92789c596b8df838baa98fa71844d84283302f7604ed565dafe5a6b5041a/oauthlib-3.3.1-py3-none-any.whl", hash = "sha256:88119c938d2b8fb88561af5f6ee0eec8cc8d552b7bb1f712743136eb7523b7a1", size = 160065, upload-time = "2025-06-19T22:48:06.508Z" },
+]
+
+[[package]]
+name = "openai"
+version = "2.46.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "distro", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "httpx", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "jiter", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "pydantic", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "sniffio", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "tqdm", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "typing-extensions", marker = "sys_platform == 'darwin' or sys_platform == 'linux' or sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/af/ac/f725c4efbda8657d02be684607e5a2e5ce362e4790fdbcbdfb7c15018647/openai-2.46.0.tar.gz", hash = "sha256:0421e0735ac41451cad894af4cddf0435bfbf8cbc538ac0e15b3c062f2ddc06a", size = 1114628, upload-time = "2026-07-17T02:48:06.05Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ea/7b/206238ebcb50b235942b1c66dba4974776f2057402a8d91c399be587d66a/openai-2.46.0-py3-none-any.whl", hash = "sha256:672381db55efb3a1e2610f29304c130cccdd0b319bace4d492b2443cb64c1e7c", size = 1637556, upload-time = "2026-07-17T02:48:03.695Z" },
 ]
 
 [[package]]
@@ -3257,6 +3463,15 @@ wheels = [
 ]
 
 [[package]]
+name = "sniffio"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
+
+[[package]]
 name = "sse-starlette"
 version = "3.4.5"
 source = { registry = "https://pypi.org/simple" }
@@ -3343,6 +3558,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/19/75/241269d1da26b624c0d5e110e8149093c759b7a286138f4efd61a60e75fe/tomli_w-1.2.0.tar.gz", hash = "sha256:2dd14fac5a47c27be9cd4c976af5a12d87fb1f0b4512f81d69cce3b35ae25021", size = 7184, upload-time = "2025-01-15T12:07:24.262Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/18/c86eb8e0202e32dd3df50d43d7ff9854f8e0603945ff398974c1d91ac1ef/tomli_w-1.2.0-py3-none-any.whl", hash = "sha256:188306098d013b691fcadc011abd66727d3c414c571bb01b1a174ba8c983cf90", size = 6675, upload-time = "2025-01-15T12:07:22.074Z" },
+]
+
+[[package]]
+name = "tqdm"
+version = "4.69.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8c/69/40407dfc835517f058b603dbf37a6df094d8582b015a51eddc988febbcb7/tqdm-4.69.0.tar.gz", hash = "sha256:700c5e85dcd5f009dd6222588a29180a193a748247a5d855b4d67db93d79a53b", size = 792569, upload-time = "2026-07-17T18:09:06.2Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fe/21/99a0cdaf54eb35e77623c41b5a2c9472ee4404bba687052791fe2aba6773/tqdm-4.69.0-py3-none-any.whl", hash = "sha256:9979978912be667a6ef21fd5d8abf54e324e63d82f7f43c360792ebc2bc4e622", size = 676680, upload-time = "2026-07-17T18:09:04.172Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Syncs `agent_framework_durabletask` with agent-framework `main` (including the workflow human-in-the-loop respond-URL addressing work that recently merged there) and adds the `agent_framework_azurefunctions` package to this repo, wiring both into the workspace, CI, and samples.

## What's included

- **durabletask**: source and tests synced from agent-framework `main` — HITL context, sub-workflow respond-URL addressing, and serialization hardening.
- **azurefunctions** (new package): `AgentFunctionApp`, `WorkflowHitlContext`, and the HITL run/status/respond routing.
- **Samples**: new `samples/azure_functions/` HITL samples (workflow and sub-workflow). Existing durabletask samples are unchanged.
- **Workspace**: `azurefunctions` added to members, sources, test paths, and bandit targets.
- **CI**: ruff, type checks, unit tests, and build now run for both packages.

## Type-checking

To keep this repo's synced source in parity with agent-framework (so future syncs need no per-repo adaptation), the type-check split now matches agent-framework:

- **Pyright (strict)** gates the package **sources**.
- **Relaxed mypy** gates the **tests** (`follow_imports = "silent"`).

Previously this repo gated sources with mypy, which conflicted with agent-framework's Pyright-tuned casts. The strict per-package `[tool.mypy]` source configs were removed.

## Validation

- Pyright (source): 0 errors, both packages
- mypy (tests): 0 issues, both packages
- Ruff: clean
- Unit tests: all pass

## Notes
- Core `agent-framework` stays an external dependency. `WorkflowHitlContext` and `AgentFunctionApp` are defined in `azurefunctions` and only lazily re-exported by core in agent-framework, so no core changes are needed here.
