### PR TITLE
Rename E2E pipeline to integration-tests

### DIFF
--- a/eng/README.md
+++ b/eng/README.md
@@ -11,9 +11,9 @@ Azure DevOps is used for jobs that need a more controlled execution environment,
 | Path | Purpose |
 | --- | --- |
 | `eng/ci/code-mirror.yml` | Mirrors the GitHub repository into Azure Repos so Azure DevOps can run trusted pipelines from a controlled copy of the source. |
-| `eng/ci/e2e-tests.yml` | Runs scheduled and manual end-to-end tests that reach Azure models through a service connection identity. |
+| `eng/ci/integration-tests.yml` | Runs integration tests on pull requests and on a daily schedule, reaching Azure models through a service connection identity. |
 | `eng/ci/package-release.yml` | Builds package artifacts and, when explicitly enabled, publishes .NET and Python packages. |
-| `eng/templates/jobs/` | Reusable jobs for shared test infrastructure and language-specific E2E test runs. |
+| `eng/templates/jobs/` | Reusable jobs for shared test infrastructure and language-specific integration test runs. |
 | `eng/templates/official/jobs/` | Reusable jobs for package build and release stages. |
 
 ## Test approach
@@ -23,16 +23,16 @@ Pull requests should continue to rely on GitHub Actions for fast validation:
 - .NET restore, build, unit tests, and package creation
 - Python linting, type checking, unit tests, and package creation
 
-End-to-end tests run in Azure DevOps because they can require access to protected resources. The E2E pipeline uses a Governed 1ES Linux agent and starts local dependencies on the build agent:
+Integration tests run in Azure DevOps because they can require access to protected resources. The integration test pipeline uses a Governed 1ES Linux agent and starts local dependencies on the build agent:
 
 - Durable Task Scheduler emulator
 - Azurite
 - Redis
 - Azure Functions Core Tools
 
-The pipeline runs on a daily schedule and can be started manually against any branch. It is not triggered by commits or pull requests, so it runs from the Azure Repos mirror and does not need a GitHub connection.
+The pipeline is connected to the GitHub repository and runs on pull requests targeting `main`, as well as on a daily schedule. Pull requests from forks do not run: the Azure DevOps organization/project setting "Limit building pull requests from forked GitHub repositories" is set to disable fork builds, so only team-authored pull requests run and secrets are never exposed to forks.
 
-Access to Azure OpenAI and Foundry models uses the identity of an Azure service connection (no API keys). Model endpoints and deployment or model names are provided as non-secret pipeline variables. As a result, the E2E pipeline does not rely on any secret variables.
+Access to Azure OpenAI and Foundry models uses the identity of an Azure service connection (no API keys). Model endpoints and deployment or model names are provided as non-secret pipeline variables. As a result, the integration test pipeline does not rely on any secret variables.
 
 ## Release approach
 

--- a/eng/ci/integration-tests.yml
+++ b/eng/ci/integration-tests.yml
@@ -1,8 +1,15 @@
-# This pipeline runs on a schedule and on manual runs only. It is not triggered by
-# commits or pull requests, so it can run from the Azure Repos mirror without a
-# GitHub connection. Trigger a manual run and pick a branch to test changes.
+# This pipeline is connected to the GitHub repository so it can validate pull
+# requests. It does not run as a CI build on push (trigger: none); it runs on PRs
+# targeting main and on a daily schedule. Pull requests from forks are prevented
+# from running by the Azure DevOps org/project setting "Limit building pull requests
+# from forked GitHub repositories" (set to Disable), so only team-authored PRs run
+# and secrets are never exposed to forks.
 trigger: none
-pr: none
+
+pr:
+  branches:
+    include:
+      - main
 
 parameters:
   - name: linuxImage
@@ -23,7 +30,7 @@ parameters:
 
 schedules:
   - cron: '0 8 * * *'
-    displayName: 'Daily E2E tests'
+    displayName: 'Daily integration tests'
     branches:
       include:
         - main
@@ -64,12 +71,12 @@ extends:
         os: windows
 
     stages:
-      - stage: E2E
-        displayName: 'End-to-end tests'
+      - stage: IntegrationTests
+        displayName: 'Integration tests'
         jobs:
-          - template: /eng/templates/jobs/dotnet-e2e-tests.yml@self
+          - template: /eng/templates/jobs/dotnet-integration-tests.yml@self
             parameters:
               azureServiceConnection: ${{ parameters.azureServiceConnection }}
-          - template: /eng/templates/jobs/python-e2e-tests.yml@self
+          - template: /eng/templates/jobs/python-integration-tests.yml@self
             parameters:
               azureServiceConnection: ${{ parameters.azureServiceConnection }}

--- a/eng/templates/jobs/dotnet-integration-tests.yml
+++ b/eng/templates/jobs/dotnet-integration-tests.yml
@@ -3,8 +3,8 @@ parameters:
     type: string
 
 jobs:
-  - job: DotNetE2E
-    displayName: '.NET E2E tests'
+  - job: DotNetIntegration
+    displayName: '.NET integration tests'
     timeoutInMinutes: 90
     variables:
       DURABLE_TASK_SCHEDULER_CONNECTION_STRING: 'Endpoint=http://localhost:8080;TaskHub=default;Authentication=None'

--- a/eng/templates/jobs/python-integration-tests.yml
+++ b/eng/templates/jobs/python-integration-tests.yml
@@ -3,8 +3,8 @@ parameters:
     type: string
 
 jobs:
-  - job: PythonE2E
-    displayName: 'Python E2E tests'
+  - job: PythonIntegration
+    displayName: 'Python integration tests'
     timeoutInMinutes: 90
     variables:
       DURABLE_TASK_SCHEDULER_CONNECTION_STRING: 'Endpoint=http://localhost:8080;TaskHub=default;Authentication=None'


### PR DESCRIPTION
Renames the integration test pipeline files for consistency with the broader team's convention.

- Renames `eng/ci/e2e-tests.yml` to `eng/ci/integration-tests.yml`
- Renames the two job templates to `dotnet-integration-tests.yml` and `python-integration-tests.yml`
- Updates internal stage and job names to match
- Adds a GitHub pull request trigger for `main` (fork PRs are excluded by the org's fork-build setting)
- Updates `eng/README.md` to describe the pull request trigger and fork behavior

Note: the existing pipeline points at the old file path, so it will not validate this PR. After merge, I'll recreate the pipeline against `eng/ci/integration-tests.yml` on `main`.