### PR TITLE
Align MCP tool trigger parameter naming between AddAIAgent and AddWorkflow

### DIFF
--- a/dotnet/samples/DurableWorkflows/AzureFunctions/03_WorkflowHITL/Program.cs
+++ b/dotnet/samples/DurableWorkflows/AzureFunctions/03_WorkflowHITL/Program.cs
@@ -46,6 +46,6 @@ Workflow expenseApproval = new WorkflowBuilder(createRequest)
 using IHost app = FunctionsApplication
     .CreateBuilder(args)
     .ConfigureFunctionsWebApplication()
-    .ConfigureDurableWorkflows(workflows => workflows.AddWorkflow(expenseApproval, exposeStatusEndpoint: true))
+    .ConfigureDurableWorkflows(workflows => workflows.AddWorkflow(expenseApproval, enableStatusEndpoint: true))
     .Build();
 app.Run();

--- a/dotnet/samples/DurableWorkflows/AzureFunctions/04_WorkflowMcpTool/Program.cs
+++ b/dotnet/samples/DurableWorkflows/AzureFunctions/04_WorkflowMcpTool/Program.cs
@@ -1,7 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 // This sample demonstrates how to expose a durable workflow as an MCP (Model Context Protocol) tool.
-// When using AddWorkflow with exposeMcpToolTrigger: true, the Functions host will automatically
+// When using AddWorkflow with enableMcpToolTrigger: true, the Functions host will automatically
 // generate a remote MCP endpoint for the app at /runtime/webhooks/mcp with a workflow-specific
 // tool name. MCP-compatible clients can then invoke the workflow as a tool.
 
@@ -37,8 +37,8 @@ using IHost app = FunctionsApplication
     .ConfigureDurableWorkflows(workflows =>
     {
         // Expose both workflows as MCP tool triggers.
-        workflows.AddWorkflow(translateWorkflow, exposeStatusEndpoint: false, exposeMcpToolTrigger: true);
-        workflows.AddWorkflow(orderLookupWorkflow, exposeStatusEndpoint: false, exposeMcpToolTrigger: true);
+        workflows.AddWorkflow(translateWorkflow, enableStatusEndpoint: false, enableMcpToolTrigger: true);
+        workflows.AddWorkflow(orderLookupWorkflow, enableStatusEndpoint: false, enableMcpToolTrigger: true);
     })
     .Build();
 app.Run();

--- a/dotnet/samples/DurableWorkflows/AzureFunctions/04_WorkflowMcpTool/README.md
+++ b/dotnet/samples/DurableWorkflows/AzureFunctions/04_WorkflowMcpTool/README.md
@@ -4,7 +4,7 @@ This sample demonstrates how to expose durable workflows as [MCP (Model Context 
 
 ## Key Concepts Demonstrated
 
-- **Workflow as MCP Tool**: Expose workflows as callable MCP tools using `exposeMcpToolTrigger: true`
+- **Workflow as MCP Tool**: Expose workflows as callable MCP tools using `enableMcpToolTrigger: true`
 - **MCP Server Hosting**: The Azure Functions host automatically generates a remote MCP endpoint at `/runtime/webhooks/mcp`
 - **String and POCO Results**: Shows workflows returning both plain strings and structured JSON objects
 

--- a/dotnet/samples/DurableWorkflows/AzureFunctions/05_WorkflowAndAgents/Program.cs
+++ b/dotnet/samples/DurableWorkflows/AzureFunctions/05_WorkflowAndAgents/Program.cs
@@ -61,7 +61,7 @@ using IHost app = FunctionsApplication
         options.Agents.AddAIAgent(assistant, enableHttpTrigger: true, enableMcpToolTrigger: true);
 
         // Register the workflow with an HTTP endpoint and MCP tool trigger
-        options.Workflows.AddWorkflow(translateWorkflow, exposeStatusEndpoint: false, exposeMcpToolTrigger: true);
+        options.Workflows.AddWorkflow(translateWorkflow, enableStatusEndpoint: false, enableMcpToolTrigger: true);
     })
     .Build();
 app.Run();

--- a/dotnet/src/Microsoft.Agents.AI.Hosting.AzureFunctions/CHANGELOG.md
+++ b/dotnet/src/Microsoft.Agents.AI.Hosting.AzureFunctions/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- [BREAKING] Renamed `AddWorkflow` parameters `exposeStatusEndpoint` and `exposeMcpToolTrigger` to `enableStatusEndpoint` and `enableMcpToolTrigger` for consistency with `AddAIAgent` ([#30](https://github.com/microsoft/agent-framework-durable-extension/pull/30))
 - Scope workflow status/respond endpoints to the route workflow name ([#6608](https://github.com/microsoft/agent-framework/pull/6608))
 - Bind MCP threadId to the current agent and guard cross-agent session dispatch ([#6531](https://github.com/microsoft/agent-framework/pull/6531))
 - Support returning workflow results from HTTP trigger endpoint ([#5321](https://github.com/microsoft/agent-framework/pull/5321))

--- a/dotnet/src/Microsoft.Agents.AI.Hosting.AzureFunctions/CHANGELOG.md
+++ b/dotnet/src/Microsoft.Agents.AI.Hosting.AzureFunctions/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-- [BREAKING] Renamed `AddWorkflow` parameters `exposeStatusEndpoint` and `exposeMcpToolTrigger` to `enableStatusEndpoint` and `enableMcpToolTrigger` for consistency with `AddAIAgent` ([#30](https://github.com/microsoft/agent-framework-durable-extension/pull/30))
+- [BREAKING] Renamed `AddWorkflow` parameters `exposeStatusEndpoint` and `exposeMcpToolTrigger` to `enableStatusEndpoint` and `enableMcpToolTrigger` for consistency with `AddAIAgent` ([#35](https://github.com/microsoft/agent-framework-durable-extension/pull/35))
 - Scope workflow status/respond endpoints to the route workflow name ([#6608](https://github.com/microsoft/agent-framework/pull/6608))
 - Bind MCP threadId to the current agent and guard cross-agent session dispatch ([#6531](https://github.com/microsoft/agent-framework/pull/6531))
 - Support returning workflow results from HTTP trigger endpoint ([#5321](https://github.com/microsoft/agent-framework/pull/5321))

--- a/dotnet/src/Microsoft.Agents.AI.Hosting.AzureFunctions/Workflows/DurableWorkflowOptionsExtensions.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Hosting.AzureFunctions/Workflows/DurableWorkflowOptionsExtensions.cs
@@ -15,14 +15,14 @@ public static class DurableWorkflowOptionsExtensions
     /// </summary>
     /// <param name="options">The workflow options to add the workflow to.</param>
     /// <param name="workflow">The workflow instance to add.</param>
-    /// <param name="exposeStatusEndpoint">If <see langword="true"/>, a GET endpoint is generated at <c>workflows/{name}/status/{runId}</c>.</param>
-    public static void AddWorkflow(this DurableWorkflowOptions options, Workflow workflow, bool exposeStatusEndpoint)
+    /// <param name="enableStatusEndpoint">If <see langword="true"/>, a GET endpoint is generated at <c>workflows/{name}/status/{runId}</c>.</param>
+    public static void AddWorkflow(this DurableWorkflowOptions options, Workflow workflow, bool enableStatusEndpoint)
     {
         ArgumentNullException.ThrowIfNull(options);
 
         options.AddWorkflow(workflow);
 
-        if (exposeStatusEndpoint && options.ParentOptions is FunctionsDurableOptions functionsOptions)
+        if (enableStatusEndpoint && options.ParentOptions is FunctionsDurableOptions functionsOptions)
         {
             functionsOptions.EnableStatusEndpoint(workflow.Name!);
         }
@@ -33,9 +33,9 @@ public static class DurableWorkflowOptionsExtensions
     /// </summary>
     /// <param name="options">The workflow options to add the workflow to.</param>
     /// <param name="workflow">The workflow instance to add.</param>
-    /// <param name="exposeStatusEndpoint">If <see langword="true"/>, a GET endpoint is generated at <c>workflows/{name}/status/{runId}</c>.</param>
-    /// <param name="exposeMcpToolTrigger">If <see langword="true"/>, an MCP tool trigger is generated for the workflow.</param>
-    public static void AddWorkflow(this DurableWorkflowOptions options, Workflow workflow, bool exposeStatusEndpoint, bool exposeMcpToolTrigger)
+    /// <param name="enableStatusEndpoint">If <see langword="true"/>, a GET endpoint is generated at <c>workflows/{name}/status/{runId}</c>.</param>
+    /// <param name="enableMcpToolTrigger">If <see langword="true"/>, an MCP tool trigger is generated for the workflow.</param>
+    public static void AddWorkflow(this DurableWorkflowOptions options, Workflow workflow, bool enableStatusEndpoint, bool enableMcpToolTrigger)
     {
         ArgumentNullException.ThrowIfNull(options);
 
@@ -43,12 +43,12 @@ public static class DurableWorkflowOptionsExtensions
 
         if (options.ParentOptions is FunctionsDurableOptions functionsOptions)
         {
-            if (exposeStatusEndpoint)
+            if (enableStatusEndpoint)
             {
                 functionsOptions.EnableStatusEndpoint(workflow.Name!);
             }
 
-            if (exposeMcpToolTrigger)
+            if (enableMcpToolTrigger)
             {
                 functionsOptions.EnableMcpToolTrigger(workflow.Name!);
             }

--- a/dotnet/src/Microsoft.Agents.AI.Hosting.AzureFunctions/Workflows/DurableWorkflowsFunctionMetadataTransformer.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Hosting.AzureFunctions/Workflows/DurableWorkflowsFunctionMetadataTransformer.cs
@@ -86,7 +86,7 @@ internal sealed class DurableWorkflowsFunctionMetadataTransformer : IFunctionMet
                     BuiltInFunctions.RunWorkflowOrchestrationHttpFunctionEntryPoint));
             }
 
-            // Register a status endpoint if opted in via AddWorkflow(exposeStatusEndpoint: true).
+            // Register a status endpoint if opted in via AddWorkflow(enableStatusEndpoint: true).
             if (this._options.IsStatusEndpointEnabled(workflow.Key))
             {
                 string statusFunctionName = $"{BuiltInFunctions.HttpPrefix}{workflow.Key}{BuiltInFunctions.StatusFunctionSuffix}";

--- a/dotnet/src/Microsoft.Agents.AI.Hosting.AzureFunctions/Workflows/DurableWorkflowsFunctionMetadataTransformer.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Hosting.AzureFunctions/Workflows/DurableWorkflowsFunctionMetadataTransformer.cs
@@ -116,7 +116,7 @@ internal sealed class DurableWorkflowsFunctionMetadataTransformer : IFunctionMet
                 }
             }
 
-            // Register an MCP tool trigger if opted in via AddWorkflow(exposeMcpToolTrigger: true).
+            // Register an MCP tool trigger if opted in via AddWorkflow(enableMcpToolTrigger: true).
             if (this._options.IsMcpToolTriggerEnabled(workflow.Key))
             {
                 string mcpToolFunctionName = $"{BuiltInFunctions.McpToolPrefix}{workflow.Key}";

--- a/dotnet/src/Microsoft.Agents.AI.Hosting.AzureFunctions/Workflows/DurableWorkflowsFunctionMetadataTransformer.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Hosting.AzureFunctions/Workflows/DurableWorkflowsFunctionMetadataTransformer.cs
@@ -116,7 +116,7 @@ internal sealed class DurableWorkflowsFunctionMetadataTransformer : IFunctionMet
                 }
             }
 
-            // Register an MCP tool trigger if opted in via AddWorkflow(enableMcpToolTrigger: true).
+            // Register an MCP tool trigger if opted in via AddWorkflow(enableStatusEndpoint: ..., enableMcpToolTrigger: true).
             if (this._options.IsMcpToolTriggerEnabled(workflow.Key))
             {
                 string mcpToolFunctionName = $"{BuiltInFunctions.McpToolPrefix}{workflow.Key}";


### PR DESCRIPTION
## Summary

Renames `AddWorkflow` parameters from `exposeStatusEndpoint`/`exposeMcpToolTrigger` to `enableStatusEndpoint`/`enableMcpToolTrigger` for consistency with `AddAIAgent` which already uses the `enable*` prefix pattern.

## Changes

- **`DurableWorkflowOptionsExtensions.cs`** — renamed both parameters and updated XML docs
- **`DurableWorkflowsFunctionMetadataTransformer.cs`** — updated comment referencing the old parameter name
- **Samples** (`03_WorkflowHITL`, `04_WorkflowMcpTool`, `05_WorkflowAndAgents`) — updated call sites
- **`04_WorkflowMcpTool/README.md`** — updated documentation reference
- **`CHANGELOG.md`** — added `[BREAKING]` entry

## Breaking change

Callers using named arguments (`exposeStatusEndpoint:` or `exposeMcpToolTrigger:`) will need to update to the new names. Positional callers are unaffected.  (We are still in preview, so I am not intentionally making this change backward compatible.)

Closes #30