### PR TITLE
Try 1es-ubuntu-24.04-min image for integration tests

### DIFF
--- a/eng/ci/integration-tests.yml
+++ b/eng/ci/integration-tests.yml
@@ -14,10 +14,12 @@ pr:
 parameters:
   - name: linuxImage
     type: string
-    default: '1es-ubuntu-22.04'
+    default: '1es-ubuntu-24.04-min'
     # Must be an Ubuntu/Debian-based image: the integration infrastructure setup
     # uses apt-get, dpkg, and the Ubuntu packages.microsoft.com feed. A non-Ubuntu
     # image (e.g. Azure Linux 3) would require reworking that setup step.
+    # 1es-ubuntu-24.04-min is a lightweight image with Docker and more free disk
+    # space, chosen to avoid the disk exhaustion seen on 1es-ubuntu-22.04.
     displayName: '1ES Hosted Pools Linux image (Ubuntu-based)'
   - name: windowsImage
     type: string
@@ -56,9 +58,10 @@ extends:
   parameters:
     pool:
       name: 1es-pool-azfunc
-      # 1es-ubuntu-22.04 is a 1ES-compliant image already in the pool and provides
-      # Docker and Azure CLI, which the tests need. CoreAI recommends migrating to
-      # an Azure Linux 3 image later for better vulnerability servicing.
+      # The Linux image is selected via the linuxImage parameter. It must be a
+      # 1ES-compliant Ubuntu image in the pool that provides Docker and Azure CLI.
+      # CoreAI recommends migrating to an Azure Linux 3 image later for better
+      # vulnerability servicing.
       image: ${{ parameters.linuxImage }}
       os: linux
 

--- a/eng/ci/integration-tests.yml
+++ b/eng/ci/integration-tests.yml
@@ -59,9 +59,10 @@ extends:
     pool:
       name: 1es-pool-azfunc
       # The Linux image is selected via the linuxImage parameter. It must be a
-      # 1ES-compliant Ubuntu image in the pool that provides Docker and Azure CLI.
-      # CoreAI recommends migrating to an Azure Linux 3 image later for better
-      # vulnerability servicing.
+      # 1ES-compliant Ubuntu image in the pool that provides Docker. Azure CLI and
+      # Azure Functions Core Tools are installed by the integration infra setup, so
+      # they are not required to be preinstalled on the image. CoreAI recommends
+      # migrating to an Azure Linux 3 image later for better vulnerability servicing.
       image: ${{ parameters.linuxImage }}
       os: linux
 

--- a/eng/ci/integration-tests.yml
+++ b/eng/ci/integration-tests.yml
@@ -15,9 +15,10 @@ parameters:
   - name: linuxImage
     type: string
     default: '1es-ubuntu-24.04-min'
-    # Must be an Ubuntu/Debian-based image: the integration infrastructure setup
-    # uses apt-get, dpkg, and the Ubuntu packages.microsoft.com feed. A non-Ubuntu
-    # image (e.g. Azure Linux 3) would require reworking that setup step.
+    # Must be an Ubuntu-based image: the integration infrastructure setup uses
+    # apt-get, dpkg, and the Ubuntu-specific packages.microsoft.com/config/ubuntu
+    # feed. A non-Ubuntu image (e.g. Debian or Azure Linux 3) would require reworking
+    # that setup step, since the feed path is keyed to the Ubuntu version.
     # 1es-ubuntu-24.04-min is a lightweight image with Docker and more free disk
     # space, chosen to avoid the disk exhaustion seen on 1es-ubuntu-22.04.
     displayName: '1ES Hosted Pools Linux image (Ubuntu-based)'

--- a/eng/templates/jobs/setup-integration-infra.yml
+++ b/eng/templates/jobs/setup-integration-infra.yml
@@ -65,7 +65,8 @@ steps:
 
         # Ubuntu codename (e.g. 'noble' for 24.04). Read from /etc/os-release rather
         # than lsb_release, which may be absent on minimal images.
-        az_dist="$(. /etc/os-release && echo "$VERSION_CODENAME")"
+        az_dist="$(. /etc/os-release && echo "${VERSION_CODENAME:-${UBUNTU_CODENAME:-}}")"
+        if [ -z "$az_dist" ]; then echo "Could not determine distro codename from /etc/os-release" >&2; exit 1; fi
         arch="$(dpkg --print-architecture)"
 
         printf 'Types: deb\nURIs: https://packages.microsoft.com/repos/azure-cli/\nSuites: %s\nComponents: main\nArchitectures: %s\nSigned-By: /etc/apt/keyrings/microsoft.gpg\n' \

--- a/eng/templates/jobs/setup-integration-infra.yml
+++ b/eng/templates/jobs/setup-integration-infra.yml
@@ -58,7 +58,9 @@ steps:
         # gnupg/curl are present on the image, so no prerequisite apt install is
         # needed (apt-transport-https is also deprecated and gone on Ubuntu 24.04).
         if [ ! -f /etc/apt/keyrings/microsoft.gpg ]; then
-          curl -sLS https://packages.microsoft.com/keys/microsoft.asc \
+          # --fail makes curl exit non-zero on an HTTP error instead of piping an
+          # HTML error page into gpg --dearmor, which would fail less clearly.
+          curl --fail -sLS https://packages.microsoft.com/keys/microsoft.asc \
             | sudo gpg --dearmor -o /etc/apt/keyrings/microsoft.gpg
           sudo chmod go+r /etc/apt/keyrings/microsoft.gpg
         fi

--- a/eng/templates/jobs/setup-integration-infra.yml
+++ b/eng/templates/jobs/setup-integration-infra.yml
@@ -64,7 +64,6 @@ steps:
         fi
 
         # Ubuntu codename (e.g. 'noble' for 24.04). Read from /etc/os-release rather
-        # Ubuntu codename (e.g. 'noble' for 24.04). Read from /etc/os-release rather
         # than lsb_release, which may be absent on minimal images. Use safe default
         # expansions so this does not trip 'set -u' if the field is absent, falling
         # back to UBUNTU_CODENAME, and fail with a clear message if neither is set.
@@ -73,7 +72,6 @@ steps:
           echo "Could not determine Ubuntu codename from /etc/os-release (VERSION_CODENAME/UBUNTU_CODENAME missing)." >&2
           exit 1
         fi
-        arch="$(dpkg --print-architecture)"
         arch="$(dpkg --print-architecture)"
 
         printf 'Types: deb\nURIs: https://packages.microsoft.com/repos/azure-cli/\nSuites: %s\nComponents: main\nArchitectures: %s\nSigned-By: /etc/apt/keyrings/microsoft.gpg\n' \

--- a/eng/templates/jobs/setup-integration-infra.yml
+++ b/eng/templates/jobs/setup-integration-infra.yml
@@ -49,12 +49,19 @@ steps:
       # which the pool may not reach. This mirrors Microsoft's documented manual
       # apt install. Skip entirely when az is already present (fuller images).
       if ! command -v az >/dev/null 2>&1; then
-        sudo apt-get update
-        sudo apt-get install -y ca-certificates curl apt-transport-https gnupg
         sudo mkdir -p /etc/apt/keyrings
-        curl -sLS https://packages.microsoft.com/keys/microsoft.asc \
-          | sudo gpg --dearmor -o /etc/apt/keyrings/microsoft.gpg
-        sudo chmod go+r /etc/apt/keyrings/microsoft.gpg
+
+        # The 1ES image already trusts packages.microsoft.com and ships the Microsoft
+        # signing key at /etc/apt/keyrings/microsoft.gpg. Only import it when missing:
+        # re-importing over an existing keyring makes gpg prompt to overwrite, which
+        # fails in the agent because there is no tty ("cannot open '/dev/tty'").
+        # gnupg/curl are present on the image, so no prerequisite apt install is
+        # needed (apt-transport-https is also deprecated and gone on Ubuntu 24.04).
+        if [ ! -f /etc/apt/keyrings/microsoft.gpg ]; then
+          curl -sLS https://packages.microsoft.com/keys/microsoft.asc \
+            | sudo gpg --dearmor -o /etc/apt/keyrings/microsoft.gpg
+          sudo chmod go+r /etc/apt/keyrings/microsoft.gpg
+        fi
 
         # Ubuntu codename (e.g. 'noble' for 24.04). Read from /etc/os-release rather
         # than lsb_release, which may be absent on minimal images.

--- a/eng/templates/jobs/setup-integration-infra.yml
+++ b/eng/templates/jobs/setup-integration-infra.yml
@@ -64,9 +64,16 @@ steps:
         fi
 
         # Ubuntu codename (e.g. 'noble' for 24.04). Read from /etc/os-release rather
-        # than lsb_release, which may be absent on minimal images.
+        # Ubuntu codename (e.g. 'noble' for 24.04). Read from /etc/os-release rather
+        # than lsb_release, which may be absent on minimal images. Use safe default
+        # expansions so this does not trip 'set -u' if the field is absent, falling
+        # back to UBUNTU_CODENAME, and fail with a clear message if neither is set.
         az_dist="$(. /etc/os-release && echo "${VERSION_CODENAME:-${UBUNTU_CODENAME:-}}")"
-        if [ -z "$az_dist" ]; then echo "Could not determine distro codename from /etc/os-release" >&2; exit 1; fi
+        if [ -z "$az_dist" ]; then
+          echo "Could not determine Ubuntu codename from /etc/os-release (VERSION_CODENAME/UBUNTU_CODENAME missing)." >&2
+          exit 1
+        fi
+        arch="$(dpkg --print-architecture)"
         arch="$(dpkg --print-architecture)"
 
         printf 'Types: deb\nURIs: https://packages.microsoft.com/repos/azure-cli/\nSuites: %s\nComponents: main\nArchitectures: %s\nSigned-By: /etc/apt/keyrings/microsoft.gpg\n' \
@@ -90,10 +97,18 @@ steps:
       # so install from Microsoft's package feed (packages.microsoft.com) instead
       # of npm. This is Microsoft's documented Linux install path for func v4.
       #
-      # The 1ES image usually already has the Microsoft feed configured, so only add
-      # it when missing. This avoids downgrading the image's packages-microsoft-prod
-      # and skips a redundant download.
-      if ! grep -rqi "packages.microsoft.com" /etc/apt/sources.list /etc/apt/sources.list.d 2>/dev/null; then
+      # The 1ES image usually already has the packages-microsoft-prod feed
+      # configured, so only add it when missing. This avoids downgrading the image's
+      # packages-microsoft-prod and skips a redundant download.
+      #
+      # Match the *prod* feed specifically, not just any packages.microsoft.com
+      # reference: the Azure CLI step above adds an azure-cli.sources file that also
+      # points at packages.microsoft.com, but that feed only carries azure-cli, not
+      # the Core Tools. A broad grep would falsely conclude the prod feed is present
+      # and skip installing it, breaking func on a truly minimal image. The prod feed
+      # URLs contain 'prod' (e.g. .../ubuntu/24.04/prod, .../microsoft-ubuntu-*-prod)
+      # whereas the azure-cli feed (.../repos/azure-cli/) does not.
+      if ! grep -rqiE "packages\.microsoft\.com/[^[:space:]]*prod" /etc/apt/sources.list /etc/apt/sources.list.d 2>/dev/null; then
         # Read the Ubuntu version from /etc/os-release rather than lsb_release, which
         # is not guaranteed to be installed on minimal images.
         ubuntu_version="$(. /etc/os-release && echo "$VERSION_ID")"

--- a/eng/templates/jobs/setup-integration-infra.yml
+++ b/eng/templates/jobs/setup-integration-infra.yml
@@ -41,6 +41,43 @@ steps:
   - bash: |
       set -euo pipefail
 
+      # Azure CLI (az). The minimal 1ES image does not ship Azure CLI, which the
+      # AzureCLI@2 test tasks require for keyless service-connection auth. Install
+      # it from Microsoft's dedicated azure-cli apt feed on packages.microsoft.com,
+      # which is reachable from the governed pool. We avoid the default
+      # aka.ms/InstallAzureCLIDeb script because it redirects to Azure blob storage,
+      # which the pool may not reach. This mirrors Microsoft's documented manual
+      # apt install. Skip entirely when az is already present (fuller images).
+      if ! command -v az >/dev/null 2>&1; then
+        sudo apt-get update
+        sudo apt-get install -y ca-certificates curl apt-transport-https gnupg
+        sudo mkdir -p /etc/apt/keyrings
+        curl -sLS https://packages.microsoft.com/keys/microsoft.asc \
+          | sudo gpg --dearmor -o /etc/apt/keyrings/microsoft.gpg
+        sudo chmod go+r /etc/apt/keyrings/microsoft.gpg
+
+        # Ubuntu codename (e.g. 'noble' for 24.04). Read from /etc/os-release rather
+        # than lsb_release, which may be absent on minimal images.
+        az_dist="$(. /etc/os-release && echo "$VERSION_CODENAME")"
+        arch="$(dpkg --print-architecture)"
+
+        printf 'Types: deb\nURIs: https://packages.microsoft.com/repos/azure-cli/\nSuites: %s\nComponents: main\nArchitectures: %s\nSigned-By: /etc/apt/keyrings/microsoft.gpg\n' \
+          "$az_dist" "$arch" | sudo tee /etc/apt/sources.list.d/azure-cli.sources
+
+        sudo apt-get update
+        sudo apt-get install -y azure-cli
+
+        # Reclaim disk on the space-constrained OS volume.
+        sudo apt-get clean
+        sudo rm -rf /var/lib/apt/lists/*
+      fi
+
+      az version
+    displayName: 'Install Azure CLI'
+
+  - bash: |
+      set -euo pipefail
+
       # Azure Functions Core Tools. The governed 1ES pool cannot reach npmjs.org,
       # so install from Microsoft's package feed (packages.microsoft.com) instead
       # of npm. This is Microsoft's documented Linux install path for func v4.


### PR DESCRIPTION
Tests switching the integration test Linux image to `1es-ubuntu-24.04-min`.

## Why
The `.NET` integration tests have been failing because the `1es-ubuntu-22.04` image fills the OS disk to 100%. Its true baseline already used ~66 GB of a 73 GB disk, leaving very little headroom once Docker images and Azure Functions Core Tools are added.

## Change
- `linuxImage` default: `1es-ubuntu-22.04` -> `1es-ubuntu-24.04-min`

`1es-ubuntu-24.04-min` is a lighter image (created by the Functions team) that reportedly ships Docker and provides more free disk space.

## Validation
This PR is validated by the `dafx.integration-tests` pipeline via the GitHub PR trigger. Watch the "Disk space (image baseline)" step to confirm the new image starts with more free space, and confirm the `.NET` job completes without exhausting the disk.