### PR TITLE
Migrate Python Azure Functions samples

### DIFF
--- a/.github/actions/azure-functions-integration-setup/action.yml
+++ b/.github/actions/azure-functions-integration-setup/action.yml
@@ -14,7 +14,8 @@ runs:
           echo "Starting Durable Task Scheduler Emulator"
           docker run -d --name dts-emulator -p 8080:8080 -p 8082:8082 -e DTS_USE_DYNAMIC_TASK_HUBS=true mcr.microsoft.com/dts/dts-emulator:latest
           echo "Waiting for Durable Task Scheduler Emulator to be ready"
-          timeout 30 bash -c 'until curl --fail --silent --show-error http://localhost:8080/healthz; do sleep 1; done'
+          # The emulator has no health endpoint and returns HTTP 400 once its listener is ready.
+          timeout 30 bash -c 'until curl --silent --show-error --output /dev/null http://localhost:8080/healthz; do sleep 1; done'
           echo "Durable Task Scheduler Emulator is ready"
       - name: Start Azurite (Azure Storage emulator)
         shell: bash

--- a/.github/actions/azure-functions-integration-setup/action.yml
+++ b/.github/actions/azure-functions-integration-setup/action.yml
@@ -27,7 +27,8 @@ runs:
           echo "Starting Azurite (Azure Storage emulator)"
           docker run -d --name azurite -p 10000:10000 -p 10001:10001 -p 10002:10002 mcr.microsoft.com/azure-storage/azurite
           echo "Waiting for Azurite (Azure Storage emulator) to be ready"
-          timeout 30 bash -c 'until curl --fail --silent --show-error http://localhost:10000/devstoreaccount1; do sleep 1; done'
+          # An unauthenticated storage request returns HTTP 400 once Azurite is ready.
+          timeout 30 bash -c 'until curl --silent --show-error --output /dev/null http://localhost:10000/devstoreaccount1; do sleep 1; done'
           echo "Azurite (Azure Storage emulator) is ready"
       - name: Start Redis
         shell: bash

--- a/.github/workflows/python-integration-tests.yml
+++ b/.github/workflows/python-integration-tests.yml
@@ -36,7 +36,9 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.13"
+          # Core Tools 4.12.1 predates the Python 3.13 proxy-worker fix for
+          # monorepo-level virtual environments (azure-functions-python-worker#1833).
+          python-version: "3.12"
 
       - name: Install uv
         uses: astral-sh/setup-uv@v6

--- a/.github/workflows/python-integration-tests.yml
+++ b/.github/workflows/python-integration-tests.yml
@@ -5,6 +5,10 @@ on:
   schedule:
     - cron: "0 9 * * *"
 
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   integration-tests:
     name: Durable Task integration tests
@@ -14,11 +18,16 @@ jobs:
     env:
       DURABLE_TASK_SCHEDULER_CONNECTION_STRING: Endpoint=http://localhost:8080;TaskHub=default;Authentication=None
       REDIS_CONNECTION_STRING: redis://localhost:6379
+      AzureWebJobsStorage: UseDevelopmentStorage=true
+      FUNCTIONS_WORKER_RUNTIME: python
       FOUNDRY_PROJECT_ENDPOINT: ${{ secrets.FOUNDRY_PROJECT_ENDPOINT }}
       FOUNDRY_MODEL: ${{ secrets.FOUNDRY_MODEL }}
       AZURE_OPENAI_ENDPOINT: ${{ secrets.AZURE_OPENAI_ENDPOINT }}
       AZURE_OPENAI_MODEL: ${{ secrets.AZURE_OPENAI_MODEL || secrets.AZURE_OPENAI_DEPLOYMENT_NAME }}
       AZURE_OPENAI_API_KEY: ${{ secrets.AZURE_OPENAI_API_KEY }}
+      AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+      AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+      AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
     steps:
       - name: Checkout
@@ -31,6 +40,36 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@v6
+
+      - name: Validate integration configuration
+        shell: bash
+        run: |
+          missing=()
+          for variable in \
+            FOUNDRY_PROJECT_ENDPOINT \
+            FOUNDRY_MODEL \
+            AZURE_OPENAI_ENDPOINT \
+            AZURE_OPENAI_MODEL \
+            AZURE_CLIENT_ID \
+            AZURE_TENANT_ID \
+            AZURE_SUBSCRIPTION_ID
+          do
+            if [[ -z "${!variable}" ]]; then
+              missing+=("${variable}")
+            fi
+          done
+
+          if (( ${#missing[@]} )); then
+            echo "::error::Missing required integration configuration: ${missing[*]}"
+            exit 1
+          fi
+
+      - name: Login to Azure
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
       - name: Start integration infrastructure
         uses: ./.github/actions/azure-functions-integration-setup

--- a/docs/features/durable-agents/AGENTS.md
+++ b/docs/features/durable-agents/AGENTS.md
@@ -7,7 +7,7 @@ Instructions for AI coding agents working on durable agents documentation.
 This directory contains feature documentation for the durable agents integration. The source code and samples live elsewhere:
 
 - .NET implementation: `dotnet/src/Microsoft.Agents.AI.DurableTask/` and `dotnet/src/Microsoft.Agents.AI.Hosting.AzureFunctions/`
-- Python implementation: `python/packages/durabletask/`; Python Azure Functions hosting remains in the external `agent-framework-azurefunctions` package
+- Python implementation: `python/packages/durabletask/`; Python Azure Functions hosting is in the `agent-framework-azurefunctions` package (`python/packages/azurefunctions/`)
 - .NET samples: `dotnet/samples/DurableAgents/`
 - Python samples: `python/samples/`
 - Official docs (Microsoft Learn): <https://learn.microsoft.com/agent-framework/integrations/azure-functions>

--- a/docs/features/durable-agents/README.md
+++ b/docs/features/durable-agents/README.md
@@ -57,7 +57,7 @@ Key types:
 
 ### Python
 
-The core Python implementation is in the `agent-framework-durabletask` package (`python/packages/durabletask`). Azure Functions hosting for Python remains in the external `agent-framework-azurefunctions` package.
+The core Python implementation is in the `agent-framework-durabletask` package (`python/packages/durabletask`). Azure Functions hosting for Python is provided by the `agent-framework-azurefunctions` package (`python/packages/azurefunctions`).
 
 Key types:
 

--- a/dotnet/samples/DurableWorkflows/ConsoleApps/09_SwitchRouting/README.md
+++ b/dotnet/samples/DurableWorkflows/ConsoleApps/09_SwitchRouting/README.md
@@ -53,7 +53,7 @@ See the [README.md](../../README.md) file in the parent directory for informatio
 ## Running the Sample
 
 ```bash
-cd dotnet/samples/04-hosting/DurableWorkflows/ConsoleApps/09_SwitchRouting
+cd dotnet/samples/DurableWorkflows/ConsoleApps/09_SwitchRouting
 dotnet run --framework net10.0
 ```
 

--- a/eng/templates/jobs/python-integration-tests.yml
+++ b/eng/templates/jobs/python-integration-tests.yml
@@ -38,32 +38,83 @@ jobs:
           # uv reads UV_INDEX_URL first, so point it at the same authenticated URL.
           UV_INDEX_URL: $(PIP_INDEX_URL)
 
-      - task: AzureCLI@2
-        displayName: 'Run Python integration tests'
-        inputs:
-          azureSubscription: ${{ parameters.azureServiceConnection }}
-          scriptType: bash
-          scriptLocation: inlineScript
-          workingDirectory: $(Build.SourcesDirectory)/python
-          inlineScript: |
-            mkdir -p ../artifacts/test-results
-            uv run --no-sync pytest packages/durabletask/tests/integration_tests \
-              -m integration \
-              -n logical \
-              --dist worksteal \
-              --timeout 480 \
-              --junitxml ../artifacts/test-results/python-integration.xml
+      - bash: |
+          set -euo pipefail
+
+          missing=()
+          for variable in \
+            FOUNDRY_PROJECT_ENDPOINT \
+            FOUNDRY_MODEL \
+            AZURE_OPENAI_ENDPOINT \
+            AZURE_OPENAI_MODEL
+          do
+            value="${!variable}"
+            if [ -z "$value" ] || [[ "$value" =~ ^\$\(.+\)$ ]]; then
+              missing+=("${variable}")
+            fi
+          done
+
+          if (( ${#missing[@]} )); then
+            echo "Missing required integration configuration: ${missing[*]}" >&2
+            exit 1
+          fi
+        displayName: 'Validate Python integration configuration'
         env:
           FOUNDRY_PROJECT_ENDPOINT: $(FOUNDRY_PROJECT_ENDPOINT)
           FOUNDRY_MODEL: $(FOUNDRY_MODEL)
           AZURE_OPENAI_ENDPOINT: $(AZURE_OPENAI_ENDPOINT)
           AZURE_OPENAI_MODEL: $(AZURE_OPENAI_DEPLOYMENT_NAME)
 
+      - task: AzureCLI@2
+        displayName: 'Run Durable Task integration tests'
+        inputs:
+          azureSubscription: ${{ parameters.azureServiceConnection }}
+          scriptType: bash
+          scriptLocation: inlineScript
+          workingDirectory: $(Build.SourcesDirectory)/python
+          inlineScript: |
+            set -euo pipefail
+            mkdir -p ../artifacts/test-results
+            uv run --no-sync pytest packages/durabletask/tests/integration_tests \
+              -m integration \
+              -n logical \
+              --dist worksteal \
+              --timeout 480 \
+              --junitxml ../artifacts/test-results/python-durabletask-integration.xml
+        env:
+          FOUNDRY_PROJECT_ENDPOINT: $(FOUNDRY_PROJECT_ENDPOINT)
+          FOUNDRY_MODEL: $(FOUNDRY_MODEL)
+          AZURE_OPENAI_ENDPOINT: $(AZURE_OPENAI_ENDPOINT)
+          AZURE_OPENAI_MODEL: $(AZURE_OPENAI_DEPLOYMENT_NAME)
+
+      - task: AzureCLI@2
+        displayName: 'Run Azure Functions integration tests'
+        inputs:
+          azureSubscription: ${{ parameters.azureServiceConnection }}
+          scriptType: bash
+          scriptLocation: inlineScript
+          workingDirectory: $(Build.SourcesDirectory)/python
+          inlineScript: |
+            set -euo pipefail
+            uv run --no-sync pytest packages/azurefunctions/tests/integration_tests \
+              -m integration \
+              -n logical \
+              --dist worksteal \
+              --timeout 480 \
+              --junitxml ../artifacts/test-results/python-azurefunctions-integration.xml
+        env:
+          FOUNDRY_PROJECT_ENDPOINT: $(FOUNDRY_PROJECT_ENDPOINT)
+          FOUNDRY_MODEL: $(FOUNDRY_MODEL)
+          AZURE_OPENAI_ENDPOINT: $(AZURE_OPENAI_ENDPOINT)
+          AZURE_OPENAI_MODEL: $(AZURE_OPENAI_DEPLOYMENT_NAME)
+          AzureWebJobsStorage: 'UseDevelopmentStorage=true'
+          FUNCTIONS_WORKER_RUNTIME: 'python'
+
       - task: PublishTestResults@2
         condition: always()
         inputs:
           testResultsFormat: JUnit
-          testResultsFiles: 'artifacts/test-results/python-integration.xml'
+          testResultsFiles: 'artifacts/test-results/python-*-integration.xml'
           searchFolder: $(Build.SourcesDirectory)
           failTaskOnFailedTests: true
         displayName: 'Publish Python test results'

--- a/eng/templates/jobs/python-integration-tests.yml
+++ b/eng/templates/jobs/python-integration-tests.yml
@@ -29,8 +29,10 @@ jobs:
 
       - bash: |
           set -euo pipefail
-          uv python install 3.13
-          uv sync --python 3.13 --all-packages --group dev --group test
+          # Core Tools 4.12.1 predates the Python 3.13 proxy-worker fix for
+          # monorepo-level virtual environments (azure-functions-python-worker#1833).
+          uv python install 3.12
+          uv sync --python 3.12 --all-packages --group dev --group test
         workingDirectory: python
         displayName: 'Sync Python workspace'
         env:

--- a/eng/templates/jobs/python-integration-tests.yml
+++ b/eng/templates/jobs/python-integration-tests.yml
@@ -43,29 +43,44 @@ jobs:
       - bash: |
           set -euo pipefail
 
+          is_missing() {
+            local value="$1"
+            [ -z "$value" ] || [[ "$value" =~ ^\$\(.+\)$ ]]
+          }
+
           missing=()
           for variable in \
             FOUNDRY_PROJECT_ENDPOINT \
             FOUNDRY_MODEL \
-            AZURE_OPENAI_ENDPOINT \
-            AZURE_OPENAI_MODEL
+            AZURE_OPENAI_ENDPOINT
           do
             value="${!variable}"
-            if [ -z "$value" ] || [[ "$value" =~ ^\$\(.+\)$ ]]; then
+            if is_missing "$value"; then
               missing+=("${variable}")
             fi
           done
+
+          azure_openai_model="$AZURE_OPENAI_MODEL"
+          if is_missing "$azure_openai_model"; then
+            azure_openai_model="$AZURE_OPENAI_DEPLOYMENT_NAME"
+          fi
+          if is_missing "$azure_openai_model"; then
+            missing+=("AZURE_OPENAI_MODEL or AZURE_OPENAI_DEPLOYMENT_NAME")
+          fi
 
           if (( ${#missing[@]} )); then
             echo "Missing required integration configuration: ${missing[*]}" >&2
             exit 1
           fi
+
+          echo "##vso[task.setvariable variable=RESOLVED_AZURE_OPENAI_MODEL]$azure_openai_model"
         displayName: 'Validate Python integration configuration'
         env:
           FOUNDRY_PROJECT_ENDPOINT: $(FOUNDRY_PROJECT_ENDPOINT)
           FOUNDRY_MODEL: $(FOUNDRY_MODEL)
           AZURE_OPENAI_ENDPOINT: $(AZURE_OPENAI_ENDPOINT)
-          AZURE_OPENAI_MODEL: $(AZURE_OPENAI_DEPLOYMENT_NAME)
+          AZURE_OPENAI_MODEL: $(AZURE_OPENAI_MODEL)
+          AZURE_OPENAI_DEPLOYMENT_NAME: $(AZURE_OPENAI_DEPLOYMENT_NAME)
 
       - task: AzureCLI@2
         displayName: 'Run Durable Task integration tests'
@@ -87,7 +102,7 @@ jobs:
           FOUNDRY_PROJECT_ENDPOINT: $(FOUNDRY_PROJECT_ENDPOINT)
           FOUNDRY_MODEL: $(FOUNDRY_MODEL)
           AZURE_OPENAI_ENDPOINT: $(AZURE_OPENAI_ENDPOINT)
-          AZURE_OPENAI_MODEL: $(AZURE_OPENAI_DEPLOYMENT_NAME)
+          AZURE_OPENAI_MODEL: $(RESOLVED_AZURE_OPENAI_MODEL)
 
       - task: AzureCLI@2
         displayName: 'Run Azure Functions integration tests'
@@ -108,7 +123,7 @@ jobs:
           FOUNDRY_PROJECT_ENDPOINT: $(FOUNDRY_PROJECT_ENDPOINT)
           FOUNDRY_MODEL: $(FOUNDRY_MODEL)
           AZURE_OPENAI_ENDPOINT: $(AZURE_OPENAI_ENDPOINT)
-          AZURE_OPENAI_MODEL: $(AZURE_OPENAI_DEPLOYMENT_NAME)
+          AZURE_OPENAI_MODEL: $(RESOLVED_AZURE_OPENAI_MODEL)
           AzureWebJobsStorage: 'UseDevelopmentStorage=true'
           FUNCTIONS_WORKER_RUNTIME: 'python'
 

--- a/python/packages/azurefunctions/AGENTS.md
+++ b/python/packages/azurefunctions/AGENTS.md
@@ -16,8 +16,8 @@ app = AgentFunctionApp(agents=[my_agent])
 
 ## Import Path
 
+Use the direct package import:
+
 ```python
-from agent_framework_azurefunctions import AgentFunctionApp
-# or directly:
 from agent_framework_azurefunctions import AgentFunctionApp
 ```

--- a/python/packages/azurefunctions/AGENTS.md
+++ b/python/packages/azurefunctions/AGENTS.md
@@ -9,7 +9,7 @@ Hosting agents as Azure Functions.
 ## Usage
 
 ```python
-from agent_framework.azure import AgentFunctionApp
+from agent_framework_azurefunctions import AgentFunctionApp
 
 app = AgentFunctionApp(agents=[my_agent])
 ```
@@ -17,7 +17,7 @@ app = AgentFunctionApp(agents=[my_agent])
 ## Import Path
 
 ```python
-from agent_framework.azure import AgentFunctionApp
+from agent_framework_azurefunctions import AgentFunctionApp
 # or directly:
 from agent_framework_azurefunctions import AgentFunctionApp
 ```

--- a/python/packages/azurefunctions/README.md
+++ b/python/packages/azurefunctions/README.md
@@ -17,7 +17,7 @@ The durable agent extension lets you host Microsoft Agent Framework agents on Az
 See the durable functions integration sample in the repository to learn how to:
 
 ```python
-from agent_framework.azure import AgentFunctionApp
+from agent_framework_azurefunctions import AgentFunctionApp
 
 _app = AgentFunctionApp()
 ```

--- a/python/packages/azurefunctions/agent_framework_azurefunctions/_app.py
+++ b/python/packages/azurefunctions/agent_framework_azurefunctions/_app.py
@@ -152,7 +152,7 @@ class AgentFunctionApp(DFAppBase):
 
     .. code-block:: python
 
-        from agent_framework.azure import AgentFunctionApp
+        from agent_framework_azurefunctions import AgentFunctionApp
         from agent_framework.openai import OpenAIChatCompletionClient
 
         # Create agents with unique names
@@ -504,6 +504,7 @@ class AgentFunctionApp(DFAppBase):
             # keys, so stripping them here keeps untrusted input off the orchestrator's
             # trusted-deserialization path (see strip_subworkflow_markers).
             client_input = strip_subworkflow_markers(client_input)
+            client_input = strip_pickle_markers(client_input)
 
             instance_id = await client.start_new(orchestrator_name, client_input=client_input)
 

--- a/python/packages/azurefunctions/tests/integration_tests/.env.example
+++ b/python/packages/azurefunctions/tests/integration_tests/.env.example
@@ -1,9 +1,15 @@
-# Azure OpenAI Configuration
+# Microsoft Foundry configuration (samples 01, 03-10, and 12)
+FOUNDRY_PROJECT_ENDPOINT=https://your-project.services.ai.azure.com/api/projects/your-project
+FOUNDRY_MODEL=your-deployment-name
+
+# Azure OpenAI configuration (samples 02 and 11)
 AZURE_OPENAI_ENDPOINT=https://your-resource.openai.azure.com/
 AZURE_OPENAI_MODEL=your-deployment-name
+
+# Run `az login` before starting the tests. The samples use AzureCliCredential.
 FUNCTIONS_WORKER_RUNTIME=python
 
-# Azure Functions Configuration
+# Azure Functions configuration
 AzureWebJobsStorage=UseDevelopmentStorage=true
 DURABLE_TASK_SCHEDULER_CONNECTION_STRING=Endpoint=http://localhost:8080;Authentication=None
 

--- a/python/packages/azurefunctions/tests/integration_tests/README.md
+++ b/python/packages/azurefunctions/tests/integration_tests/README.md
@@ -13,12 +13,20 @@ cp .env.example .env
 ```
 
 Required variables:
+- `FOUNDRY_PROJECT_ENDPOINT`
+- `FOUNDRY_MODEL`
 - `AZURE_OPENAI_ENDPOINT`
 - `AZURE_OPENAI_MODEL`
-- `AZURE_OPENAI_API_KEY`
 - `AzureWebJobsStorage`
 - `DURABLE_TASK_SCHEDULER_CONNECTION_STRING`
 - `FUNCTIONS_WORKER_RUNTIME`
+
+Run `az login` before the tests. The hosted samples use `AzureCliCredential`.
+
+For GitHub Actions, configure the same model endpoints plus `AZURE_CLIENT_ID`,
+`AZURE_TENANT_ID`, and `AZURE_SUBSCRIPTION_ID` as secrets on the `integration`
+environment. The workflow uses Azure Login with OpenID Connect so
+`AzureCliCredential` can authenticate without a stored client secret.
 
 ### 2. Start required services
 
@@ -59,7 +67,6 @@ Each test file uses pytest markers to automatically configure and start the func
 pytestmark = [
     pytest.mark.sample("01_single_agent"),
     pytest.mark.usefixtures("function_app_for_test"),
-    skip_if_azure_functions_integration_tests_disabled,
 ]
 ```
 

--- a/python/packages/azurefunctions/tests/integration_tests/conftest.py
+++ b/python/packages/azurefunctions/tests/integration_tests/conftest.py
@@ -297,7 +297,7 @@ def _get_sample_path_from_marker(request: pytest.FixtureRequest) -> tuple[Path |
 
     sample_name = marker.args[0]
     repo_root = _resolve_repo_root()
-    sample_path = repo_root / "samples" / "04-hosting" / "azure_functions" / sample_name
+    sample_path = repo_root / "samples" / "azure_functions" / sample_name
 
     if not sample_path.exists():
         return None, f"Sample directory does not exist: {sample_path}"

--- a/python/packages/azurefunctions/tests/integration_tests/conftest.py
+++ b/python/packages/azurefunctions/tests/integration_tests/conftest.py
@@ -341,9 +341,10 @@ def _load_and_validate_env(sample_path: Path) -> None:
     # Samples that host no AI agents need no model credentials (only the DTS emulator
     # and Azurite). The suite-level gate still requires *some* LLM config to be present.
     no_llm_samples = {"13_subworkflow_hitl"}
+    azure_openai_samples = {"02_multi_agent", "11_workflow_parallel"}
     if sample_path.name in no_llm_samples:
         pass
-    elif sample_path.name == "11_workflow_parallel":
+    elif sample_path.name in azure_openai_samples:
         required_env_vars.extend(["AZURE_OPENAI_ENDPOINT", "AZURE_OPENAI_MODEL"])
     else:
         required_env_vars.extend(["FOUNDRY_PROJECT_ENDPOINT", "FOUNDRY_MODEL"])

--- a/python/packages/azurefunctions/tests/integration_tests/conftest.py
+++ b/python/packages/azurefunctions/tests/integration_tests/conftest.py
@@ -371,14 +371,6 @@ def _start_function_app(sample_path: Path, port: int) -> subprocess.Popen[Any]:
     # use the task hub name to separate orchestration state.
     env["TASKHUB_NAME"] = f"test{uuid.uuid4().hex[:8]}"
 
-    # The Azure Functions Python worker's dependency isolation mechanism crashes
-    # on Python 3.13 with a SIGSEGV in the protobuf C extension (google._upb).
-    # Disabling isolation lets the worker load dependencies from the app's own
-    # environment, which avoids the crash.
-    # See: https://github.com/Azure/azure-functions-python-worker/issues/1797
-    if sys.version_info >= (3, 13):
-        env.setdefault("PYTHON_ISOLATE_WORKER_DEPENDENCIES", "0")
-
     # On Windows, use CREATE_NEW_PROCESS_GROUP to allow proper termination
     # shell=True only on Windows to handle PATH resolution
     if sys.platform == "win32":

--- a/python/packages/azurefunctions/tests/integration_tests/test_02_multi_agent.py
+++ b/python/packages/azurefunctions/tests/integration_tests/test_02_multi_agent.py
@@ -35,9 +35,8 @@ class TestSampleMultiAgent:
         self.math_base_url = f"{base_url}/api/agents/MathAgent"
         self.helper = sample_helper
 
-    @pytest.mark.skip(reason="Flaky in CI: times out / crashes the xdist runner; temporarily disabled.")
-    def test_weather_agent(self) -> None:
-        """Test WeatherAgent endpoint."""
+    def test_weather_and_math_agents(self) -> None:
+        """Test both agent endpoints with one function host."""
         response = self.helper.post_json(
             f"{self.weather_base_url}/run",
             {"message": "What is the weather in Seattle?"},
@@ -47,8 +46,6 @@ class TestSampleMultiAgent:
         assert data["status"] == "success"
         assert "response" in data
 
-    def test_math_agent(self) -> None:
-        """Test MathAgent endpoint."""
         response = self.helper.post_json(
             f"{self.math_base_url}/run",
             {"message": "Calculate a 20% tip on a $50 bill", "wait_for_response": False},

--- a/python/packages/azurefunctions/tests/integration_tests/test_08_mcp_server.py
+++ b/python/packages/azurefunctions/tests/integration_tests/test_08_mcp_server.py
@@ -1,0 +1,69 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+"""Integration tests for the MCP server sample."""
+
+import pytest
+from mcp import ClientSession
+from mcp.client.streamable_http import streamable_http_client
+from mcp.types import CallToolResult, TextContent
+
+pytestmark = [
+    pytest.mark.flaky,
+    pytest.mark.integration,
+    pytest.mark.sample("08_mcp_server"),
+    pytest.mark.usefixtures("function_app_for_test"),
+]
+
+
+def _response_text(result: CallToolResult) -> str:
+    """Collect text content from an MCP tool response."""
+    return "\n".join(content.text for content in result.content if isinstance(content, TextContent))
+
+
+class TestMcpServerSample:
+    """Tests for the 08_mcp_server sample."""
+
+    def test_health_reports_trigger_configuration(self, base_url: str, sample_helper) -> None:
+        """Verify each agent exposes only its configured triggers."""
+        response = sample_helper.get(f"{base_url}/api/health")
+        assert response.status_code == 200
+
+        agents = {agent["name"]: agent for agent in response.json()["agents"]}
+        assert set(agents) == {"Joker", "StockAdvisor", "PlantAdvisor"}
+        assert agents["Joker"]["http_endpoint_enabled"] is True
+        assert agents["Joker"]["mcp_tool_enabled"] is False
+        assert agents["StockAdvisor"]["http_endpoint_enabled"] is False
+        assert agents["StockAdvisor"]["mcp_tool_enabled"] is True
+        assert agents["PlantAdvisor"]["http_endpoint_enabled"] is True
+        assert agents["PlantAdvisor"]["mcp_tool_enabled"] is True
+
+        disabled_response = sample_helper.post_json(
+            f"{base_url}/api/agents/StockAdvisor/run",
+            {"message": "What is the current price of MSFT?"},
+        )
+        assert disabled_response.status_code == 404
+
+    async def test_mcp_tools_can_be_listed_and_invoked(self, base_url: str) -> None:
+        """Verify MCP-only and dual-trigger agents are callable as MCP tools."""
+        async with (
+            streamable_http_client(f"{base_url}/runtime/webhooks/mcp") as (
+                read_stream,
+                write_stream,
+                _,
+            ),
+            ClientSession(read_stream, write_stream) as session,
+        ):
+            await session.initialize()
+
+            tools = (await session.list_tools()).tools
+            tool_names = {tool.name for tool in tools}
+            assert "Joker" not in tool_names
+            assert {"StockAdvisor", "PlantAdvisor"} <= tool_names
+
+            for tool_name, query in (
+                ("StockAdvisor", "What was the all-time high price of MSFT?"),
+                ("PlantAdvisor", "Recommend a low-light indoor plant."),
+            ):
+                result = await session.call_tool(tool_name, {"query": query})
+                assert result.isError is False
+                assert _response_text(result).strip()

--- a/python/packages/azurefunctions/tests/integration_tests/test_09_workflow_shared_state.py
+++ b/python/packages/azurefunctions/tests/integration_tests/test_09_workflow_shared_state.py
@@ -21,7 +21,7 @@ Usage:
 
 import pytest
 
-# Must match the workflow name in samples/04-hosting/azure_functions/09_workflow_shared_state/function_app.py
+# Must match the workflow name in samples/azure_functions/09_workflow_shared_state/function_app.py
 WORKFLOW_NAME = "email_triage_shared_state"
 
 # Module-level markers - applied to all tests in this file

--- a/python/packages/azurefunctions/tests/integration_tests/test_10_workflow_no_shared_state.py
+++ b/python/packages/azurefunctions/tests/integration_tests/test_10_workflow_no_shared_state.py
@@ -21,7 +21,7 @@ Usage:
 
 import pytest
 
-# Must match the workflow name in samples/04-hosting/azure_functions/10_workflow_no_shared_state/function_app.py
+# Must match the workflow name in samples/azure_functions/10_workflow_no_shared_state/function_app.py
 WORKFLOW_NAME = "email_triage"
 
 # Module-level markers - applied to all tests in this file

--- a/python/packages/azurefunctions/tests/integration_tests/test_11_workflow_parallel.py
+++ b/python/packages/azurefunctions/tests/integration_tests/test_11_workflow_parallel.py
@@ -45,7 +45,6 @@ class TestWorkflowParallel:
         self.base_url = base_url
         self.helper = sample_helper
 
-    @pytest.mark.skip(reason="Flaky in CI: times out / crashes the xdist runner; temporarily disabled.")
     def test_parallel_workflow_end_to_end(self) -> None:
         """Run the parallel workflow end-to-end: start, check status, verify completion.
 

--- a/python/packages/azurefunctions/tests/integration_tests/test_11_workflow_parallel.py
+++ b/python/packages/azurefunctions/tests/integration_tests/test_11_workflow_parallel.py
@@ -23,7 +23,7 @@ Usage:
 
 import pytest
 
-# Must match the workflow name in samples/04-hosting/azure_functions/11_workflow_parallel/function_app.py
+# Must match the workflow name in samples/azure_functions/11_workflow_parallel/function_app.py
 WORKFLOW_NAME = "parallel_review"
 
 # Module-level markers - applied to all tests in this file

--- a/python/packages/azurefunctions/tests/integration_tests/test_12_workflow_hitl.py
+++ b/python/packages/azurefunctions/tests/integration_tests/test_12_workflow_hitl.py
@@ -34,7 +34,7 @@ pytestmark = [
     pytest.mark.usefixtures("function_app_for_test"),
 ]
 
-# Must match the workflow name in samples/04-hosting/azure_functions/12_workflow_hitl/function_app.py
+# Must match the workflow name in samples/azure_functions/12_workflow_hitl/function_app.py
 WORKFLOW_NAME = "content_moderation"
 
 

--- a/python/packages/azurefunctions/tests/test_azurefunctions_workflow_initial_input.py
+++ b/python/packages/azurefunctions/tests/test_azurefunctions_workflow_initial_input.py
@@ -1,0 +1,72 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+"""Behavioral tests for Azure Functions workflow HTTP initial input."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any, TypeVar
+from unittest.mock import AsyncMock, Mock, patch
+
+from agent_framework import Executor, Workflow, WorkflowBuilder, WorkflowContext, handler
+
+from agent_framework_azurefunctions import AgentFunctionApp
+
+FuncT = TypeVar("FuncT", bound=Callable[..., Any])
+
+
+def _identity_decorator(*args: Any, **kwargs: Any) -> Callable[[FuncT], FuncT]:
+    def decorator(func: FuncT) -> FuncT:
+        return func
+
+    return decorator
+
+
+class _Start(Executor):
+    def __init__(self) -> None:
+        super().__init__(id="start")
+
+    @handler(input=str | dict, workflow_output=str)
+    async def run(self, message: str | dict, ctx: WorkflowContext) -> None:
+        pass
+
+
+def _capture_run_handler(workflow: Workflow) -> Callable[..., Any]:
+    captured_routes: dict[str, Callable[..., Any]] = {}
+
+    def capture_route(*args: Any, **kwargs: Any) -> Callable[[FuncT], FuncT]:
+        def decorator(func: FuncT) -> FuncT:
+            captured_routes[kwargs["route"]] = func
+            return func
+
+        return decorator
+
+    with (
+        patch.object(AgentFunctionApp, "function_name", new=_identity_decorator),
+        patch.object(AgentFunctionApp, "route", new=capture_route),
+        patch.object(AgentFunctionApp, "durable_client_input", new=_identity_decorator),
+        patch.object(AgentFunctionApp, "activity_trigger", new=_identity_decorator),
+        patch.object(AgentFunctionApp, "orchestration_trigger", new=_identity_decorator),
+    ):
+        AgentFunctionApp(workflow=workflow, enable_health_check=False)
+
+    return captured_routes[f"workflow/{workflow.name}/run"]
+
+
+async def test_workflow_run_route_neutralizes_reserved_marker_shaped_input() -> None:
+    """The workflow run route schedules neutralized framework-reserved metadata."""
+    executor = _Start()
+    workflow = WorkflowBuilder(name="input_boundary", start_executor=executor, output_from=[executor]).build()
+    handler = _capture_run_handler(workflow)
+    request = Mock()
+    request.get_json.return_value = {
+        "__pickled__": "not-checkpoint-data",
+        "__type__": "builtins:int",
+    }
+    request.url = "https://example.test/api/workflow/input_boundary/run"
+    client = AsyncMock()
+    client.start_new.return_value = "instance-1"
+
+    await handler(request, client)
+
+    assert client.start_new.await_args.kwargs["client_input"] is None

--- a/python/packages/azurefunctions/tests/test_integration_sample_coverage.py
+++ b/python/packages/azurefunctions/tests/test_integration_sample_coverage.py
@@ -1,0 +1,48 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+"""Coverage checks for the Azure Functions sample integration tests."""
+
+import ast
+from pathlib import Path
+
+
+def _sample_markers(test_file: Path) -> set[str]:
+    """Return literal pytest.mark.sample values declared in a test module."""
+    tree = ast.parse(test_file.read_text(encoding="utf-8"), filename=str(test_file))
+    markers: set[str] = set()
+
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "sample"
+            and len(node.args) == 1
+            and isinstance(node.args[0], ast.Constant)
+            and isinstance(node.args[0].value, str)
+        ):
+            markers.add(node.args[0].value)
+
+    return markers
+
+
+def test_every_sample_has_integration_coverage() -> None:
+    """Require each Azure Functions sample to have one integration test module."""
+    python_root = Path(__file__).resolve().parents[3]
+    sample_root = python_root / "samples" / "azure_functions"
+    integration_test_root = Path(__file__).parent / "integration_tests"
+
+    sample_names = {
+        path.name for path in sample_root.iterdir() if path.is_dir() and (path / "function_app.py").is_file()
+    }
+    markers_by_test = {
+        test_file.name: _sample_markers(test_file) for test_file in integration_test_root.glob("test_*.py")
+    }
+
+    invalid_tests = {test_name: markers for test_name, markers in markers_by_test.items() if len(markers) != 1}
+    assert not invalid_tests, f"Integration test modules must declare exactly one sample marker: {invalid_tests}"
+
+    covered_samples = set().union(*markers_by_test.values())
+    assert covered_samples == sample_names, (
+        f"Missing integration coverage: {sorted(sample_names - covered_samples)}; "
+        f"stale integration markers: {sorted(covered_samples - sample_names)}"
+    )

--- a/python/packages/azurefunctions/tests/test_integration_sample_coverage.py
+++ b/python/packages/azurefunctions/tests/test_integration_sample_coverage.py
@@ -25,8 +25,43 @@ def _sample_markers(test_file: Path) -> set[str]:
     return markers
 
 
+def _is_pytest_skip_marker(node: ast.expr) -> bool:
+    """Return whether an expression is pytest.mark.skip, with or without arguments."""
+    target = node.func if isinstance(node, ast.Call) else node
+    return (
+        isinstance(target, ast.Attribute)
+        and target.attr == "skip"
+        and isinstance(target.value, ast.Attribute)
+        and target.value.attr == "mark"
+        and isinstance(target.value.value, ast.Name)
+        and target.value.value.id == "pytest"
+    )
+
+
+def _unconditional_skip_lines(test_file: Path) -> list[int]:
+    """Return lines containing unconditional pytest skip markers."""
+    tree = ast.parse(test_file.read_text(encoding="utf-8"), filename=str(test_file))
+    skip_lines: list[int] = []
+
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)):
+            skip_lines.extend(
+                decorator.lineno for decorator in node.decorator_list if _is_pytest_skip_marker(decorator)
+            )
+
+    for statement in tree.body:
+        if (
+            isinstance(statement, (ast.Assign, ast.AnnAssign))
+            and any(isinstance(target, ast.Name) and target.id == "pytestmark" for target in ast.walk(statement))
+            and any(_is_pytest_skip_marker(node) for node in ast.walk(statement) if isinstance(node, ast.expr))
+        ):
+            skip_lines.append(statement.lineno)
+
+    return sorted(set(skip_lines))
+
+
 def test_every_sample_has_integration_coverage() -> None:
-    """Require each Azure Functions sample to have one integration test module."""
+    """Require each Azure Functions sample to have an enabled integration test module."""
     python_root = Path(__file__).resolve().parents[3]
     sample_root = python_root / "samples" / "azure_functions"
     integration_test_root = Path(__file__).parent / "integration_tests"
@@ -41,8 +76,55 @@ def test_every_sample_has_integration_coverage() -> None:
     invalid_tests = {test_name: markers for test_name, markers in markers_by_test.items() if len(markers) != 1}
     assert not invalid_tests, f"Integration test modules must declare exactly one sample marker: {invalid_tests}"
 
+    skipped_tests = {
+        test_file.name: skip_lines
+        for test_file in integration_test_root.glob("test_*.py")
+        if (skip_lines := _unconditional_skip_lines(test_file))
+    }
+    assert not skipped_tests, f"Integration test modules must not contain unconditional skips: {skipped_tests}"
+
     covered_samples = set().union(*markers_by_test.values())
     assert covered_samples == sample_names, (
         f"Missing integration coverage: {sorted(sample_names - covered_samples)}; "
         f"stale integration markers: {sorted(covered_samples - sample_names)}"
     )
+
+
+def test_skip_guard_detects_decorators_and_module_markers(tmp_path: Path) -> None:
+    """Detect called, bare, and module-level unconditional skip markers."""
+    test_file = tmp_path / "test_sample.py"
+    test_file.write_text(
+        """
+import pytest
+
+pytestmark = [pytest.mark.integration, pytest.mark.skip(reason="disabled")]
+
+@pytest.mark.skip
+def test_bare_skip():
+    pass
+
+@pytest.mark.skip(reason="disabled")
+def test_called_skip():
+    pass
+""",
+        encoding="utf-8",
+    )
+
+    assert len(_unconditional_skip_lines(test_file)) == 3
+
+
+def test_skip_guard_ignores_conditional_runtime_skips(tmp_path: Path) -> None:
+    """Allow runtime skips that depend on conditions inside a test."""
+    test_file = tmp_path / "test_sample.py"
+    test_file.write_text(
+        """
+import pytest
+
+def test_conditionally_skipped(condition):
+    if condition:
+        pytest.skip("not supported in this environment")
+""",
+        encoding="utf-8",
+    )
+
+    assert _unconditional_skip_lines(test_file) == []

--- a/python/packages/azurefunctions/tests/test_integration_sample_coverage.py
+++ b/python/packages/azurefunctions/tests/test_integration_sample_coverage.py
@@ -90,6 +90,23 @@ def test_every_sample_has_integration_coverage() -> None:
     )
 
 
+def test_integration_pipelines_run_azure_functions_suite() -> None:
+    """Require every Python integration pipeline to execute the Azure Functions suite."""
+    repo_root = Path(__file__).resolve().parents[4]
+    pipeline_paths = [
+        repo_root / ".github" / "workflows" / "python-integration-tests.yml",
+        repo_root / "eng" / "templates" / "jobs" / "python-integration-tests.yml",
+    ]
+    expected_command = "pytest packages/azurefunctions/tests/integration_tests"
+
+    missing_invocations = [
+        str(path.relative_to(repo_root))
+        for path in pipeline_paths
+        if expected_command not in path.read_text(encoding="utf-8")
+    ]
+    assert not missing_invocations, f"Azure Functions integration suite is not invoked by: {missing_invocations}"
+
+
 def test_skip_guard_detects_decorators_and_module_markers(tmp_path: Path) -> None:
     """Detect called, bare, and module-level unconditional skip markers."""
     test_file = tmp_path / "test_sample.py"

--- a/python/packages/durabletask/agent_framework_durabletask/_client.py
+++ b/python/packages/durabletask/agent_framework_durabletask/_client.py
@@ -29,7 +29,7 @@ class DurableAIAgentClient(DurableAgentProvider[AgentResponse]):
     Example:
         ```python
         from durabletask import TaskHubGrpcClient
-        from agent_framework.azure import DurableAIAgentClient
+        from agent_framework_durabletask import DurableAIAgentClient
 
         # Create the underlying client
         client = TaskHubGrpcClient(host_address="localhost:4001")

--- a/python/packages/durabletask/agent_framework_durabletask/_orchestration_context.py
+++ b/python/packages/durabletask/agent_framework_durabletask/_orchestration_context.py
@@ -28,7 +28,7 @@ class DurableAIAgentOrchestrationContext(DurableAgentProvider[DurableAgentTask])
     Example:
         ```python
         from durabletask import Orchestration
-        from agent_framework.azure import DurableAIAgentOrchestrationContext
+        from agent_framework_durabletask import DurableAIAgentOrchestrationContext
 
 
         def my_orchestration(context: OrchestrationContext):

--- a/python/packages/durabletask/agent_framework_durabletask/_workflows/client.py
+++ b/python/packages/durabletask/agent_framework_durabletask/_workflows/client.py
@@ -49,7 +49,7 @@ class DurableWorkflowClient:
     Example:
         ```python
         from durabletask.azuremanaged.client import DurableTaskSchedulerClient
-        from agent_framework.azure import DurableWorkflowClient
+        from agent_framework_durabletask import DurableWorkflowClient
 
         # Create the underlying client
         client = DurableTaskSchedulerClient(host_address="localhost:8080", taskhub="default")

--- a/python/packages/durabletask/agent_framework_durabletask/_workflows/orchestrator.py
+++ b/python/packages/durabletask/agent_framework_durabletask/_workflows/orchestrator.py
@@ -746,7 +746,7 @@ def _coerce_initial_input(workflow: Workflow, raw_value: Any) -> Any:
 
     input_type = _select_primary_input_type(start_executor)
     if input_type is None:
-        return raw_value
+        return strip_pickle_markers(raw_value)
     # The initial payload is untrusted external input (HTTP body / client input) with no
     # legitimate checkpoint type markers, so neutralize any pickle-marker injection before
     # it can reach deserialize_value() inside reconstruct_to_type() (avoids pickle RCE).

--- a/python/packages/durabletask/tests/test_durabletask_workflow_initial_input.py
+++ b/python/packages/durabletask/tests/test_durabletask_workflow_initial_input.py
@@ -1,0 +1,112 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+"""Behavioral tests for Durable Task workflow initial input."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from typing import Any
+
+from agent_framework import Executor, Workflow, WorkflowBuilder, WorkflowContext, handler
+
+from agent_framework_durabletask import execute_workflow_activity, run_workflow_orchestrator
+
+
+class _InlineWorkflowHost:
+    """Run activity tasks inline while exercising the public orchestration surface."""
+
+    def __init__(self, workflow: Workflow) -> None:
+        self.workflow = workflow
+
+    @property
+    def instance_id(self) -> str:
+        return "test-instance"
+
+    @property
+    def is_replaying(self) -> bool:
+        return False
+
+    @property
+    def supports_event_streaming(self) -> bool:
+        return False
+
+    @property
+    def current_utc_datetime(self) -> datetime:
+        return datetime.now(timezone.utc)
+
+    def prepare_agent_task(self, executor_id: str, message: str, orchestration_instance_id: str) -> Any:
+        raise AssertionError("This test workflow has no agent executors")
+
+    def prepare_activity_task(self, activity_name: str, input_json: str) -> str:
+        activity_input = json.loads(input_json)
+        executor = self.workflow.executors[activity_input["executor_id"]]
+        return execute_workflow_activity(executor, input_json, self.workflow)
+
+    def call_sub_orchestrator(self, name: str, input: Any, instance_id: str | None = None) -> Any:
+        raise AssertionError("This test workflow has no sub-workflows")
+
+    def task_all(self, tasks: list[Any]) -> list[Any]:
+        return tasks
+
+    def task_any(self, tasks: list[Any]) -> Any:
+        raise AssertionError("This test workflow does not wait for competing tasks")
+
+    def wait_for_external_event(self, name: str) -> Any:
+        raise AssertionError("This test workflow has no external events")
+
+    def create_timer(self, fire_at: datetime) -> Any:
+        raise AssertionError("This test workflow has no timers")
+
+    def set_custom_status(self, status: Any) -> None:
+        pass
+
+    def new_uuid(self) -> str:
+        return "test-uuid"
+
+    def cancel_task(self, task: Any) -> None:
+        pass
+
+    def get_task_result(self, task: Any) -> Any:
+        return task
+
+
+class _NullableUnionStart(Executor):
+    def __init__(self) -> None:
+        super().__init__(id="start")
+
+    @handler(input=str | dict | None, workflow_output=str)
+    async def run(self, message: str | dict[str, Any] | None, ctx: WorkflowContext[Any, str]) -> None:
+        await ctx.yield_output("neutralized" if message is None else "accepted")
+
+
+def _run_inline(workflow: Workflow, initial_input: Any) -> list[Any] | dict[str, Any]:
+    host = _InlineWorkflowHost(workflow)
+    orchestration = run_workflow_orchestrator(host, workflow, initial_input)
+    yielded = next(orchestration)
+
+    while True:
+        try:
+            yielded = orchestration.send(yielded)
+        except StopIteration as completed:
+            return completed.value
+
+
+def test_reserved_marker_shaped_initial_input_is_neutralized() -> None:
+    """Framework-reserved serialization metadata is not delivered as application input."""
+    executor = _NullableUnionStart()
+    workflow = WorkflowBuilder(start_executor=executor, output_from=[executor]).build()
+    initial_input = {
+        "__pickled__": "not-checkpoint-data",
+        "__type__": "builtins:int",
+    }
+
+    assert _run_inline(workflow, initial_input) == ["neutralized"]
+
+
+def test_regular_union_initial_input_is_preserved() -> None:
+    """Ordinary JSON input keeps the union-typed workflow's existing behavior."""
+    executor = _NullableUnionStart()
+    workflow = WorkflowBuilder(start_executor=executor, output_from=[executor]).build()
+
+    assert _run_inline(workflow, {"message": "hello"}) == ["accepted"]

--- a/python/samples/01_single_agent/client.py
+++ b/python/samples/01_single_agent/client.py
@@ -16,7 +16,7 @@ import asyncio
 import logging
 import os
 
-from agent_framework.azure import DurableAIAgentClient
+from agent_framework_durabletask import DurableAIAgentClient
 from azure.identity import AzureCliCredential
 from dotenv import load_dotenv
 from durabletask.azuremanaged.client import DurableTaskSchedulerClient

--- a/python/samples/01_single_agent/worker.py
+++ b/python/samples/01_single_agent/worker.py
@@ -16,8 +16,8 @@ import logging
 import os
 
 from agent_framework import Agent
-from agent_framework.azure import DurableAIAgentWorker
 from agent_framework.foundry import FoundryChatClient
+from agent_framework_durabletask import DurableAIAgentWorker
 from azure.identity import AzureCliCredential
 from azure.identity.aio import AzureCliCredential as AsyncAzureCliCredential
 from dotenv import load_dotenv

--- a/python/samples/02_multi_agent/client.py
+++ b/python/samples/02_multi_agent/client.py
@@ -17,7 +17,7 @@ import asyncio
 import logging
 import os
 
-from agent_framework.azure import DurableAIAgentClient
+from agent_framework_durabletask import DurableAIAgentClient
 from azure.identity import AzureCliCredential
 from dotenv import load_dotenv
 from durabletask.azuremanaged.client import DurableTaskSchedulerClient

--- a/python/samples/02_multi_agent/worker.py
+++ b/python/samples/02_multi_agent/worker.py
@@ -18,8 +18,8 @@ import os
 from typing import Any
 
 from agent_framework import Agent, tool
-from agent_framework.azure import DurableAIAgentWorker
 from agent_framework.openai import OpenAIChatCompletionClient
+from agent_framework_durabletask import DurableAIAgentWorker
 from azure.identity import AzureCliCredential
 from azure.identity.aio import AzureCliCredential as AsyncAzureCliCredential
 from dotenv import load_dotenv

--- a/python/samples/03_single_agent_streaming/client.py
+++ b/python/samples/03_single_agent_streaming/client.py
@@ -20,7 +20,7 @@ import os
 from datetime import timedelta
 
 import redis.asyncio as aioredis
-from agent_framework.azure import DurableAIAgentClient
+from agent_framework_durabletask import DurableAIAgentClient
 from azure.identity import AzureCliCredential
 from dotenv import load_dotenv
 from durabletask.azuremanaged.client import DurableTaskSchedulerClient

--- a/python/samples/03_single_agent_streaming/worker.py
+++ b/python/samples/03_single_agent_streaming/worker.py
@@ -19,12 +19,12 @@ from datetime import timedelta
 
 import redis.asyncio as aioredis
 from agent_framework import Agent, AgentResponseUpdate
-from agent_framework.azure import (
+from agent_framework.foundry import FoundryChatClient
+from agent_framework_durabletask import (
     AgentCallbackContext,
     AgentResponseCallbackProtocol,
     DurableAIAgentWorker,
 )
-from agent_framework.foundry import FoundryChatClient
 from azure.identity import AzureCliCredential
 from azure.identity.aio import AzureCliCredential as AsyncAzureCliCredential
 from dotenv import load_dotenv

--- a/python/samples/04_single_agent_orchestration_chaining/worker.py
+++ b/python/samples/04_single_agent_orchestration_chaining/worker.py
@@ -18,8 +18,8 @@ import os
 from collections.abc import Generator
 
 from agent_framework import Agent, AgentResponse
-from agent_framework.azure import DurableAIAgentOrchestrationContext, DurableAIAgentWorker
 from agent_framework.foundry import FoundryChatClient
+from agent_framework_durabletask import DurableAIAgentOrchestrationContext, DurableAIAgentWorker
 from azure.identity import AzureCliCredential
 from azure.identity.aio import AzureCliCredential as AsyncAzureCliCredential
 from dotenv import load_dotenv

--- a/python/samples/05_multi_agent_orchestration_concurrency/worker.py
+++ b/python/samples/05_multi_agent_orchestration_concurrency/worker.py
@@ -19,8 +19,8 @@ from collections.abc import Generator
 from typing import Any
 
 from agent_framework import Agent, AgentResponse
-from agent_framework.azure import DurableAIAgentOrchestrationContext, DurableAIAgentWorker
 from agent_framework.foundry import FoundryChatClient
+from agent_framework_durabletask import DurableAIAgentOrchestrationContext, DurableAIAgentWorker
 from azure.identity import AzureCliCredential
 from azure.identity.aio import AzureCliCredential as AsyncAzureCliCredential
 from dotenv import load_dotenv

--- a/python/samples/06_multi_agent_orchestration_conditionals/worker.py
+++ b/python/samples/06_multi_agent_orchestration_conditionals/worker.py
@@ -19,8 +19,8 @@ from collections.abc import Generator
 from typing import Any, cast
 
 from agent_framework import Agent, AgentResponse
-from agent_framework.azure import DurableAIAgentOrchestrationContext, DurableAIAgentWorker
 from agent_framework.openai import OpenAIChatCompletionClient
+from agent_framework_durabletask import DurableAIAgentOrchestrationContext, DurableAIAgentWorker
 from azure.identity import AzureCliCredential
 from azure.identity.aio import AzureCliCredential as AsyncAzureCliCredential
 from azure.identity.aio import get_bearer_token_provider as get_async_bearer_token_provider

--- a/python/samples/07_single_agent_orchestration_hitl/worker.py
+++ b/python/samples/07_single_agent_orchestration_hitl/worker.py
@@ -20,8 +20,8 @@ from datetime import timedelta
 from typing import Any, cast
 
 from agent_framework import Agent, AgentResponse
-from agent_framework.azure import DurableAIAgentOrchestrationContext, DurableAIAgentWorker
 from agent_framework.foundry import FoundryChatClient
+from agent_framework_durabletask import DurableAIAgentOrchestrationContext, DurableAIAgentWorker
 from azure.identity import AzureCliCredential
 from azure.identity.aio import AzureCliCredential as AsyncAzureCliCredential
 from dotenv import load_dotenv

--- a/python/samples/08_workflow/client.py
+++ b/python/samples/08_workflow/client.py
@@ -16,7 +16,7 @@ import asyncio
 import logging
 import os
 
-from agent_framework.azure import DurableWorkflowClient
+from agent_framework_durabletask import DurableWorkflowClient
 from azure.identity import AzureCliCredential
 from dotenv import load_dotenv
 from durabletask.azuremanaged.client import DurableTaskSchedulerClient

--- a/python/samples/08_workflow/worker.py
+++ b/python/samples/08_workflow/worker.py
@@ -38,8 +38,8 @@ from agent_framework import (
     WorkflowContext,
     handler,
 )
-from agent_framework.azure import DurableAIAgentWorker
 from agent_framework.foundry import FoundryChatClient, FoundryChatOptions
+from agent_framework_durabletask import DurableAIAgentWorker
 from azure.identity import AzureCliCredential
 from azure.identity.aio import AzureCliCredential as AsyncAzureCliCredential
 from dotenv import load_dotenv

--- a/python/samples/09_workflow_hitl/client.py
+++ b/python/samples/09_workflow_hitl/client.py
@@ -23,7 +23,7 @@ import os
 import time
 from typing import Any
 
-from agent_framework.azure import DurableWorkflowClient
+from agent_framework_durabletask import DurableWorkflowClient
 from azure.identity import AzureCliCredential
 from dotenv import load_dotenv
 from durabletask.azuremanaged.client import DurableTaskSchedulerClient

--- a/python/samples/09_workflow_hitl/worker.py
+++ b/python/samples/09_workflow_hitl/worker.py
@@ -48,8 +48,8 @@ from agent_framework import (
     handler,
     response_handler,
 )
-from agent_framework.azure import DurableAIAgentWorker
 from agent_framework.foundry import FoundryChatClient, FoundryChatOptions
+from agent_framework_durabletask import DurableAIAgentWorker
 from azure.identity import AzureCliCredential
 from azure.identity.aio import AzureCliCredential as AsyncAzureCliCredential
 from dotenv import load_dotenv

--- a/python/samples/10_workflow_streaming/client.py
+++ b/python/samples/10_workflow_streaming/client.py
@@ -24,7 +24,7 @@ import asyncio
 import logging
 import os
 
-from agent_framework.azure import DurableWorkflowClient
+from agent_framework_durabletask import DurableWorkflowClient
 from azure.identity import AzureCliCredential
 from dotenv import load_dotenv
 from durabletask.azuremanaged.client import DurableTaskSchedulerClient

--- a/python/samples/10_workflow_streaming/worker.py
+++ b/python/samples/10_workflow_streaming/worker.py
@@ -34,8 +34,8 @@ from agent_framework import (
     WorkflowContext,
     handler,
 )
-from agent_framework.azure import DurableAIAgentWorker
 from agent_framework.foundry import FoundryChatClient
+from agent_framework_durabletask import DurableAIAgentWorker
 from azure.identity import AzureCliCredential
 from azure.identity.aio import AzureCliCredential as AsyncAzureCliCredential
 from dotenv import load_dotenv

--- a/python/samples/11_subworkflow/client.py
+++ b/python/samples/11_subworkflow/client.py
@@ -19,7 +19,7 @@ import asyncio
 import logging
 import os
 
-from agent_framework.azure import DurableWorkflowClient
+from agent_framework_durabletask import DurableWorkflowClient
 from azure.identity import AzureCliCredential
 from dotenv import load_dotenv
 from durabletask.azuremanaged.client import DurableTaskSchedulerClient

--- a/python/samples/11_subworkflow/worker.py
+++ b/python/samples/11_subworkflow/worker.py
@@ -50,8 +50,8 @@ from agent_framework import (
     WorkflowExecutor,
     handler,
 )
-from agent_framework.azure import DurableAIAgentWorker
 from agent_framework.foundry import FoundryChatClient, FoundryChatOptions
+from agent_framework_durabletask import DurableAIAgentWorker
 from azure.identity import AzureCliCredential
 from azure.identity.aio import AzureCliCredential as AsyncAzureCliCredential
 from dotenv import load_dotenv

--- a/python/samples/12_subworkflow_hitl/client.py
+++ b/python/samples/12_subworkflow_hitl/client.py
@@ -25,7 +25,7 @@ import os
 import time
 from typing import Any
 
-from agent_framework.azure import DurableWorkflowClient
+from agent_framework_durabletask import DurableWorkflowClient
 from azure.identity import AzureCliCredential
 from dotenv import load_dotenv
 from durabletask.azuremanaged.client import DurableTaskSchedulerClient

--- a/python/samples/12_subworkflow_hitl/worker.py
+++ b/python/samples/12_subworkflow_hitl/worker.py
@@ -50,7 +50,7 @@ from agent_framework import (
     handler,
     response_handler,
 )
-from agent_framework.azure import DurableAIAgentWorker
+from agent_framework_durabletask import DurableAIAgentWorker
 from azure.identity import AzureCliCredential
 from dotenv import load_dotenv
 from durabletask.azuremanaged.worker import DurableTaskSchedulerWorker

--- a/python/samples/README.md
+++ b/python/samples/README.md
@@ -2,6 +2,22 @@
 
 This directory contains samples for durable agent hosting using the Durable Task Scheduler. These samples demonstrate the worker-client architecture pattern, enabling distributed agent execution with persistent conversation state.
 
+## Import convention
+
+These samples import the durable hosting types **directly from the extension packages** —
+`agent_framework_durabletask` and `agent_framework_azurefunctions`:
+
+```python
+from agent_framework_durabletask import DurableAIAgentWorker, DurableWorkflowClient
+from agent_framework_azurefunctions import AgentFunctionApp
+```
+
+For backward compatibility these entry-point types are also re-exported from
+`agent_framework.azure` in the core `agent-framework` package, so existing
+`from agent_framework.azure import ...` code keeps working. **New and updated samples should use
+the direct package imports shown above** — the canonical, self-contained path for this repo —
+rather than routing through the `agent_framework.azure` shim.
+
 ## Quick Prerequisites Checklist
 
 Install and verify these tools before [Running the Samples](#running-the-samples):
@@ -56,8 +72,19 @@ az account show
 
 ### Azure Functions Hosting
 
-These samples host workflows on Azure Durable Functions (`func start`) instead of the worker-client model above. Each has its own setup steps in its README.
+These samples host workflows and agents on Azure Durable Functions (`func start`) instead of the worker-client model above. Each has its own setup steps in its README, and shared environment setup lives in [azure_functions/README.md](azure_functions/README.md).
 
+- **[azure_functions/01_single_agent](azure_functions/01_single_agent/)**: Host a single AI agent on Azure Functions with direct HTTP API access for interactive conversations.
+- **[azure_functions/02_multi_agent](azure_functions/02_multi_agent/)**: Host multiple AI agents on Azure Functions, each reachable via its own HTTP endpoint.
+- **[azure_functions/03_reliable_streaming](azure_functions/03_reliable_streaming/)**: Reliable, resumable streaming for durable agents using Redis Streams with cursor-based reconnection.
+- **[azure_functions/04_single_agent_orchestration_chaining](azure_functions/04_single_agent_orchestration_chaining/)**: Chain two invocations of the same agent inside a Durable Functions orchestration, preserving conversation state between runs.
+- **[azure_functions/05_multi_agent_orchestration_concurrency](azure_functions/05_multi_agent_orchestration_concurrency/)**: Run two agents in parallel inside a Durable Functions orchestration and merge their responses.
+- **[azure_functions/06_multi_agent_orchestration_conditionals](azure_functions/06_multi_agent_orchestration_conditionals/)**: Conditional orchestration that screens emails with a spam-detector agent and drafts replies with an email assistant agent.
+- **[azure_functions/07_single_agent_orchestration_hitl](azure_functions/07_single_agent_orchestration_hitl/)**: Human-in-the-loop orchestration where a writer agent iterates until a reviewer approves or the attempt limit is reached.
+- **[azure_functions/08_mcp_server](azure_functions/08_mcp_server/)**: Expose agents as both HTTP endpoints and [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) tools.
+- **[azure_functions/09_workflow_shared_state](azure_functions/09_workflow_shared_state/)**: Run a MAF `Workflow` with `SharedState` on Azure Durable Functions.
+- **[azure_functions/10_workflow_no_shared_state](azure_functions/10_workflow_no_shared_state/)**: Run a MAF `Workflow` on Azure Durable Functions without SharedState.
+- **[azure_functions/11_workflow_parallel](azure_functions/11_workflow_parallel/)**: Parallel execution of executors and agents in an Azure Durable Functions workflow.
 - **[azure_functions/12_workflow_hitl](azure_functions/12_workflow_hitl/)**: The workflow human-in-the-loop pattern on Azure Durable Functions, with the reviewer notified from inside the workflow via `WorkflowHitlContext`.
 - **[azure_functions/13_subworkflow_hitl](azure_functions/13_subworkflow_hitl/)**: A human-in-the-loop pause inside a sub-workflow on Azure Durable Functions, exposed through a single top-level respond surface.
 

--- a/python/samples/azure_functions/01_single_agent/README.md
+++ b/python/samples/azure_functions/01_single_agent/README.md
@@ -1,0 +1,64 @@
+# Single Agent Sample (Python)
+
+This sample demonstrates how to use the Durable Extension for Agent Framework to create a simple Azure Functions app that hosts a single AI agent and provides direct HTTP API access for interactive conversations.
+
+## Key Concepts Demonstrated
+
+- Defining a simple agent with the Microsoft Agent Framework and wiring it into
+  an Azure Functions app via the Durable Extension for Agent Framework.
+- Calling the agent through generated HTTP endpoints (`/api/agents/Joker/run`).
+- Managing conversation state with session identifiers, so multiple clients can
+  interact with the agent concurrently without sharing context.
+
+## Prerequisites
+
+Follow the common setup steps in `../README.md` to install tooling, configure Azure OpenAI credentials, and install the Python dependencies for this sample.
+
+## Running the Sample
+
+Send a prompt to the Joker agent:
+
+Bash (Linux/macOS/WSL):
+
+```bash
+curl -i -X POST http://localhost:7071/api/agents/Joker/run \
+     -d "Tell me a short joke about cloud computing."
+```
+
+PowerShell:
+
+```powershell
+Invoke-RestMethod -Method Post -Uri http://localhost:7071/api/agents/Joker/run `
+    -Body "Tell me a short joke about cloud computing."
+```
+
+The agent responds with a JSON payload that includes the generated joke.
+
+> [!TIP]
+> To return immediately with an HTTP 202 response instead of waiting for the agent output, set the `x-ms-wait-for-response` header or include `"wait_for_response": false` in the request body. The default behavior waits for the response.
+
+## Expected Output
+
+The default plain-text response looks like the following:
+
+```http
+HTTP/1.1 200 OK
+Content-Type: text/plain; charset=utf-8
+x-ms-thread-id: 4f205157170244bfbd80209df383757e
+
+Why did the cloud break up with the server?
+
+Because it found someone more "uplifting"!
+```
+
+When you specify the `x-ms-wait-for-response` header or include `"wait_for_response": false` in the request body, the Functions host responds with an HTTP 202 and queues the request to run in the background. A typical response body looks like the following:
+
+```json
+{
+  "status": "accepted",
+  "response": "Agent request accepted",
+  "message": "Tell me a short joke about cloud computing.",
+  "thread_id": "<guid>",
+  "correlation_id": "<guid>"
+}
+```

--- a/python/samples/azure_functions/01_single_agent/demo.http
+++ b/python/samples/azure_functions/01_single_agent/demo.http
@@ -1,0 +1,22 @@
+### Joker Agent Sample Interactions
+@baseUrl = http://localhost:7071
+@agentName = Joker
+@agentRoute = {{baseUrl}}/api/agents/{{agentName}}
+@healthRoute = {{baseUrl}}/api/health
+
+### Health Check
+GET {{healthRoute}}
+
+### Ask for a joke (JSON payload)
+POST {{agentRoute}}/run
+Content-Type: application/json
+
+{
+  "message": "Add a security element to it.",
+  "thread_id": "thread-001"
+}
+
+### Ask for a joke (plain text payload)
+POST {{agentRoute}}/run
+
+Give me a programming joke about race conditions.

--- a/python/samples/azure_functions/01_single_agent/function_app.py
+++ b/python/samples/azure_functions/01_single_agent/function_app.py
@@ -1,0 +1,52 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+"""Host a single Foundry-powered agent inside Azure Functions.
+
+Components used in this sample:
+- FoundryChatClient to call the Foundry deployment.
+- AgentFunctionApp to expose HTTP endpoints via the Durable Functions extension.
+
+Prerequisites: set `FOUNDRY_PROJECT_ENDPOINT`, `FOUNDRY_MODEL`, and sign in
+with Azure CLI before starting the Functions host."""
+
+import os
+from typing import Any
+
+from agent_framework import Agent
+from agent_framework.foundry import FoundryChatClient
+from agent_framework_azurefunctions import AgentFunctionApp
+from azure.identity.aio import AzureCliCredential
+from dotenv import load_dotenv
+
+load_dotenv()
+
+
+# 1. Instantiate the agent with the chosen deployment and instructions.
+def _create_agent() -> Any:
+    """Create the Joker agent."""
+    return Agent(
+        client=FoundryChatClient(
+            project_endpoint=os.environ["FOUNDRY_PROJECT_ENDPOINT"],
+            model=os.environ["FOUNDRY_MODEL"],
+            credential=AzureCliCredential(),
+        ),
+        name="Joker",
+        instructions="You are good at telling jokes.",
+    )
+
+
+# 2. Register the agent with AgentFunctionApp so Azure Functions exposes the required triggers.
+app = AgentFunctionApp(agents=[_create_agent()], enable_health_check=True, max_poll_retries=50)
+
+"""
+Expected output when invoking `POST /api/agents/Joker/run` with plain-text input:
+
+HTTP/1.1 202 Accepted
+{
+  "status": "accepted",
+  "response": "Agent request accepted",
+  "message": "Tell me a short joke about cloud computing.",
+  "conversation_id": "<guid>",
+  "correlation_id": "<guid>"
+}
+"""

--- a/python/samples/azure_functions/01_single_agent/host.json
+++ b/python/samples/azure_functions/01_single_agent/host.json
@@ -1,0 +1,12 @@
+{
+  "version": "2.0",
+  "extensionBundle": {
+    "id": "Microsoft.Azure.Functions.ExtensionBundle",
+    "version": "[4.*, 5.0.0)"
+  },
+  "extensions": {
+    "durableTask": {
+      "hubName": "%TASKHUB_NAME%"
+    }
+  }
+}

--- a/python/samples/azure_functions/01_single_agent/local.settings.json.template
+++ b/python/samples/azure_functions/01_single_agent/local.settings.json.template
@@ -1,0 +1,11 @@
+{
+  "IsEncrypted": false,
+  "Values": {
+    "FUNCTIONS_WORKER_RUNTIME": "python",
+    "AzureWebJobsStorage": "UseDevelopmentStorage=true",
+    "DURABLE_TASK_SCHEDULER_CONNECTION_STRING": "Endpoint=http://localhost:8080;TaskHub=default;Authentication=None",
+    "TASKHUB_NAME": "default",
+    "FOUNDRY_PROJECT_ENDPOINT": "<FOUNDRY_PROJECT_ENDPOINT>",
+    "FOUNDRY_MODEL": "<FOUNDRY_MODEL>"
+  }
+}

--- a/python/samples/azure_functions/01_single_agent/requirements.txt
+++ b/python/samples/azure_functions/01_single_agent/requirements.txt
@@ -1,0 +1,14 @@
+# Agent Framework packages
+# To use the deployed version, uncomment the lines below and comment out the local installation lines
+# agent-framework-foundry
+# agent-framework-azurefunctions
+
+# Local installation (for development and testing)
+# Each package must be listed explicitly because pip doesn't resolve uv workspace sources.
+# Without explicit entries, pip would fetch transitive dependencies from PyPI instead of local source.
+agent-framework-foundry>=1.10.1,<2  # Foundry support from PyPI (pulls in core)
+-e ../../../packages/durabletask  # Durable Task support - dependency of azurefunctions
+-e ../../../packages/azurefunctions  # Azure Functions integration - the main package for this sample
+
+# Azure authentication
+azure-identity

--- a/python/samples/azure_functions/01_single_agent/requirements.txt
+++ b/python/samples/azure_functions/01_single_agent/requirements.txt
@@ -12,3 +12,6 @@ agent-framework-foundry>=1.10.1,<2  # Foundry support from PyPI (pulls in core)
 
 # Azure authentication
 azure-identity
+
+# Local environment loading
+python-dotenv

--- a/python/samples/azure_functions/02_multi_agent/README.md
+++ b/python/samples/azure_functions/02_multi_agent/README.md
@@ -1,0 +1,103 @@
+# Multi-Agent Sample
+
+This sample demonstrates how to use the Durable Extension for Agent Framework to create an Azure Functions app that hosts multiple AI agents and provides direct HTTP API access for interactive conversations with each agent.
+
+## Key Concepts Demonstrated
+
+- Using the Microsoft Agent Framework to define multiple AI agents with unique names and instructions.
+- Registering multiple agents with the Function app and running them using HTTP.
+- Conversation management (via session IDs) for isolated interactions per agent.
+- Two different methods for registering agents: list-based initialization and incremental addition.
+
+## Prerequisites
+
+Complete the common environment preparation steps described in `../README.md`, including installing Azure Functions Core Tools, starting Azurite, configuring Azure OpenAI settings, and installing this sample's requirements.
+
+## Running the Sample
+
+With the environment setup and function app running, you can test the sample by sending HTTP requests to the different agent endpoints.
+
+You can use the `demo.http` file to send messages to the agents, or a command line tool like `curl` as shown below:
+
+> **Note:** Each endpoint waits for the agent response by default. To receive an immediate HTTP 202 instead, set the `x-ms-wait-for-response` header or include `"wait_for_response": false` in the request body.
+
+### Test the Weather Agent
+
+Bash (Linux/macOS/WSL):
+Weather agent request:
+
+```bash
+curl -X POST http://localhost:7071/api/agents/WeatherAgent/run \
+    -H "Content-Type: application/json" \
+    -d '{"message": "What is the weather in Seattle?"}'
+```
+
+Expected HTTP 202 payload:
+
+```json
+{
+  "status": "accepted",
+  "response": "Agent request accepted",
+  "message": "What is the weather in Seattle?",
+  "thread_id": "<guid>",
+  "correlation_id": "<guid>"
+}
+```
+
+Math agent request:
+
+```bash
+curl -X POST http://localhost:7071/api/agents/MathAgent/run \
+    -H "Content-Type: application/json" \
+    -d '{"message": "Calculate a 20% tip on a $50 bill"}'
+```
+
+Expected HTTP 202 payload:
+
+```json
+{
+  "status": "accepted",
+  "response": "Agent request accepted",
+  "message": "Calculate a 20% tip on a $50 bill",
+  "thread_id": "<guid>",
+  "correlation_id": "<guid>"
+}
+```
+
+Health check (optional):
+
+```bash
+curl http://localhost:7071/api/health
+```
+
+Expected response:
+
+```json
+{
+  "status": "healthy",
+  "agents": [
+    {"name": "WeatherAgent", "type": "Agent"},
+    {"name": "MathAgent", "type": "Agent"}
+  ],
+  "agent_count": 2
+}
+```
+
+## Code Structure
+
+The sample demonstrates two ways to register multiple agents:
+
+### Option 1: Pass list of agents during initialization
+```python
+app = AgentFunctionApp(agents=[weather_agent, math_agent])
+```
+
+### Option 2: Add agents incrementally (commented in sample)
+```python
+app = AgentFunctionApp()
+app.add_agent(weather_agent)
+app.add_agent(math_agent)
+```
+
+Each agent automatically gets:
+- `POST /api/agents/{agent_name}/run` - Send messages to the agent

--- a/python/samples/azure_functions/02_multi_agent/demo.http
+++ b/python/samples/azure_functions/02_multi_agent/demo.http
@@ -1,0 +1,55 @@
+### DAFx Multi-Agent Function App - HTTP Samples
+### Use with the VS Code REST Client extension or any HTTP client
+###
+### API Structure:
+### - POST /api/agents/{agentName}/run        -> Send a message to an agent
+### - GET  /api/health                        -> Health check and agent metadata
+
+### Variables
+@baseUrl = http://localhost:7071
+@weatherAgentName = WeatherAgent
+@mathAgentName = MathAgent
+@weatherAgentRoute = {{baseUrl}}/api/agents/{{weatherAgentName}}
+@mathAgentRoute = {{baseUrl}}/api/agents/{{mathAgentName}}
+@healthRoute = {{baseUrl}}/api/health
+
+### Health Check
+# Confirms the Azure Functions app is running and both agents are registered
+# Expected response:
+# {
+#   "status": "healthy",
+#   "agents": [
+#     {"name": "WeatherAgent", "type": "AzureOpenAIAssistantsAgent"},
+#     {"name": "MathAgent", "type": "AzureOpenAIAssistantsAgent"}
+#   ],
+#   "agent_count": 2
+# }
+GET {{healthRoute}}
+
+###
+
+### Weather Agent - Current Conditions
+# Tests the Weather agent's tool-assisted response path
+# Expected response: { "response": "The weather in Seattle...", "status": "success" }
+POST {{weatherAgentRoute}}/run
+Content-Type: application/json
+
+{
+  "message": "What is the weather in Seattle?",
+  "thread_id": "weather-user-001"
+}
+
+###
+
+### Math Agent - Tip Calculation
+# Exercises the Math agent with a calculation request
+# Expected response: { "response": "A 20% tip on a $50 bill is $10...", "status": "success" }
+POST {{mathAgentRoute}}/run
+Content-Type: application/json
+
+{
+  "message": "Calculate a 20% tip on a $50 bill",
+  "thread_id": "math-user-001"
+}
+
+###

--- a/python/samples/azure_functions/02_multi_agent/function_app.py
+++ b/python/samples/azure_functions/02_multi_agent/function_app.py
@@ -1,0 +1,111 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+"""Host multiple Azure OpenAI-powered agents inside a single Azure Functions app.
+
+Components used in this sample:
+- OpenAIChatCompletionClient configured for Azure OpenAI.
+- AgentFunctionApp to register multiple agents and expose dedicated HTTP endpoints.
+- Custom tool functions to demonstrate tool invocation from different agents.
+
+Prerequisites: set `AZURE_OPENAI_ENDPOINT`, `AZURE_OPENAI_MODEL`, and sign in with Azure CLI before starting the Functions host."""
+
+import logging
+from typing import Any
+
+from agent_framework import Agent, tool
+from agent_framework.openai import OpenAIChatCompletionClient
+from agent_framework_azurefunctions import AgentFunctionApp
+from azure.identity.aio import AzureCliCredential
+from dotenv import load_dotenv
+
+# Load environment variables from .env file
+load_dotenv()
+
+logger = logging.getLogger(__name__)
+
+
+# NOTE: approval_mode="never_require" is for sample brevity. Use "always_require" in production;
+# see samples/02-agents/tools/function_tool_with_approval.py
+# and samples/02-agents/tools/function_tool_with_approval_and_sessions.py.
+@tool(approval_mode="never_require")
+def get_weather(location: str) -> dict[str, Any]:
+    """Get current weather for a location."""
+    logger.info(f"🔧 [TOOL CALLED] get_weather(location={location})")
+    result = {
+        "location": location,
+        "temperature": 72,
+        "conditions": "Sunny",
+        "humidity": 45,
+    }
+    logger.info(f"✓ [TOOL RESULT] {result}")
+    return result
+
+
+@tool(approval_mode="never_require")
+def calculate_tip(bill_amount: float, tip_percentage: float = 15.0) -> dict[str, Any]:
+    """Calculate tip amount and total bill."""
+
+    logger.info(f"🔧 [TOOL CALLED] calculate_tip(bill_amount={bill_amount}, tip_percentage={tip_percentage})")
+    tip = bill_amount * (tip_percentage / 100)
+    total = bill_amount + tip
+    result = {
+        "bill_amount": bill_amount,
+        "tip_percentage": tip_percentage,
+        "tip_amount": round(tip, 2),
+        "total": round(total, 2),
+    }
+    logger.info(f"✓ [TOOL RESULT] {result}")
+    return result
+
+
+# 1. Create multiple agents, each with its own instruction set and tools.
+client = OpenAIChatCompletionClient(
+    credential=AzureCliCredential(),
+)
+
+weather_agent = Agent(
+    client=client,
+    name="WeatherAgent",
+    instructions="You are a helpful weather assistant. Provide current weather information.",
+    tools=[get_weather],
+)
+
+math_agent = Agent(
+    client=client,
+    name="MathAgent",
+    instructions="You are a helpful math assistant. Help users with calculations like tip calculations.",
+    tools=[calculate_tip],
+)
+
+
+# 2. Register both agents with AgentFunctionApp to expose their HTTP routes and health check.
+app = AgentFunctionApp(agents=[weather_agent, math_agent], enable_health_check=True, max_poll_retries=50)
+
+# Option 2: Add agents after initialization (commented out as we're using Option 1)
+# app = AgentFunctionApp(enable_health_check=True)
+# app.add_agent(weather_agent)
+# app.add_agent(math_agent)
+
+"""
+Expected output when invoking `POST /api/agents/WeatherAgent/run`:
+
+HTTP/1.1 202 Accepted
+{
+  "status": "accepted",
+  "response": "Agent request accepted",
+  "message": "What is the weather in Seattle?",
+  "conversation_id": "<guid>",
+  "correlation_id": "<guid>"
+}
+
+Expected output when invoking `POST /api/agents/MathAgent/run`:
+
+HTTP/1.1 202 Accepted
+{
+  "status": "accepted",
+  "response": "Agent request accepted",
+  "message": "Calculate a 20% tip on a $50 bill",
+  "conversation_id": "<guid>",
+  "correlation_id": "<guid>"
+}
+"""

--- a/python/samples/azure_functions/02_multi_agent/function_app.py
+++ b/python/samples/azure_functions/02_multi_agent/function_app.py
@@ -7,7 +7,8 @@ Components used in this sample:
 - AgentFunctionApp to register multiple agents and expose dedicated HTTP endpoints.
 - Custom tool functions to demonstrate tool invocation from different agents.
 
-Prerequisites: set `AZURE_OPENAI_ENDPOINT`, `AZURE_OPENAI_MODEL`, and sign in with Azure CLI before starting the Functions host."""
+Prerequisites: set `AZURE_OPENAI_ENDPOINT` and `AZURE_OPENAI_MODEL`, then sign in
+with Azure CLI before starting the Functions host."""
 
 import logging
 from typing import Any

--- a/python/samples/azure_functions/02_multi_agent/host.json
+++ b/python/samples/azure_functions/02_multi_agent/host.json
@@ -1,0 +1,20 @@
+{
+  "version": "2.0",
+  "logging": {
+    "applicationInsights": {
+      "samplingSettings": {
+        "isEnabled": true,
+        "maxTelemetryItemsPerSecond": 20
+      }
+    }
+  },
+  "extensionBundle": {
+    "id": "Microsoft.Azure.Functions.ExtensionBundle",
+    "version": "[4.*, 5.0.0)"
+  },
+  "extensions": {
+    "durableTask": {
+      "hubName": "%TASKHUB_NAME%"
+    }
+  }
+}

--- a/python/samples/azure_functions/02_multi_agent/local.settings.json.template
+++ b/python/samples/azure_functions/02_multi_agent/local.settings.json.template
@@ -1,0 +1,11 @@
+{
+  "IsEncrypted": false,
+  "Values": {
+    "FUNCTIONS_WORKER_RUNTIME": "python",
+    "AzureWebJobsStorage": "UseDevelopmentStorage=true",
+    "DURABLE_TASK_SCHEDULER_CONNECTION_STRING": "Endpoint=http://localhost:8080;TaskHub=default;Authentication=None",
+    "TASKHUB_NAME": "default",
+    "FOUNDRY_PROJECT_ENDPOINT": "<FOUNDRY_PROJECT_ENDPOINT>",
+    "FOUNDRY_MODEL": "<FOUNDRY_MODEL>"
+  }
+}

--- a/python/samples/azure_functions/02_multi_agent/local.settings.json.template
+++ b/python/samples/azure_functions/02_multi_agent/local.settings.json.template
@@ -5,7 +5,7 @@
     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
     "DURABLE_TASK_SCHEDULER_CONNECTION_STRING": "Endpoint=http://localhost:8080;TaskHub=default;Authentication=None",
     "TASKHUB_NAME": "default",
-    "FOUNDRY_PROJECT_ENDPOINT": "<FOUNDRY_PROJECT_ENDPOINT>",
-    "FOUNDRY_MODEL": "<FOUNDRY_MODEL>"
+    "AZURE_OPENAI_ENDPOINT": "<AZURE_OPENAI_ENDPOINT>",
+    "AZURE_OPENAI_MODEL": "<AZURE_OPENAI_MODEL>"
   }
 }

--- a/python/samples/azure_functions/02_multi_agent/requirements.txt
+++ b/python/samples/azure_functions/02_multi_agent/requirements.txt
@@ -1,0 +1,14 @@
+# Agent Framework packages
+# To use the deployed version, uncomment the lines below and comment out the local installation lines
+# agent-framework-foundry
+# agent-framework-azurefunctions
+
+# Local installation (for development and testing)
+# Each package must be listed explicitly because pip doesn't resolve uv workspace sources.
+# Without explicit entries, pip would fetch transitive dependencies from PyPI instead of local source.
+agent-framework-foundry>=1.10.1,<2  # Foundry support from PyPI (pulls in core)
+-e ../../../packages/durabletask  # Durable Task support - dependency of azurefunctions
+-e ../../../packages/azurefunctions  # Azure Functions integration - the main package for this sample
+
+# Azure authentication
+azure-identity

--- a/python/samples/azure_functions/02_multi_agent/requirements.txt
+++ b/python/samples/azure_functions/02_multi_agent/requirements.txt
@@ -12,3 +12,6 @@ agent-framework-foundry>=1.10.1,<2  # Foundry support from PyPI (pulls in core)
 
 # Azure authentication
 azure-identity
+
+# Local environment loading
+python-dotenv

--- a/python/samples/azure_functions/03_reliable_streaming/README.md
+++ b/python/samples/azure_functions/03_reliable_streaming/README.md
@@ -1,0 +1,132 @@
+# Agent Response Callbacks with Redis Streaming
+
+This sample demonstrates how to use Redis Streams with agent response callbacks to enable reliable, resumable streaming for durable agents. Clients can disconnect and reconnect without losing messages by using cursor-based pagination.
+
+## Key Concepts Demonstrated
+
+- Using `AgentResponseCallbackProtocol` to capture streaming agent responses
+- Persisting streaming chunks to Redis Streams for reliable delivery
+- Building a custom HTTP endpoint to read from Redis with Server-Sent Events (SSE) format
+- Supporting cursor-based resumption for disconnected clients
+- Managing Redis client lifecycle with async context managers
+
+## Prerequisites
+
+In addition to the common setup steps in `../README.md`, this sample requires Redis:
+
+```bash
+# Start Redis
+docker run -d --name redis -p 6379:6379 redis:latest
+```
+
+Update `local.settings.json` with your Redis connection string:
+
+```json
+{
+  "Values": {
+    "REDIS_CONNECTION_STRING": "redis://localhost:6379"
+  }
+}
+```
+
+## Running the Sample
+
+### Start the agent run
+
+The agent executes in the background via durable orchestration. The `RedisStreamCallback` persists streaming chunks to Redis:
+
+```bash
+curl -X POST http://localhost:7071/api/agents/TravelPlanner/run \
+  -H "Content-Type: text/plain" \
+  -d "Plan a 3-day trip to Tokyo"
+```
+
+Response (202 Accepted):
+```json
+{
+  "status": "accepted",
+  "response": "Agent request accepted",
+  "conversation_id": "abc-123-def-456",
+  "correlation_id": "xyz-789"
+}
+```
+
+### Stream the response from Redis
+
+Use the custom `/api/agent/stream/{conversation_id}` endpoint to read persisted chunks:
+
+```bash
+curl http://localhost:7071/api/agent/stream/abc-123-def-456 \
+  -H "Accept: text/event-stream"
+```
+
+Response (SSE format):
+```
+id: 1734649123456-0
+event: message
+data: Here's a wonderful 3-day Tokyo itinerary...
+
+id: 1734649123789-0
+event: message
+data: Day 1: Arrival and Shibuya...
+
+id: 1734649124012-0
+event: done
+data: [DONE]
+```
+
+### Resume from a cursor
+
+Use a cursor ID from an SSE event to skip already-processed messages:
+
+```bash
+curl "http://localhost:7071/api/agent/stream/abc-123-def-456?cursor=1734649123456-0" \
+  -H "Accept: text/event-stream"
+```
+
+## How It Works
+
+### 1. Redis Callback
+
+The `RedisStreamCallback` class implements `AgentResponseCallbackProtocol` to capture streaming updates:
+
+```python
+class RedisStreamCallback(AgentResponseCallbackProtocol):
+    async def on_streaming_response_update(self, update, context):
+        # Write chunk to Redis Stream
+        async with await get_stream_handler() as handler:
+            await handler.write_chunk(thread_id, update.text, sequence)
+
+    async def on_agent_response(self, response, context):
+        # Write end-of-stream marker
+        async with await get_stream_handler() as handler:
+            await handler.write_completion(thread_id, sequence)
+```
+
+### 2. Custom Streaming Endpoint
+
+The `/api/agent/stream/{conversation_id}` endpoint reads from Redis:
+
+```python
+@app.route(route="agent/stream/{conversation_id}", methods=["GET"])
+async def stream(req):
+    conversation_id = req.route_params.get("conversation_id")
+    cursor = req.params.get("cursor")  # Optional
+
+    async with await get_stream_handler() as handler:
+        async for chunk in handler.read_stream(conversation_id, cursor):
+            # Format and return chunks
+```
+
+### 3. Redis Streams
+
+Messages are stored in Redis Streams with automatic TTL (default: 10 minutes):
+
+```
+Stream Key: agent-stream:{conversation_id}
+Entry: {
+  "text": "chunk content",
+  "sequence": "0",
+  "timestamp": "1734649123456"
+}
+```

--- a/python/samples/azure_functions/03_reliable_streaming/demo.http
+++ b/python/samples/azure_functions/03_reliable_streaming/demo.http
@@ -1,0 +1,55 @@
+### Reliable Streaming with Redis - Demo HTTP Requests
+### Use with the VS Code REST Client extension or any HTTP client
+###
+### Workflow:
+### 1. POST /api/agents/{agentName}/run  -> Start durable agent (returns conversation_id)
+### 2. GET  /api/agent/stream/{id}       -> Read chunks from Redis (SSE or plain text)
+### 3. Add ?cursor={id} to resume from a specific point
+###
+### Prerequisites:
+### - Redis: docker run -d --name redis -p 6379:6379 redis:latest
+### - Start function app: func start
+
+### Variables
+@baseUrl = http://localhost:7071
+@agentName = TravelPlanner
+
+### Health Check
+GET {{baseUrl}}/api/health
+
+###
+
+### Start Agent Run
+# Starts the agent in the background via durable orchestration.
+# The RedisStreamCallback persists streaming chunks to Redis.
+# @name trip
+POST {{baseUrl}}/api/agents/{{agentName}}/run
+Content-Type: text/plain
+
+Plan a 3-day trip to Tokyo
+
+###
+
+### Stream from Redis (SSE format)
+# Reads persisted chunks from Redis using cursor-based pagination.
+# The conversation_id is automatically captured from the previous request.
+@conversationId = {{trip.response.body.$.conversation_id}}
+GET {{baseUrl}}/api/agent/stream/{{conversationId}}
+Accept: text/event-stream
+
+###
+
+### Stream from Redis (plain text)
+# Same as above, but returns plain text instead of SSE format
+GET {{baseUrl}}/api/agent/stream/{{conversationId}}
+Accept: text/plain
+
+###
+
+### Resume from cursor
+# Use a cursor ID from an SSE event to skip already-processed messages
+# Replace {cursor_id} with an actual entry ID from the SSE stream
+GET {{baseUrl}}/api/agent/stream/{{conversationId}}?cursor={cursor_id}
+Accept: text/event-stream
+
+###

--- a/python/samples/azure_functions/03_reliable_streaming/function_app.py
+++ b/python/samples/azure_functions/03_reliable_streaming/function_app.py
@@ -1,0 +1,324 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+"""Reliable streaming for durable agents using Redis Streams.
+
+This sample demonstrates how to implement reliable streaming for durable agents using Redis Streams.
+
+Components used in this sample:
+- FoundryChatClient to create the travel planner agent with tools.
+- AgentFunctionApp with a Redis-based callback for persistent streaming.
+- Custom HTTP endpoint to resume streaming from any point using cursor-based pagination.
+
+Prerequisites:
+- Set FOUNDRY_PROJECT_ENDPOINT and FOUNDRY_MODEL
+- Sign in with Azure CLI (`az login`) for `AzureCliCredential`
+- Redis running (docker run -d --name redis -p 6379:6379 redis:latest)
+- DTS and Azurite running (see parent README)
+"""
+
+import logging
+import os
+from datetime import timedelta
+
+import azure.functions as func
+import redis.asyncio as aioredis
+from agent_framework import Agent, AgentResponseUpdate
+from agent_framework.foundry import FoundryChatClient
+from agent_framework_azurefunctions import AgentFunctionApp
+from agent_framework_durabletask import AgentCallbackContext, AgentResponseCallbackProtocol
+from azure.identity.aio import AzureCliCredential
+from dotenv import load_dotenv
+from redis_stream_response_handler import RedisStreamResponseHandler, StreamChunk  # pyrefly: ignore[missing-import]
+from tools import get_local_events, get_weather_forecast  # pyrefly: ignore[missing-import]
+
+# Load environment variables from .env file
+load_dotenv()
+
+logger = logging.getLogger(__name__)
+
+# Configuration
+REDIS_CONNECTION_STRING = os.environ.get("REDIS_CONNECTION_STRING", "redis://localhost:6379")
+REDIS_STREAM_TTL_MINUTES = int(os.environ.get("REDIS_STREAM_TTL_MINUTES", "10"))
+
+
+async def get_stream_handler() -> RedisStreamResponseHandler:
+    """Create a new Redis stream handler for each request.
+
+    This avoids event loop conflicts in Azure Functions by creating
+    a fresh Redis client in the current event loop context.
+    """
+    # Create a new Redis client in the current event loop
+    redis_client = aioredis.from_url(
+        REDIS_CONNECTION_STRING,
+        encoding="utf-8",
+        decode_responses=False,
+    )
+
+    return RedisStreamResponseHandler(
+        redis_client=redis_client,
+        stream_ttl=timedelta(minutes=REDIS_STREAM_TTL_MINUTES),
+    )
+
+
+class RedisStreamCallback(AgentResponseCallbackProtocol):
+    """Callback that writes streaming updates to Redis Streams for reliable delivery.
+
+    This enables clients to disconnect and reconnect without losing messages.
+    """
+
+    def __init__(self) -> None:
+        self._logger = logging.getLogger("durableagent.samples.redis_streaming")
+        self._sequence_numbers = {}  # Track sequence per thread
+
+    async def on_streaming_response_update(
+        self,
+        update: AgentResponseUpdate,
+        context: AgentCallbackContext,
+    ) -> None:
+        """Write streaming update to Redis Stream.
+
+        Args:
+            update: The streaming response update chunk.
+            context: The callback context with thread_id, agent_name, etc.
+        """
+        thread_id = context.thread_id
+        if not thread_id:
+            self._logger.warning("No thread_id available for streaming update")
+            return
+
+        if not update.text:
+            return
+
+        text = update.text
+
+        # Get or initialize sequence number for this thread
+        if thread_id not in self._sequence_numbers:
+            self._sequence_numbers[thread_id] = 0
+
+        sequence = self._sequence_numbers[thread_id]
+
+        try:
+            # Use context manager to ensure Redis client is properly closed
+            async with await get_stream_handler() as stream_handler:
+                # Write chunk to Redis Stream using public API
+                await stream_handler.write_chunk(thread_id, text, sequence)
+
+                self._sequence_numbers[thread_id] += 1
+
+                self._logger.info(
+                    "[%s][%s] Wrote chunk to Redis: seq=%d, text=%s",
+                    context.agent_name,
+                    thread_id[:8],
+                    sequence,
+                    text,
+                )
+        except Exception as ex:
+            self._logger.error(f"Error writing to Redis stream: {ex}", exc_info=True)
+
+    async def on_agent_response(self, response, context: AgentCallbackContext) -> None:
+        """Write end-of-stream marker when agent completes.
+
+        Args:
+            response: The final agent response.
+            context: The callback context.
+        """
+        thread_id = context.thread_id
+        if not thread_id:
+            return
+
+        sequence = self._sequence_numbers.get(thread_id, 0)
+
+        try:
+            # Use context manager to ensure Redis client is properly closed
+            async with await get_stream_handler() as stream_handler:
+                # Write end-of-stream marker using public API
+                await stream_handler.write_completion(thread_id, sequence)
+
+                self._logger.info(
+                    "[%s][%s] Agent completed, wrote end-of-stream marker",
+                    context.agent_name,
+                    thread_id[:8],
+                )
+
+                # Clean up sequence tracker
+                self._sequence_numbers.pop(thread_id, None)
+        except Exception as ex:
+            self._logger.error(f"Error writing end-of-stream marker: {ex}", exc_info=True)
+
+
+# Create the Redis streaming callback
+redis_callback = RedisStreamCallback()
+
+
+# Create the travel planner agent
+def create_travel_agent():
+    """Create the TravelPlanner agent with tools."""
+    return Agent(
+        client=FoundryChatClient(
+            project_endpoint=os.environ["FOUNDRY_PROJECT_ENDPOINT"],
+            model=os.environ["FOUNDRY_MODEL"],
+            credential=AzureCliCredential(),
+        ),
+        name="TravelPlanner",
+        instructions="""You are an expert travel planner who creates detailed, personalized travel itineraries.
+When asked to plan a trip, you should:
+1. Create a comprehensive day-by-day itinerary
+2. Include specific recommendations for activities, restaurants, and attractions
+3. Provide practical tips for each destination
+4. Consider weather and local events when making recommendations
+5. Include estimated times and logistics between activities
+
+Always use the available tools to get current weather forecasts and local events
+for the destination to make your recommendations more relevant and timely.
+
+Format your response with clear headings for each day and include emoji icons
+to make the itinerary easy to scan and visually appealing.""",
+        tools=[get_weather_forecast, get_local_events],
+    )
+
+
+# Create AgentFunctionApp with the Redis callback
+app = AgentFunctionApp(
+    agents=[create_travel_agent()],
+    enable_health_check=True,
+    default_callback=redis_callback,
+    max_poll_retries=100,  # Increase for longer-running agents
+)
+
+
+# Custom streaming endpoint for reading from Redis
+# Use the standard /api/agents/TravelPlanner/run endpoint to start agent runs
+
+
+@app.function_name("stream")
+@app.route(route="agent/stream/{conversation_id}", methods=["GET"])
+async def stream(req: func.HttpRequest) -> func.HttpResponse:
+    """Resume streaming from a specific cursor position for an existing session.
+
+    This endpoint reads all currently available chunks from Redis for the given
+    conversation ID, starting from the specified cursor (or beginning if no cursor).
+
+    Use this endpoint to resume a stream after disconnection. Pass the conversation ID
+    and optionally a cursor (Redis entry ID) to continue from where you left off.
+
+    Query Parameters:
+        cursor (optional): Redis stream entry ID to resume from. If not provided, starts from beginning.
+
+    Response Headers:
+        Content-Type: text/event-stream or text/plain based on Accept header
+        x-conversation-id: The conversation/thread ID
+
+    SSE Event Fields (when Accept: text/event-stream):
+        id: Redis stream entry ID (use as cursor for resumption)
+        event: "message" for content, "done" for completion, "error" for errors
+        data: The text content or status message
+    """
+    try:
+        conversation_id = req.route_params.get("conversation_id")
+        if not conversation_id:
+            return func.HttpResponse(
+                "Conversation ID is required.",
+                status_code=400,
+            )
+
+        # Get optional cursor from query string
+        cursor = req.params.get("cursor")
+
+        logger.info(f"Resuming stream for conversation {conversation_id} from cursor: {cursor or '(beginning)'}")
+
+        # Check Accept header to determine response format
+        accept_header = req.headers.get("Accept", "")
+        use_sse_format = "text/plain" not in accept_header.lower()
+
+        # Stream chunks from Redis
+        return await _stream_to_client(conversation_id, cursor, use_sse_format)
+
+    except Exception as ex:
+        logger.error(f"Error in stream endpoint: {ex}", exc_info=True)
+        return func.HttpResponse(
+            f"Internal server error: {str(ex)}",
+            status_code=500,
+        )
+
+
+async def _stream_to_client(
+    conversation_id: str,
+    cursor: str | None,
+    use_sse_format: bool,
+) -> func.HttpResponse:
+    """Stream chunks from Redis to the HTTP response.
+
+    Args:
+        conversation_id: The conversation ID to stream from.
+        cursor: Optional cursor to resume from. If None, streams from the beginning.
+        use_sse_format: True to use SSE format, false for plain text.
+
+    Returns:
+        HTTP response with all currently available chunks.
+    """
+    chunks = []
+
+    # Use context manager to ensure Redis client is properly closed
+    async with await get_stream_handler() as stream_handler:
+        try:
+            async for chunk in stream_handler.read_stream(conversation_id, cursor):
+                if chunk.error:
+                    logger.warning(f"Stream error for {conversation_id}: {chunk.error}")
+                    chunks.append(_format_error(chunk.error, use_sse_format))
+                    break
+
+                if chunk.is_done:
+                    chunks.append(_format_end_of_stream(chunk.entry_id, use_sse_format))
+                    break
+
+                if chunk.text:
+                    chunks.append(_format_chunk(chunk, use_sse_format))
+
+        except Exception as ex:
+            logger.error(f"Error reading from Redis: {ex}", exc_info=True)
+            chunks.append(_format_error(str(ex), use_sse_format))
+
+    # Return all chunks
+    response_body = "".join(chunks)
+
+    return func.HttpResponse(
+        body=response_body,
+        mimetype="text/event-stream" if use_sse_format else "text/plain; charset=utf-8",
+        headers={
+            "Cache-Control": "no-cache",
+            "Connection": "keep-alive",
+            "x-conversation-id": conversation_id,
+        },
+    )
+
+
+def _format_chunk(chunk: StreamChunk, use_sse_format: bool) -> str:
+    """Format a text chunk."""
+    if use_sse_format:
+        return _format_sse_event("message", chunk.text or "", chunk.entry_id)
+    return chunk.text or ""
+
+
+def _format_end_of_stream(entry_id: str, use_sse_format: bool) -> str:
+    """Format end-of-stream marker."""
+    if use_sse_format:
+        return _format_sse_event("done", "[DONE]", entry_id)
+    return "\n"
+
+
+def _format_error(error: str, use_sse_format: bool) -> str:
+    """Format error message."""
+    if use_sse_format:
+        return _format_sse_event("error", error, None)
+    return f"\n[Error: {error}]\n"
+
+
+def _format_sse_event(event_type: str, data: str, event_id: str | None = None) -> str:
+    """Format a Server-Sent Event."""
+    lines = []
+    if event_id:
+        lines.append(f"id: {event_id}")
+    lines.append(f"event: {event_type}")
+    lines.append(f"data: {data}")
+    lines.append("")
+    return "\n".join(lines) + "\n"

--- a/python/samples/azure_functions/03_reliable_streaming/function_app.py
+++ b/python/samples/azure_functions/03_reliable_streaming/function_app.py
@@ -319,6 +319,7 @@ def _format_sse_event(event_type: str, data: str, event_id: str | None = None) -
     if event_id:
         lines.append(f"id: {event_id}")
     lines.append(f"event: {event_type}")
-    lines.append(f"data: {data}")
+    normalized_data = data.replace("\r\n", "\n").replace("\r", "\n")
+    lines.extend(f"data: {line}" for line in normalized_data.split("\n"))
     lines.append("")
     return "\n".join(lines) + "\n"

--- a/python/samples/azure_functions/03_reliable_streaming/host.json
+++ b/python/samples/azure_functions/03_reliable_streaming/host.json
@@ -1,0 +1,20 @@
+{
+  "version": "2.0",
+  "logging": {
+    "applicationInsights": {
+      "samplingSettings": {
+        "isEnabled": true,
+        "maxTelemetryItemsPerSecond": 20
+      }
+    }
+  },
+  "extensionBundle": {
+    "id": "Microsoft.Azure.Functions.ExtensionBundle",
+    "version": "[4.*, 5.0.0)"
+  },
+  "extensions": {
+    "durableTask": {
+      "hubName": "%TASKHUB_NAME%"
+    }
+  }
+}

--- a/python/samples/azure_functions/03_reliable_streaming/local.settings.json.template
+++ b/python/samples/azure_functions/03_reliable_streaming/local.settings.json.template
@@ -1,0 +1,13 @@
+{
+  "IsEncrypted": false,
+  "Values": {
+    "FUNCTIONS_WORKER_RUNTIME": "python",
+    "AzureWebJobsStorage": "UseDevelopmentStorage=true",
+    "DURABLE_TASK_SCHEDULER_CONNECTION_STRING": "Endpoint=http://localhost:8080;TaskHub=default;Authentication=None",
+    "TASKHUB_NAME": "default",
+    "REDIS_CONNECTION_STRING": "redis://localhost:6379",
+    "REDIS_STREAM_TTL_MINUTES": "10",
+    "FOUNDRY_PROJECT_ENDPOINT": "<FOUNDRY_PROJECT_ENDPOINT>",
+    "FOUNDRY_MODEL": "<FOUNDRY_MODEL>"
+  }
+}

--- a/python/samples/azure_functions/03_reliable_streaming/redis_stream_response_handler.py
+++ b/python/samples/azure_functions/03_reliable_streaming/redis_stream_response_handler.py
@@ -1,0 +1,201 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+"""Redis-based streaming response handler for durable agents.
+
+This module provides reliable, resumable streaming of agent responses using Redis Streams
+as a message broker. It enables clients to disconnect and reconnect without losing messages.
+"""
+
+import asyncio
+import time
+from collections.abc import AsyncIterator
+from dataclasses import dataclass
+from datetime import timedelta
+
+import redis.asyncio as aioredis
+
+
+@dataclass
+class StreamChunk:
+    """Represents a chunk of streamed data from Redis.
+
+    Attributes:
+        entry_id: The Redis stream entry ID (used as cursor for resumption).
+        text: The text content of the chunk, if any.
+        is_done: Whether this is the final chunk in the stream.
+        error: Error message if an error occurred, otherwise None.
+    """
+
+    entry_id: str
+    text: str | None = None
+    is_done: bool = False
+    error: str | None = None
+
+
+class RedisStreamResponseHandler:
+    """Handles agent responses by persisting them to Redis Streams.
+
+    This handler writes agent response updates to Redis Streams, enabling reliable,
+    resumable streaming delivery to clients. Clients can disconnect and reconnect
+    at any point using cursor-based pagination.
+
+    Attributes:
+        MAX_EMPTY_READS: Maximum number of empty reads before timing out.
+        POLL_INTERVAL_MS: Interval in milliseconds between polling attempts.
+    """
+
+    MAX_EMPTY_READS = 300
+    POLL_INTERVAL_MS = 1000
+
+    def __init__(self, redis_client: aioredis.Redis, stream_ttl: timedelta):
+        """Initialize the Redis stream response handler.
+
+        Args:
+            redis_client: The async Redis client instance.
+            stream_ttl: Time-to-live for stream entries in Redis.
+        """
+        self._redis = redis_client
+        self._stream_ttl = stream_ttl
+
+    async def __aenter__(self):
+        """Enter async context manager."""
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        """Exit async context manager and close Redis connection."""
+        await self._redis.aclose()
+
+    async def write_chunk(
+        self,
+        conversation_id: str,
+        text: str,
+        sequence: int,
+    ) -> None:
+        """Write a single text chunk to the Redis Stream.
+
+        Args:
+            conversation_id: The conversation ID for this agent run.
+            text: The text content to write.
+            sequence: The sequence number for ordering.
+        """
+        stream_key = self._get_stream_key(conversation_id)
+        await self._redis.xadd(
+            stream_key,
+            {
+                "text": text,
+                "sequence": str(sequence),
+                "timestamp": str(int(time.time() * 1000)),
+            },
+        )
+        await self._redis.expire(stream_key, self._stream_ttl)
+
+    async def write_completion(
+        self,
+        conversation_id: str,
+        sequence: int,
+    ) -> None:
+        """Write an end-of-stream marker to the Redis Stream.
+
+        Args:
+            conversation_id: The conversation ID for this agent run.
+            sequence: The final sequence number.
+        """
+        stream_key = self._get_stream_key(conversation_id)
+        await self._redis.xadd(
+            stream_key,
+            {
+                "text": "",
+                "sequence": str(sequence),
+                "timestamp": str(int(time.time() * 1000)),
+                "done": "true",
+            },
+        )
+        await self._redis.expire(stream_key, self._stream_ttl)
+
+    async def read_stream(
+        self,
+        conversation_id: str,
+        cursor: str | None = None,
+    ) -> AsyncIterator[StreamChunk]:
+        """Read entries from a Redis Stream with cursor-based pagination.
+
+        This method polls the Redis Stream for new entries, yielding chunks as they
+        become available. Clients can resume from any point using the entry_id from
+        a previous chunk.
+
+        Args:
+            conversation_id: The conversation ID to read from.
+            cursor: Optional cursor to resume from. If None, starts from beginning.
+
+        Yields:
+            StreamChunk instances containing text content or status markers.
+        """
+        stream_key = self._get_stream_key(conversation_id)
+        start_id = cursor if cursor else "0-0"
+
+        empty_read_count = 0
+        has_seen_data = False
+
+        while True:
+            try:
+                # Read up to 100 entries from the stream
+                entries = await self._redis.xread(
+                    {stream_key: start_id},
+                    count=100,
+                    block=None,
+                )
+
+                if not entries:
+                    # No entries found
+                    if not has_seen_data:
+                        empty_read_count += 1
+                        if empty_read_count >= self.MAX_EMPTY_READS:
+                            timeout_seconds = self.MAX_EMPTY_READS * self.POLL_INTERVAL_MS / 1000
+                            yield StreamChunk(
+                                entry_id=start_id,
+                                error=f"Stream not found or timed out after {timeout_seconds} seconds",
+                            )
+                            return
+
+                    # Wait before polling again
+                    await asyncio.sleep(self.POLL_INTERVAL_MS / 1000)
+                    continue
+
+                has_seen_data = True
+
+                # Process entries from the stream
+                for _stream_name, stream_entries in entries:
+                    for entry_id, entry_data in stream_entries:
+                        start_id = entry_id.decode() if isinstance(entry_id, bytes) else entry_id
+
+                        # Decode entry data
+                        text = entry_data.get(b"text", b"").decode() if b"text" in entry_data else None
+                        done = entry_data.get(b"done", b"").decode() if b"done" in entry_data else None
+                        error = entry_data.get(b"error", b"").decode() if b"error" in entry_data else None
+
+                        if error:
+                            yield StreamChunk(entry_id=start_id, error=error)
+                            return
+
+                        if done == "true":
+                            yield StreamChunk(entry_id=start_id, is_done=True)
+                            return
+
+                        if text:
+                            yield StreamChunk(entry_id=start_id, text=text)
+
+            except Exception as ex:
+                yield StreamChunk(entry_id=start_id, error=str(ex))
+                return
+
+    @staticmethod
+    def _get_stream_key(conversation_id: str) -> str:
+        """Generate the Redis key for a conversation's stream.
+
+        Args:
+            conversation_id: The conversation ID.
+
+        Returns:
+            The Redis stream key.
+        """
+        return f"agent-stream:{conversation_id}"

--- a/python/samples/azure_functions/03_reliable_streaming/requirements.txt
+++ b/python/samples/azure_functions/03_reliable_streaming/requirements.txt
@@ -1,0 +1,17 @@
+# Agent Framework packages
+# To use the deployed version, uncomment the lines below and comment out the local installation lines
+# agent-framework-foundry
+# agent-framework-azurefunctions
+
+# Local installation (for development and testing)
+# Each package must be listed explicitly because pip doesn't resolve uv workspace sources.
+# Without explicit entries, pip would fetch transitive dependencies from PyPI instead of local source.
+agent-framework-foundry>=1.10.1,<2  # Foundry support from PyPI (pulls in core)
+-e ../../../packages/durabletask  # Durable Task support - dependency of azurefunctions
+-e ../../../packages/azurefunctions  # Azure Functions integration - the main package for this sample
+
+# Azure authentication
+azure-identity
+
+# Redis client with asyncio support (used by redis_stream_response_handler.py)
+redis[asyncio]

--- a/python/samples/azure_functions/03_reliable_streaming/requirements.txt
+++ b/python/samples/azure_functions/03_reliable_streaming/requirements.txt
@@ -13,5 +13,8 @@ agent-framework-foundry>=1.10.1,<2  # Foundry support from PyPI (pulls in core)
 # Azure authentication
 azure-identity
 
+# Local environment loading
+python-dotenv
+
 # Redis client with asyncio support (used by redis_stream_response_handler.py)
 redis[asyncio]

--- a/python/samples/azure_functions/03_reliable_streaming/tools.py
+++ b/python/samples/azure_functions/03_reliable_streaming/tools.py
@@ -1,0 +1,164 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+"""Mock travel tools for demonstration purposes.
+
+In a real application, these would call actual weather and events APIs.
+"""
+
+from typing import Annotated
+
+
+def get_weather_forecast(
+    destination: Annotated[str, "The destination city or location"],
+    date: Annotated[str, 'The date for the forecast (e.g., "2025-01-15" or "next Monday")'],
+) -> str:
+    """Get the weather forecast for a destination on a specific date.
+
+    Use this to provide weather-aware recommendations in the itinerary.
+
+    Args:
+        destination: The destination city or location.
+        date: The date for the forecast.
+
+    Returns:
+        A weather forecast summary.
+    """
+    # Mock weather data based on destination for realistic responses
+    weather_by_region = {
+        "Tokyo": ("Partly cloudy with a chance of light rain", 58, 45),
+        "Paris": ("Overcast with occasional drizzle", 52, 41),
+        "New York": ("Clear and cold", 42, 28),
+        "London": ("Foggy morning, clearing in afternoon", 48, 38),
+        "Sydney": ("Sunny and warm", 82, 68),
+        "Rome": ("Sunny with light breeze", 62, 48),
+        "Barcelona": ("Partly sunny", 59, 47),
+        "Amsterdam": ("Cloudy with light rain", 46, 38),
+        "Dubai": ("Sunny and hot", 85, 72),
+        "Singapore": ("Tropical thunderstorms in afternoon", 88, 77),
+        "Bangkok": ("Hot and humid, afternoon showers", 91, 78),
+        "Los Angeles": ("Sunny and pleasant", 72, 55),
+        "San Francisco": ("Morning fog, afternoon sun", 62, 52),
+        "Seattle": ("Rainy with breaks", 48, 40),
+        "Miami": ("Warm and sunny", 78, 65),
+        "Honolulu": ("Tropical paradise weather", 82, 72),
+    }
+
+    # Find a matching destination or use a default
+    forecast = ("Partly cloudy", 65, 50)
+    for city, weather in weather_by_region.items():
+        if city.lower() in destination.lower():
+            forecast = weather
+            break
+
+    condition, high_f, low_f = forecast
+    high_c = (high_f - 32) * 5 // 9
+    low_c = (low_f - 32) * 5 // 9
+
+    recommendation = _get_weather_recommendation(condition)
+
+    return f"""Weather forecast for {destination} on {date}:
+Conditions: {condition}
+High: {high_f}°F ({high_c}°C)
+Low: {low_f}°F ({low_c}°C)
+
+Recommendation: {recommendation}"""
+
+
+def get_local_events(
+    destination: Annotated[str, "The destination city or location"],
+    date: Annotated[str, 'The date to search for events (e.g., "2025-01-15" or "next week")'],
+) -> str:
+    """Get local events and activities happening at a destination around a specific date.
+
+    Use this to suggest timely activities and experiences.
+
+    Args:
+        destination: The destination city or location.
+        date: The date to search for events.
+
+    Returns:
+        A list of local events and activities.
+    """
+    # Mock events data based on destination
+    events_by_city = {
+        "Tokyo": [
+            "🎭 Kabuki Theater Performance at Kabukiza Theatre - Traditional Japanese drama",
+            "🌸 Winter Illuminations at Yoyogi Park - Spectacular light displays",
+            "🍜 Ramen Festival at Tokyo Station - Sample ramen from across Japan",
+            "🎮 Gaming Expo at Tokyo Big Sight - Latest video games and technology",
+        ],
+        "Paris": [
+            "🎨 Impressionist Exhibition at Musée d'Orsay - Extended evening hours",
+            "🍷 Wine Tasting Tour in Le Marais - Local sommelier guided",
+            "🎵 Jazz Night at Le Caveau de la Huchette - Historic jazz club",
+            "🥐 French Pastry Workshop - Learn from master pâtissiers",
+        ],
+        "New York": [
+            "🎭 Broadway Show: Hamilton - Limited engagement performances",
+            "🏀 Knicks vs Lakers at Madison Square Garden",
+            "🎨 Modern Art Exhibit at MoMA - New installations",
+            "🍕 Pizza Walking Tour of Brooklyn - Artisan pizzerias",
+        ],
+        "London": [
+            "👑 Royal Collection Exhibition at Buckingham Palace",
+            "🎭 West End Musical: The Phantom of the Opera",
+            "🍺 Craft Beer Festival at Brick Lane",
+            "🎪 Winter Wonderland at Hyde Park - Rides and markets",
+        ],
+        "Sydney": [
+            "🏄 Pro Surfing Competition at Bondi Beach",
+            "🎵 Opera at Sydney Opera House - La Bohème",
+            "🦘 Wildlife Night Safari at Taronga Zoo",
+            "🍽️ Harbor Dinner Cruise with fireworks",
+        ],
+        "Rome": [
+            "🏛️ After-Hours Vatican Tour - Skip the crowds",
+            "🍝 Pasta Making Class in Trastevere",
+            "🎵 Classical Concert at Borghese Gallery",
+            "🍷 Wine Tasting in Roman Cellars",
+        ],
+    }
+
+    # Find events for the destination or use generic events
+    events = [
+        "🎭 Local theater performance",
+        "🍽️ Food and wine festival",
+        "🎨 Art gallery opening",
+        "🎵 Live music at local venues",
+    ]
+
+    for city, city_events in events_by_city.items():
+        if city.lower() in destination.lower():
+            events = city_events
+            break
+
+    event_list = "\n• ".join(events)
+    return f"""Local events in {destination} around {date}:
+
+• {event_list}
+
+💡 Tip: Book popular events in advance as they may sell out quickly!"""
+
+
+def _get_weather_recommendation(condition: str) -> str:
+    """Get a recommendation based on weather conditions.
+
+    Args:
+        condition: The weather condition description.
+
+    Returns:
+        A recommendation string.
+    """
+    condition_lower = condition.lower()
+
+    if "rain" in condition_lower or "drizzle" in condition_lower:
+        return "Bring an umbrella and waterproof jacket. Consider indoor activities for backup."
+    if "fog" in condition_lower:
+        return "Morning visibility may be limited. Plan outdoor sightseeing for afternoon."
+    if "cold" in condition_lower:
+        return "Layer up with warm clothing. Hot drinks and cozy cafés recommended."
+    if "hot" in condition_lower or "warm" in condition_lower:
+        return "Stay hydrated and use sunscreen. Plan strenuous activities for cooler morning hours."
+    if "thunder" in condition_lower or "storm" in condition_lower:
+        return "Keep an eye on weather updates. Have indoor alternatives ready."
+    return "Pleasant conditions expected. Great day for outdoor exploration!"

--- a/python/samples/azure_functions/04_single_agent_orchestration_chaining/README.md
+++ b/python/samples/azure_functions/04_single_agent_orchestration_chaining/README.md
@@ -1,0 +1,53 @@
+# Single Agent Orchestration Sample (Python)
+
+This sample shows how to chain two invocations of the same agent inside a Durable Functions orchestration while
+preserving the conversation state between runs.
+
+## Key Concepts
+- Deterministic orchestrations that make sequential agent calls on a shared session
+- Reusing an agent session to carry conversation history across invocations
+- HTTP endpoints for starting the orchestration and polling for status/output
+
+## Prerequisites
+
+Start with the shared setup instructions in `../README.md` to create a virtual environment, install dependencies, and configure Azure OpenAI and storage settings.
+
+## Running the Sample
+Start the orchestration:
+
+```bash
+curl -X POST http://localhost:7071/api/singleagent/run
+```
+
+Poll the returned `statusQueryGetUri` until completion:
+
+```bash
+curl http://localhost:7071/api/singleagent/status/<instanceId>
+```
+
+> **Note:** The underlying agent run endpoint now waits for responses by default. If you invoke it directly and prefer an immediate HTTP 202, set the `x-ms-wait-for-response` header or include `"wait_for_response": false` in the payload.
+
+The orchestration first requests an inspirational sentence from the agent, then refines the initial response while
+keeping it under 25 words—mirroring the behaviour of the corresponding .NET sample.
+
+## Expected Output
+
+Sample response when starting the orchestration:
+
+```json
+{
+  "message": "Single-agent orchestration started.",
+  "instanceId": "ebb5c1df123e4d6fb8e7d703ffd0d0b0",
+  "statusQueryGetUri": "http://localhost:7071/api/singleagent/status/ebb5c1df123e4d6fb8e7d703ffd0d0b0"
+}
+```
+
+Sample completed status payload:
+
+```json
+{
+  "instanceId": "ebb5c1df123e4d6fb8e7d703ffd0d0b0",
+  "runtimeStatus": "Completed",
+  "output": "Learning is a journey where curiosity turns effort into mastery."
+}
+```

--- a/python/samples/azure_functions/04_single_agent_orchestration_chaining/demo.http
+++ b/python/samples/azure_functions/04_single_agent_orchestration_chaining/demo.http
@@ -1,0 +1,9 @@
+### Start the single-agent orchestration
+POST http://localhost:7071/api/singleagent/run
+
+
+### Check the status of the orchestration
+
+@instanceId =<Replace with the instance ID from the response above>
+
+GET http://localhost:7071/api/singleagent/status/{{instanceId}}

--- a/python/samples/azure_functions/04_single_agent_orchestration_chaining/function_app.py
+++ b/python/samples/azure_functions/04_single_agent_orchestration_chaining/function_app.py
@@ -1,0 +1,174 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+"""Chain two runs of a single agent inside a Durable Functions orchestration.
+
+Components used in this sample:
+- FoundryChatClient to construct the writer agent hosted by Agent Framework.
+- AgentFunctionApp to surface HTTP and orchestration triggers via the Azure Functions extension.
+- Durable Functions orchestration to run sequential agent invocations on the same conversation session.
+
+Prerequisites: configure `FOUNDRY_PROJECT_ENDPOINT`, `FOUNDRY_MODEL`, and sign in with Azure CLI before starting the Functions host."""
+
+import json
+import logging
+import os
+from collections.abc import Generator
+from typing import Any
+
+import azure.functions as func
+from agent_framework import Agent
+from agent_framework.foundry import FoundryChatClient
+from agent_framework_azurefunctions import AgentFunctionApp
+from azure.durable_functions import DurableOrchestrationClient, DurableOrchestrationContext
+from azure.identity.aio import AzureCliCredential
+
+logger = logging.getLogger(__name__)
+
+# 1. Define the agent name used across the orchestration.
+WRITER_AGENT_NAME = "WriterAgent"
+
+
+# 2. Create the writer agent that will be invoked twice within the orchestration.
+def _create_writer_agent() -> Any:
+    """Create the writer agent with the same persona as the C# sample."""
+    instructions = (
+        "You refine short pieces of text. When given an initial sentence you enhance it;\n"
+        "when given an improved sentence you polish it further."
+    )
+
+    _client = FoundryChatClient(
+        project_endpoint=os.environ["FOUNDRY_PROJECT_ENDPOINT"],
+        model=os.environ["FOUNDRY_MODEL"],
+        credential=AzureCliCredential(),
+    )
+    return Agent(
+        client=_client,
+        name=WRITER_AGENT_NAME,
+        instructions=instructions,
+    )
+
+
+# 3. Register the agent with AgentFunctionApp so HTTP and orchestration triggers are exposed.
+app = AgentFunctionApp(agents=[_create_writer_agent()], enable_health_check=True)
+
+
+# 4. Orchestration that runs the agent sequentially on a shared session for chaining behaviour.
+@app.orchestration_trigger(context_name="context")
+def single_agent_orchestration(context: DurableOrchestrationContext) -> Generator[Any, Any, str]:
+    """Run the writer agent twice on the same session to mirror chaining behaviour."""
+
+    writer = app.get_agent(context, WRITER_AGENT_NAME)
+    writer_session = writer.create_session()
+
+    initial = yield writer.run(
+        messages="Write a concise inspirational sentence about learning.",
+        session=writer_session,
+    )
+
+    improved_prompt = f"Improve this further while keeping it under 25 words: {initial.text}"
+
+    refined = yield writer.run(
+        messages=improved_prompt,
+        session=writer_session,
+    )
+
+    return refined.text
+
+
+# 5. HTTP endpoint to kick off the orchestration and return the status query URI.
+@app.route(route="singleagent/run", methods=["POST"])
+@app.durable_client_input(client_name="client")
+async def start_single_agent_orchestration(
+    req: func.HttpRequest,
+    client: DurableOrchestrationClient,
+) -> func.HttpResponse:
+    """Start the orchestration and return status metadata."""
+
+    instance_id = await client.start_new(
+        orchestration_function_name="single_agent_orchestration",
+    )
+
+    logger.info("[HTTP] Started orchestration with instance_id: %s", instance_id)
+
+    status_url = _build_status_url(req.url, instance_id, route="singleagent")
+
+    payload = {
+        "message": "Single-agent orchestration started.",
+        "instanceId": instance_id,
+        "statusQueryGetUri": status_url,
+    }
+
+    return func.HttpResponse(
+        body=json.dumps(payload),
+        status_code=202,
+        mimetype="application/json",
+    )
+
+
+# 6. HTTP endpoint to fetch orchestration status using the original instance ID.
+@app.route(route="singleagent/status/{instanceId}", methods=["GET"])
+@app.durable_client_input(client_name="client")
+async def get_orchestration_status(
+    req: func.HttpRequest,
+    client: DurableOrchestrationClient,
+) -> func.HttpResponse:
+    """Return orchestration runtime status."""
+
+    instance_id = req.route_params.get("instanceId")
+    if not instance_id:
+        return func.HttpResponse(
+            body=json.dumps({"error": "Missing instanceId"}),
+            status_code=400,
+            mimetype="application/json",
+        )
+
+    status = await client.get_status(instance_id)
+
+    response_data: dict[str, Any] = {
+        "instanceId": status.instance_id,
+        "runtimeStatus": status.runtime_status.name if status.runtime_status else None,
+    }
+
+    if status.input_ is not None:
+        response_data["input"] = status.input_
+
+    if status.output is not None:
+        response_data["output"] = status.output
+
+    return func.HttpResponse(
+        body=json.dumps(response_data),
+        status_code=200,
+        mimetype="application/json",
+    )
+
+
+# 7. Helper to construct durable status URLs similar to the .NET sample implementation.
+def _build_status_url(request_url: str, instance_id: str, *, route: str) -> str:
+    """Construct the status query URI similar to DurableHttpApiExtensions in C#."""
+
+    # Split once on /api/ to preserve host and scheme in local emulator and Azure.
+    base_url, _, _ = request_url.partition("/api/")
+    if not base_url:
+        base_url = request_url.rstrip("/")
+    return f"{base_url}/api/{route}/status/{instance_id}"
+
+
+"""
+Expected output when calling `POST /api/singleagent/run` and following the returned status URL:
+
+HTTP/1.1 202 Accepted
+{
+    "message": "Single-agent orchestration started.",
+    "instanceId": "<guid>",
+    "statusQueryGetUri": "http://localhost:7071/api/singleagent/status/<guid>"
+}
+
+Subsequent `GET /api/singleagent/status/<guid>` after completion returns:
+
+HTTP/1.1 200 OK
+{
+    "instanceId": "<guid>",
+    "runtimeStatus": "Completed",
+    "output": "Learning is a journey where curiosity turns effort into mastery."
+}
+"""

--- a/python/samples/azure_functions/04_single_agent_orchestration_chaining/function_app.py
+++ b/python/samples/azure_functions/04_single_agent_orchestration_chaining/function_app.py
@@ -7,7 +7,8 @@ Components used in this sample:
 - AgentFunctionApp to surface HTTP and orchestration triggers via the Azure Functions extension.
 - Durable Functions orchestration to run sequential agent invocations on the same conversation session.
 
-Prerequisites: configure `FOUNDRY_PROJECT_ENDPOINT`, `FOUNDRY_MODEL`, and sign in with Azure CLI before starting the Functions host."""
+Prerequisites: configure `FOUNDRY_PROJECT_ENDPOINT` and `FOUNDRY_MODEL`, then sign
+in with Azure CLI before starting the Functions host."""
 
 import json
 import logging
@@ -72,7 +73,7 @@ def single_agent_orchestration(context: DurableOrchestrationContext) -> Generato
         session=writer_session,
     )
 
-    return refined.text
+    return refined.text  # noqa: B901 - Durable orchestrators return their final output.
 
 
 # 5. HTTP endpoint to kick off the orchestration and return the status query URI.

--- a/python/samples/azure_functions/04_single_agent_orchestration_chaining/host.json
+++ b/python/samples/azure_functions/04_single_agent_orchestration_chaining/host.json
@@ -1,0 +1,12 @@
+{
+  "version": "2.0",
+  "extensionBundle": {
+    "id": "Microsoft.Azure.Functions.ExtensionBundle",
+    "version": "[4.*, 5.0.0)"
+  },
+  "extensions": {
+    "durableTask": {
+      "hubName": "%TASKHUB_NAME%"
+    }
+  }
+}

--- a/python/samples/azure_functions/04_single_agent_orchestration_chaining/local.settings.json.template
+++ b/python/samples/azure_functions/04_single_agent_orchestration_chaining/local.settings.json.template
@@ -1,0 +1,11 @@
+{
+  "IsEncrypted": false,
+  "Values": {
+    "FUNCTIONS_WORKER_RUNTIME": "python",
+    "AzureWebJobsStorage": "UseDevelopmentStorage=true",
+    "DURABLE_TASK_SCHEDULER_CONNECTION_STRING": "Endpoint=http://localhost:8080;TaskHub=default;Authentication=None",
+    "TASKHUB_NAME": "default",
+    "FOUNDRY_PROJECT_ENDPOINT": "<FOUNDRY_PROJECT_ENDPOINT>",
+    "FOUNDRY_MODEL": "<FOUNDRY_MODEL>"
+  }
+}

--- a/python/samples/azure_functions/04_single_agent_orchestration_chaining/requirements.txt
+++ b/python/samples/azure_functions/04_single_agent_orchestration_chaining/requirements.txt
@@ -1,0 +1,14 @@
+# Agent Framework packages
+# To use the deployed version, uncomment the lines below and comment out the local installation lines
+# agent-framework-foundry
+# agent-framework-azurefunctions
+
+# Local installation (for development and testing)
+# Each package must be listed explicitly because pip doesn't resolve uv workspace sources.
+# Without explicit entries, pip would fetch transitive dependencies from PyPI instead of local source.
+agent-framework-foundry>=1.10.1,<2  # Foundry support from PyPI (pulls in core)
+-e ../../../packages/durabletask  # Durable Task support - dependency of azurefunctions
+-e ../../../packages/azurefunctions  # Azure Functions integration - the main package for this sample
+
+# Azure authentication
+azure-identity

--- a/python/samples/azure_functions/05_multi_agent_orchestration_concurrency/README.md
+++ b/python/samples/azure_functions/05_multi_agent_orchestration_concurrency/README.md
@@ -1,0 +1,58 @@
+# Multi-Agent Orchestration (Concurrency) – Python
+
+This sample starts a Durable Functions orchestration that runs two agents in parallel and merges their responses.
+
+## Highlights
+- Two agents (`PhysicistAgent` and `ChemistAgent`) share a single Azure OpenAI deployment configuration.
+- The orchestration uses `context.task_all(...)` to safely run both agents concurrently.
+- HTTP routes (`/api/multiagent/run` and `/api/multiagent/status/{instanceId}`) mirror the .NET sample for parity.
+
+## Prerequisites
+
+Use the shared setup instructions in `../README.md` to prepare the environment, install dependencies, and configure Azure OpenAI and storage settings before running this sample.
+
+## Running the Sample
+Start the orchestration:
+
+```bash
+curl -X POST \
+  -H "Content-Type: text/plain" \
+  --data "What is temperature?" \
+  http://localhost:7071/api/multiagent/run
+```
+
+Poll the returned `statusQueryGetUri` until completion:
+
+```bash
+curl http://localhost:7071/api/multiagent/status/<instanceId>
+```
+
+> **Note:** The agent run endpoints wait for responses by default. If you call them directly and need an immediate HTTP 202, set the `x-ms-wait-for-response` header or include `"wait_for_response": false` in the request payload.
+
+The orchestration launches both agents simultaneously so their domain-specific answers can be combined for the caller.
+
+## Expected Output
+
+Example response when starting the orchestration:
+
+```json
+{
+  "message": "Multi-agent concurrent orchestration started.",
+  "prompt": "What is temperature?",
+  "instanceId": "94d56266f0a04e5a8f9f3a1f77a4c597",
+  "statusQueryGetUri": "http://localhost:7071/api/multiagent/status/94d56266f0a04e5a8f9f3a1f77a4c597"
+}
+```
+
+Example completed status payload:
+
+```json
+{
+  "instanceId": "94d56266f0a04e5a8f9f3a1f77a4c597",
+  "runtimeStatus": "Completed",
+  "output": {
+    "physicist": "Temperature measures the average kinetic energy of particles in a system.",
+    "chemist": "Temperature reflects how molecular motion influences reaction rates and equilibria."
+  }
+}
+```

--- a/python/samples/azure_functions/05_multi_agent_orchestration_concurrency/demo.http
+++ b/python/samples/azure_functions/05_multi_agent_orchestration_concurrency/demo.http
@@ -1,0 +1,11 @@
+### Start the multi-agent concurrent orchestration
+POST http://localhost:7071/api/multiagent/run
+Content-Type: text/plain
+
+What is temperature?
+
+### Check the status of the orchestration
+
+@instanceId =<Enter the instance ID from the response above>
+
+GET http://localhost:7071/api/multiagent/status/{{instanceId}}

--- a/python/samples/azure_functions/05_multi_agent_orchestration_concurrency/function_app.py
+++ b/python/samples/azure_functions/05_multi_agent_orchestration_concurrency/function_app.py
@@ -1,0 +1,206 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+"""Fan out concurrent runs across two agents inside a Durable Functions orchestration.
+
+Components used in this sample:
+- FoundryChatClient to create domain-specific agents hosted by Agent Framework.
+- AgentFunctionApp to expose orchestration and HTTP triggers.
+- Durable Functions orchestration that executes agent calls in parallel and aggregates results.
+
+Prerequisites: configure `FOUNDRY_PROJECT_ENDPOINT`, `FOUNDRY_MODEL`, and sign in with Azure CLI before starting the Functions host."""
+
+import json
+import logging
+import os
+from collections.abc import Generator
+from typing import Any, cast
+
+import azure.functions as func
+from agent_framework import Agent, AgentResponse
+from agent_framework.foundry import FoundryChatClient
+from agent_framework_azurefunctions import AgentFunctionApp
+from azure.durable_functions import DurableOrchestrationClient, DurableOrchestrationContext
+from azure.identity.aio import AzureCliCredential
+from dotenv import load_dotenv
+
+# Load environment variables from .env file
+load_dotenv()
+
+logger = logging.getLogger(__name__)
+
+# 1. Define agent names shared across the orchestration.
+PHYSICIST_AGENT_NAME = "PhysicistAgent"
+CHEMIST_AGENT_NAME = "ChemistAgent"
+
+
+# 2. Instantiate both agents that the orchestration will run concurrently.
+def _create_agents() -> list[Any]:
+    physicist = Agent(
+        client=FoundryChatClient(
+            project_endpoint=os.environ["FOUNDRY_PROJECT_ENDPOINT"],
+            model=os.environ["FOUNDRY_MODEL"],
+            credential=AzureCliCredential(),
+        ),
+        name=PHYSICIST_AGENT_NAME,
+        instructions="You are an expert in physics. You answer questions from a physics perspective.",
+    )
+
+    chemist = Agent(
+        client=FoundryChatClient(
+            project_endpoint=os.environ["FOUNDRY_PROJECT_ENDPOINT"],
+            model=os.environ["FOUNDRY_MODEL"],
+            credential=AzureCliCredential(),
+        ),
+        name=CHEMIST_AGENT_NAME,
+        instructions="You are an expert in chemistry. You answer questions from a chemistry perspective.",
+    )
+
+    return [physicist, chemist]
+
+
+# 3. Register both agents with AgentFunctionApp and selectively enable HTTP endpoints.
+agents = _create_agents()
+app = AgentFunctionApp(enable_health_check=True, enable_http_endpoints=False)
+app.add_agent(agents[0], enable_http_endpoint=True)
+app.add_agent(agents[1])
+
+
+# 4. Durable Functions orchestration that runs both agents in parallel.
+@app.orchestration_trigger(context_name="context")
+def multi_agent_concurrent_orchestration(context: DurableOrchestrationContext) -> Generator[Any, Any, dict[str, str]]:
+    """Fan out to two domain-specific agents and aggregate their responses."""
+    prompt = context.get_input()
+    if not prompt or not str(prompt).strip():
+        raise ValueError("Prompt is required")
+
+    physicist = app.get_agent(context, PHYSICIST_AGENT_NAME)
+    chemist = app.get_agent(context, CHEMIST_AGENT_NAME)
+
+    physicist_session = physicist.create_session()
+    chemist_session = chemist.create_session()
+
+    # Create tasks from agent.run() calls
+    physicist_task = physicist.run(messages=str(prompt), session=physicist_session)
+    chemist_task = chemist.run(messages=str(prompt), session=chemist_session)
+
+    # Execute both tasks concurrently using task_all
+    task_results = yield context.task_all([physicist_task, chemist_task])
+
+    physicist_result = cast(AgentResponse, task_results[0])
+    chemist_result = cast(AgentResponse, task_results[1])
+
+    return {
+        "physicist": physicist_result.text,
+        "chemist": chemist_result.text,
+    }
+
+
+# 5. HTTP endpoint to accept prompts and start the concurrent orchestration.
+@app.route(route="multiagent/run", methods=["POST"])
+@app.durable_client_input(client_name="client")
+async def start_multi_agent_concurrent_orchestration(
+    req: func.HttpRequest,
+    client: DurableOrchestrationClient,
+) -> func.HttpResponse:
+    """Kick off the orchestration with a plain text prompt."""
+
+    body_bytes = req.get_body() or b""
+    prompt = body_bytes.decode("utf-8", errors="replace").strip()
+    if not prompt:
+        return func.HttpResponse(
+            body=json.dumps({"error": "Prompt is required"}),
+            status_code=400,
+            mimetype="application/json",
+        )
+
+    instance_id = await client.start_new(
+        orchestration_function_name="multi_agent_concurrent_orchestration",
+        client_input=prompt,
+    )
+
+    logger.info("[HTTP] Started orchestration with instance_id: %s", instance_id)
+
+    status_url = _build_status_url(req.url, instance_id, route="multiagent")
+
+    payload = {
+        "message": "Multi-agent concurrent orchestration started.",
+        "prompt": prompt,
+        "instanceId": instance_id,
+        "statusQueryGetUri": status_url,
+    }
+
+    return func.HttpResponse(
+        body=json.dumps(payload),
+        status_code=202,
+        mimetype="application/json",
+    )
+
+
+# 6. HTTP endpoint to retrieve orchestration status and aggregated outputs.
+@app.route(route="multiagent/status/{instanceId}", methods=["GET"])
+@app.durable_client_input(client_name="client")
+async def get_orchestration_status(
+    req: func.HttpRequest,
+    client: DurableOrchestrationClient,
+) -> func.HttpResponse:
+    instance_id = req.route_params.get("instanceId")
+    if not instance_id:
+        return func.HttpResponse(
+            body=json.dumps({"error": "Missing instanceId"}),
+            status_code=400,
+            mimetype="application/json",
+        )
+
+    status = await client.get_status(instance_id)
+
+    response_data: dict[str, Any] = {
+        "instanceId": status.instance_id,
+        "runtimeStatus": status.runtime_status.name if status.runtime_status else None,
+        "createdTime": status.created_time.isoformat() if status.created_time else None,
+        "lastUpdatedTime": status.last_updated_time.isoformat() if status.last_updated_time else None,
+    }
+
+    if status.input_ is not None:
+        response_data["input"] = status.input_
+
+    if status.output is not None:
+        response_data["output"] = status.output
+
+    return func.HttpResponse(
+        body=json.dumps(response_data),
+        status_code=200,
+        mimetype="application/json",
+    )
+
+
+# 7. Helper to construct durable status URLs.
+def _build_status_url(request_url: str, instance_id: str, *, route: str) -> str:
+    base_url, _, _ = request_url.partition("/api/")
+    if not base_url:
+        base_url = request_url.rstrip("/")
+    return f"{base_url}/api/{route}/status/{instance_id}"
+
+
+"""
+Expected output when calling `POST /api/multiagent/run` with a plain-text prompt:
+
+HTTP/1.1 202 Accepted
+{
+    "message": "Multi-agent concurrent orchestration started.",
+    "prompt": "What is temperature?",
+    "instanceId": "<guid>",
+    "statusQueryGetUri": "http://localhost:7071/api/multiagent/status/<guid>"
+}
+
+Polling `GET /api/multiagent/status/<guid>` after completion returns:
+
+HTTP/1.1 200 OK
+{
+    "instanceId": "<guid>",
+    "runtimeStatus": "Completed",
+    "output": {
+        "physicist": "Temperature measures the average kinetic energy of particles in a system.",
+        "chemist": "Temperature reflects how molecular motion influences reaction rates and equilibria."
+    }
+}
+"""

--- a/python/samples/azure_functions/05_multi_agent_orchestration_concurrency/function_app.py
+++ b/python/samples/azure_functions/05_multi_agent_orchestration_concurrency/function_app.py
@@ -7,7 +7,8 @@ Components used in this sample:
 - AgentFunctionApp to expose orchestration and HTTP triggers.
 - Durable Functions orchestration that executes agent calls in parallel and aggregates results.
 
-Prerequisites: configure `FOUNDRY_PROJECT_ENDPOINT`, `FOUNDRY_MODEL`, and sign in with Azure CLI before starting the Functions host."""
+Prerequisites: configure `FOUNDRY_PROJECT_ENDPOINT` and `FOUNDRY_MODEL`, then sign
+in with Azure CLI before starting the Functions host."""
 
 import json
 import logging
@@ -89,7 +90,7 @@ def multi_agent_concurrent_orchestration(context: DurableOrchestrationContext) -
     physicist_result = cast(AgentResponse, task_results[0])
     chemist_result = cast(AgentResponse, task_results[1])
 
-    return {
+    return {  # noqa: B901 - Durable orchestrators return their final output.
         "physicist": physicist_result.text,
         "chemist": chemist_result.text,
     }

--- a/python/samples/azure_functions/05_multi_agent_orchestration_concurrency/host.json
+++ b/python/samples/azure_functions/05_multi_agent_orchestration_concurrency/host.json
@@ -1,0 +1,12 @@
+{
+  "version": "2.0",
+  "extensionBundle": {
+    "id": "Microsoft.Azure.Functions.ExtensionBundle",
+    "version": "[4.*, 5.0.0)"
+  },
+  "extensions": {
+    "durableTask": {
+      "hubName": "%TASKHUB_NAME%"
+    }
+  }
+}

--- a/python/samples/azure_functions/05_multi_agent_orchestration_concurrency/local.settings.json.template
+++ b/python/samples/azure_functions/05_multi_agent_orchestration_concurrency/local.settings.json.template
@@ -1,0 +1,11 @@
+{
+  "IsEncrypted": false,
+  "Values": {
+    "FUNCTIONS_WORKER_RUNTIME": "python",
+    "AzureWebJobsStorage": "UseDevelopmentStorage=true",
+    "DURABLE_TASK_SCHEDULER_CONNECTION_STRING": "Endpoint=http://localhost:8080;TaskHub=default;Authentication=None",
+    "TASKHUB_NAME": "default",
+    "FOUNDRY_PROJECT_ENDPOINT": "<FOUNDRY_PROJECT_ENDPOINT>",
+    "FOUNDRY_MODEL": "<FOUNDRY_MODEL>"
+  }
+}

--- a/python/samples/azure_functions/05_multi_agent_orchestration_concurrency/requirements.txt
+++ b/python/samples/azure_functions/05_multi_agent_orchestration_concurrency/requirements.txt
@@ -1,0 +1,14 @@
+# Agent Framework packages
+# To use the deployed version, uncomment the lines below and comment out the local installation lines
+# agent-framework-foundry
+# agent-framework-azurefunctions
+
+# Local installation (for development and testing)
+# Each package must be listed explicitly because pip doesn't resolve uv workspace sources.
+# Without explicit entries, pip would fetch transitive dependencies from PyPI instead of local source.
+agent-framework-foundry>=1.10.1,<2  # Foundry support from PyPI (pulls in core)
+-e ../../../packages/durabletask  # Durable Task support - dependency of azurefunctions
+-e ../../../packages/azurefunctions  # Azure Functions integration - the main package for this sample
+
+# Azure authentication
+azure-identity

--- a/python/samples/azure_functions/05_multi_agent_orchestration_concurrency/requirements.txt
+++ b/python/samples/azure_functions/05_multi_agent_orchestration_concurrency/requirements.txt
@@ -12,3 +12,6 @@ agent-framework-foundry>=1.10.1,<2  # Foundry support from PyPI (pulls in core)
 
 # Azure authentication
 azure-identity
+
+# Local environment loading
+python-dotenv

--- a/python/samples/azure_functions/06_multi_agent_orchestration_conditionals/README.md
+++ b/python/samples/azure_functions/06_multi_agent_orchestration_conditionals/README.md
@@ -1,0 +1,35 @@
+# Multi-Agent Orchestration (Conditionals) – Python
+
+This sample evaluates incoming emails with a spam detector agent and,
+when appropriate, drafts a response using an email assistant agent.
+
+## Prerequisites
+
+Set up the shared prerequisites outlined in `../README.md`, including the virtual environment, dependency installation, and Azure OpenAI and storage configuration.
+
+## Scenario Overview
+- Two Azure OpenAI agents share a single deployment: one flags spam, the other drafts replies.
+- Structured responses (`is_spam` and `reason`, or `response`) determine which orchestration branch runs.
+- Activity functions handle the side effects of spam handling and email sending.
+
+## Running the Sample
+Submit an email payload:
+
+```bash
+curl -X POST "http://localhost:7071/api/spamdetection/run" \
+  -H "Content-Type: application/json" \
+  -d '{"email_id": "email-001", "email_content": "URGENT! You'\''ve won $1,000,000! Click here now to claim your prize! Limited time offer! Don'\''t miss out!"}'
+```
+
+Poll the returned `statusQueryGetUri` or call the status route directly:
+
+```bash
+curl http://localhost:7071/api/spamdetection/status/<instanceId>
+```
+
+> **Note:** The spam detection run endpoint waits for responses by default. To opt into an immediate HTTP 202, set the `x-ms-wait-for-response` header or include `"wait_for_response": false` in the POST body.
+
+## Expected Responses
+- Spam payloads return `Email marked as spam: <reason>` by invoking the `handle_spam_email` activity.
+- Legitimate emails return `Email sent: <draft>` after the email assistant agent produces a structured reply.
+- The status endpoint mirrors Durable Functions metadata, including runtime status and the agent output.

--- a/python/samples/azure_functions/06_multi_agent_orchestration_conditionals/demo.http
+++ b/python/samples/azure_functions/06_multi_agent_orchestration_conditionals/demo.http
@@ -1,0 +1,24 @@
+### Test spam detection with a legitimate email
+POST http://localhost:7071/api/spamdetection/run
+Content-Type: application/json
+
+{
+  "email_id": "email-001",
+  "email_content": "Hi John, I hope you're doing well. I wanted to follow up on our meeting yesterday about the quarterly report. Could you please send me the updated figures by Friday? Thanks!"
+}
+
+
+### Test spam detection with a spam email
+POST http://localhost:7071/api/spamdetection/run
+Content-Type: application/json
+
+{
+  "email_id": "email-002",
+  "email_content": "URGENT! You've won $1,000,000! Click here now to claim your prize! Limited time offer! Don't miss out!"
+}
+
+
+### Check the status of the orchestration
+@instanceId =<Replace with the instance ID from the response above>
+
+GET http://localhost:7071/api/spamdetection/status/{{instanceId}}

--- a/python/samples/azure_functions/06_multi_agent_orchestration_conditionals/function_app.py
+++ b/python/samples/azure_functions/06_multi_agent_orchestration_conditionals/function_app.py
@@ -119,7 +119,7 @@ def spam_detection_orchestration(context: DurableOrchestrationContext) -> Genera
 
     if spam_result.is_spam:
         result = yield context.call_activity("handle_spam_email", spam_result.reason)  # type: ignore[misc]
-        return result
+        return result  # noqa: B901 - Durable orchestrators return their final output.
 
     email_session = email_agent.create_session()
 
@@ -142,7 +142,7 @@ def spam_detection_orchestration(context: DurableOrchestrationContext) -> Genera
         raise ValueError("Failed to parse email response") from ex
 
     result = yield context.call_activity("send_email", email_result.response)  # type: ignore[misc]
-    return result
+    return result  # noqa: B901 - Durable orchestrators return their final output.
 
 
 # 5. HTTP starter endpoint launches the orchestration for each email payload.

--- a/python/samples/azure_functions/06_multi_agent_orchestration_conditionals/function_app.py
+++ b/python/samples/azure_functions/06_multi_agent_orchestration_conditionals/function_app.py
@@ -1,0 +1,265 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+"""Route email requests through conditional orchestration with two agents.
+
+Components used in this sample:
+- FoundryChatClient agents for spam detection and email drafting.
+- AgentFunctionApp with Durable orchestration, activity, and HTTP triggers.
+- Pydantic models that validate payloads and agent JSON responses.
+
+Prerequisites: set `FOUNDRY_PROJECT_ENDPOINT`, `FOUNDRY_MODEL`, and sign in with Azure CLI before running the
+Functions host."""
+
+import json
+import logging
+import os
+from collections.abc import Generator, Mapping
+from typing import Any
+
+import azure.functions as func
+from agent_framework import Agent
+from agent_framework.foundry import FoundryChatClient
+from agent_framework_azurefunctions import AgentFunctionApp
+from azure.durable_functions import DurableOrchestrationClient, DurableOrchestrationContext
+from azure.identity.aio import AzureCliCredential
+from pydantic import BaseModel, ValidationError
+
+logger = logging.getLogger(__name__)
+
+# 1. Define agent names shared across the orchestration.
+SPAM_AGENT_NAME = "SpamDetectionAgent"
+EMAIL_AGENT_NAME = "EmailAssistantAgent"
+
+
+class SpamDetectionResult(BaseModel):
+    is_spam: bool
+    reason: str
+
+
+class EmailResponse(BaseModel):
+    response: str
+
+
+class EmailPayload(BaseModel):
+    email_id: str
+    email_content: str
+
+
+# 2. Instantiate both agents so they can be registered with AgentFunctionApp.
+def _create_agents() -> list[Any]:
+    client = FoundryChatClient(
+        project_endpoint=os.environ["FOUNDRY_PROJECT_ENDPOINT"],
+        model=os.environ["FOUNDRY_MODEL"],
+        credential=AzureCliCredential(),
+    )
+
+    spam_agent = Agent(
+        client=client,
+        name=SPAM_AGENT_NAME,
+        instructions="You are a spam detection assistant that identifies spam emails.",
+    )
+
+    email_agent = Agent(
+        client=client,
+        name=EMAIL_AGENT_NAME,
+        instructions="You are an email assistant that helps users draft responses to emails with professionalism.",
+    )
+
+    return [spam_agent, email_agent]
+
+
+app = AgentFunctionApp(agents=_create_agents(), enable_health_check=True)
+
+
+# 3. Activities handle the side effects for spam and legitimate emails.
+@app.activity_trigger(input_name="reason")
+def handle_spam_email(reason: str) -> str:
+    return f"Email marked as spam: {reason}"
+
+
+@app.activity_trigger(input_name="message")
+def send_email(message: str) -> str:
+    return f"Email sent: {message}"
+
+
+# 4. Orchestration validates input, runs agents, and branches on spam results.
+@app.orchestration_trigger(context_name="context")
+def spam_detection_orchestration(context: DurableOrchestrationContext) -> Generator[Any, Any, str]:
+    payload_raw = context.get_input()
+    if not isinstance(payload_raw, Mapping):
+        raise ValueError("Email data is required")
+
+    try:
+        payload = EmailPayload.model_validate(payload_raw)
+    except ValidationError as exc:
+        raise ValueError(f"Invalid email payload: {exc}") from exc
+
+    spam_agent = app.get_agent(context, SPAM_AGENT_NAME)
+    email_agent = app.get_agent(context, EMAIL_AGENT_NAME)
+
+    spam_session = spam_agent.create_session()
+
+    spam_prompt = (
+        "Analyze this email for spam content and return a JSON response with 'is_spam' (boolean) "
+        "and 'reason' (string) fields:\n"
+        f"Email ID: {payload.email_id}\n"
+        f"Content: {payload.email_content}"
+    )
+
+    spam_result_raw = yield spam_agent.run(
+        messages=spam_prompt,
+        session=spam_session,
+        options={"response_format": SpamDetectionResult},
+    )
+
+    try:
+        spam_result = spam_result_raw.value
+    except Exception as ex:
+        raise ValueError("Failed to parse spam detection result") from ex
+
+    if spam_result.is_spam:
+        result = yield context.call_activity("handle_spam_email", spam_result.reason)  # type: ignore[misc]
+        return result
+
+    email_session = email_agent.create_session()
+
+    email_prompt = (
+        "Draft a professional response to this email. Return a JSON response with a 'response' field "
+        "containing the reply:\n\n"
+        f"Email ID: {payload.email_id}\n"
+        f"Content: {payload.email_content}"
+    )
+
+    email_result_raw = yield email_agent.run(
+        messages=email_prompt,
+        session=email_session,
+        options={"response_format": EmailResponse},
+    )
+
+    try:
+        email_result = email_result_raw.value
+    except Exception as ex:
+        raise ValueError("Failed to parse email response") from ex
+
+    result = yield context.call_activity("send_email", email_result.response)  # type: ignore[misc]
+    return result
+
+
+# 5. HTTP starter endpoint launches the orchestration for each email payload.
+@app.route(route="spamdetection/run", methods=["POST"])
+@app.durable_client_input(client_name="client")
+async def start_spam_detection_orchestration(
+    req: func.HttpRequest,
+    client: DurableOrchestrationClient,
+) -> func.HttpResponse:
+    try:
+        body = req.get_json()
+    except ValueError:
+        body = None
+
+    if not isinstance(body, Mapping):
+        return func.HttpResponse(
+            body=json.dumps({"error": "Email data is required"}),
+            status_code=400,
+            mimetype="application/json",
+        )
+
+    try:
+        payload = EmailPayload.model_validate(body)
+    except ValidationError as exc:
+        return func.HttpResponse(
+            body=json.dumps({"error": f"Invalid email payload: {exc}"}),
+            status_code=400,
+            mimetype="application/json",
+        )
+
+    instance_id = await client.start_new(
+        orchestration_function_name="spam_detection_orchestration",
+        client_input=payload.model_dump(),
+    )
+
+    logger.info("[HTTP] Started spam detection orchestration with instance_id: %s", instance_id)
+
+    status_url = _build_status_url(req.url, instance_id, route="spamdetection")
+
+    payload_json = {
+        "message": "Spam detection orchestration started.",
+        "emailId": payload.email_id,
+        "instanceId": instance_id,
+        "statusQueryGetUri": status_url,
+    }
+
+    return func.HttpResponse(
+        body=json.dumps(payload_json),
+        status_code=202,
+        mimetype="application/json",
+    )
+
+
+# 6. Status endpoint mirrors Durable Functions default payload with agent data.
+@app.route(route="spamdetection/status/{instanceId}", methods=["GET"])
+@app.durable_client_input(client_name="client")
+async def get_orchestration_status(
+    req: func.HttpRequest,
+    client: DurableOrchestrationClient,
+) -> func.HttpResponse:
+    instance_id = req.route_params.get("instanceId")
+    if not instance_id:
+        return func.HttpResponse(
+            body=json.dumps({"error": "Missing instanceId"}),
+            status_code=400,
+            mimetype="application/json",
+        )
+
+    status = await client.get_status(instance_id)
+
+    response_data: dict[str, Any] = {
+        "instanceId": status.instance_id,
+        "runtimeStatus": status.runtime_status.name if status.runtime_status else None,
+        "createdTime": status.created_time.isoformat() if status.created_time else None,
+        "lastUpdatedTime": status.last_updated_time.isoformat() if status.last_updated_time else None,
+    }
+
+    if status.input_ is not None:
+        response_data["input"] = status.input_
+
+    if status.output is not None:
+        response_data["output"] = status.output
+
+    return func.HttpResponse(
+        body=json.dumps(response_data),
+        status_code=200,
+        mimetype="application/json",
+    )
+
+
+# 7. Helper utilities keep URL construction and structured parsing deterministic.
+def _build_status_url(request_url: str, instance_id: str, *, route: str) -> str:
+    base_url, _, _ = request_url.partition("/api/")
+    if not base_url:
+        base_url = request_url.rstrip("/")
+    return f"{base_url}/api/{route}/status/{instance_id}"
+
+
+"""
+Expected response from `POST /api/spamdetection/run`:
+
+HTTP/1.1 202 Accepted
+{
+    "message": "Spam detection orchestration started.",
+    "emailId": "123",
+    "instanceId": "<durable-instance-id>",
+    "statusQueryGetUri": "http://localhost:7071/runtime/webhooks/durabletask/instances/<durable-instance-id>"
+}
+
+Expected response from `GET /api/spamdetection/status/{instanceId}` once complete:
+
+HTTP/1.1 200 OK
+{
+    "instanceId": "<durable-instance-id>",
+    "runtimeStatus": "Completed",
+    "createdTime": "2024-01-01T00:00:00+00:00",
+    "lastUpdatedTime": "2024-01-01T00:00:10+00:00",
+    "output": "Email sent: Thank you for reaching out..."
+}
+"""

--- a/python/samples/azure_functions/06_multi_agent_orchestration_conditionals/host.json
+++ b/python/samples/azure_functions/06_multi_agent_orchestration_conditionals/host.json
@@ -1,0 +1,12 @@
+{
+  "version": "2.0",
+  "extensionBundle": {
+    "id": "Microsoft.Azure.Functions.ExtensionBundle",
+    "version": "[4.*, 5.0.0)"
+  },
+  "extensions": {
+    "durableTask": {
+      "hubName": "%TASKHUB_NAME%"
+    }
+  }
+}

--- a/python/samples/azure_functions/06_multi_agent_orchestration_conditionals/local.settings.json.template
+++ b/python/samples/azure_functions/06_multi_agent_orchestration_conditionals/local.settings.json.template
@@ -1,0 +1,11 @@
+{
+  "IsEncrypted": false,
+  "Values": {
+    "FUNCTIONS_WORKER_RUNTIME": "python",
+    "AzureWebJobsStorage": "UseDevelopmentStorage=true",
+    "DURABLE_TASK_SCHEDULER_CONNECTION_STRING": "Endpoint=http://localhost:8080;TaskHub=default;Authentication=None",
+    "TASKHUB_NAME": "default",
+    "FOUNDRY_PROJECT_ENDPOINT": "<FOUNDRY_PROJECT_ENDPOINT>",
+    "FOUNDRY_MODEL": "<FOUNDRY_MODEL>"
+  }
+}

--- a/python/samples/azure_functions/06_multi_agent_orchestration_conditionals/requirements.txt
+++ b/python/samples/azure_functions/06_multi_agent_orchestration_conditionals/requirements.txt
@@ -1,0 +1,14 @@
+# Agent Framework packages
+# To use the deployed version, uncomment the lines below and comment out the local installation lines
+# agent-framework-foundry
+# agent-framework-azurefunctions
+
+# Local installation (for development and testing)
+# Each package must be listed explicitly because pip doesn't resolve uv workspace sources.
+# Without explicit entries, pip would fetch transitive dependencies from PyPI instead of local source.
+agent-framework-foundry>=1.10.1,<2  # Foundry support from PyPI (pulls in core)
+-e ../../../packages/durabletask  # Durable Task support - dependency of azurefunctions
+-e ../../../packages/azurefunctions  # Azure Functions integration - the main package for this sample
+
+# Azure authentication
+azure-identity

--- a/python/samples/azure_functions/07_single_agent_orchestration_hitl/README.md
+++ b/python/samples/azure_functions/07_single_agent_orchestration_hitl/README.md
@@ -1,0 +1,48 @@
+# Single-Agent Orchestration (HITL) – Python
+
+This sample demonstrates the human-in-the-loop (HITL) scenario.
+A single writer agent iterates on content until a human reviewer approves the
+output or a maximum number of attempts is reached.
+
+## Prerequisites
+
+Complete the common setup instructions in `../README.md` to prepare the virtual environment, install dependencies, and configure Foundry and storage settings.
+
+## What It Shows
+- Identical environment variable usage (`FOUNDRY_PROJECT_ENDPOINT`,
+  `FOUNDRY_MODEL`) and HTTP surface area (`/api/hitl/...`).
+- Durable orchestrations that pause for external events while maintaining
+  deterministic state (`context.wait_for_external_event` + timed cancellation).
+- Activity functions that encapsulate the out-of-band operations such as notifying
+a reviewer and publishing content.
+
+## Running the Sample
+Start the HITL orchestration:
+
+```bash
+curl -X POST http://localhost:7071/api/hitl/run \
+  -H "Content-Type: application/json" \
+  -d '{"topic": "Write a friendly release note"}'
+```
+
+Poll the returned `statusQueryGetUri` or call the status route directly:
+
+```bash
+curl http://localhost:7071/api/hitl/status/<instanceId>
+```
+
+Approve or reject the draft:
+
+```bash
+curl -X POST http://localhost:7071/api/hitl/approve/<instanceId> \
+  -H "Content-Type: application/json" \
+  -d '{"approved": true, "feedback": "Looks good"}'
+```
+
+> **Note:** Calls to the underlying agent run endpoint wait for responses by default. If you need an immediate HTTP 202 response, set the `x-ms-wait-for-response` header or include `"wait_for_response": false` in the request body.
+
+## Expected Responses
+- `POST /api/hitl/run` returns a 202 Accepted payload with the Durable Functions instance ID.
+- `POST /api/hitl/approve/{instanceId}` echoes the decision that the orchestration receives.
+- `GET /api/hitl/status/{instanceId}` reports `runtimeStatus`, custom status messages, and the final content when approved.
+The orchestration sets custom status messages, retries on rejection with reviewer feedback, and raises a timeout if human approval does not arrive.

--- a/python/samples/azure_functions/07_single_agent_orchestration_hitl/demo.http
+++ b/python/samples/azure_functions/07_single_agent_orchestration_hitl/demo.http
@@ -1,0 +1,44 @@
+### Start the HITL content generation orchestration with default timeout (72 hours)
+POST http://localhost:7071/api/hitl/run
+Content-Type: application/json
+
+{
+  "topic": "The Future of Artificial Intelligence",
+  "max_review_attempts": 3
+}
+
+
+### Start the HITL content generation orchestration with a short timeout (~4 seconds)
+POST http://localhost:7071/api/hitl/run
+Content-Type: application/json
+
+{
+  "topic": "The Future of Artificial Intelligence",
+  "max_review_attempts": 3,
+  "approval_timeout_hours": 0.001
+}
+
+
+### Replace INSTANCE_ID_GOES_HERE below with the value returned from the POST call
+@instanceId=<INSTANCE_ID_GOES_HERE>
+
+### Check the status of the orchestration
+GET http://localhost:7071/api/hitl/status/{{instanceId}}
+
+### Send human approval
+POST http://localhost:7071/api/hitl/approve/{{instanceId}}
+Content-Type: application/json
+
+{
+  "approved": true,
+  "feedback": "Great article! The content is well-structured and informative."
+}
+
+### Send human rejection with feedback
+POST http://localhost:7071/api/hitl/approve/{{instanceId}}
+Content-Type: application/json
+
+{
+  "approved": false,
+  "feedback": "The article needs more technical depth and better examples."
+}

--- a/python/samples/azure_functions/07_single_agent_orchestration_hitl/function_app.py
+++ b/python/samples/azure_functions/07_single_agent_orchestration_hitl/function_app.py
@@ -7,7 +7,8 @@ Components used in this sample:
 - AgentFunctionApp with Durable orchestration, HTTP triggers, and activity triggers.
 - External events that pause the workflow until a human decision arrives or times out.
 
-Prerequisites: configure `FOUNDRY_PROJECT_ENDPOINT`, `FOUNDRY_MODEL`, and sign in with Azure CLI before running `func start`."""
+Prerequisites: configure `FOUNDRY_PROJECT_ENDPOINT` and `FOUNDRY_MODEL`, then sign in
+with Azure CLI before running `func start`."""
 
 import json
 import logging
@@ -51,7 +52,8 @@ class HumanApproval(BaseModel):
 def _create_writer_agent() -> Any:
     instructions = (
         "You are a professional content writer who creates high-quality articles on various topics. "
-        "You write engaging, informative, and well-structured content that follows best practices for readability and accuracy. "
+        "You write engaging, informative, and well-structured content that follows best practices "
+        "for readability and accuracy. "
         "Return your response as JSON with 'title' and 'content' fields."
     )
 
@@ -142,7 +144,9 @@ def content_generation_hitl_orchestration(context: DurableOrchestrationContext) 
                 context.set_custom_status(
                     f"Content published successfully at {context.current_utc_datetime:%Y-%m-%dT%H:%M:%S}"
                 )
-                return {"content": content.content}
+                return {  # noqa: B901 - Durable orchestrators return their final output.
+                    "content": content.content
+                }
 
             context.set_custom_status("Content rejected by human reviewer. Incorporating feedback and regenerating...")
 
@@ -151,7 +155,8 @@ def content_generation_hitl_orchestration(context: DurableOrchestrationContext) 
                 break
 
             rewrite_prompt = (
-                "The content was rejected by a human reviewer. Please rewrite the article incorporating their feedback.\n\n"
+                "The content was rejected by a human reviewer. "
+                "Please rewrite the article incorporating their feedback.\n\n"
                 f"Human Feedback: {approval_payload.feedback or 'No feedback provided.'}"
             )
             rewritten_raw = yield writer.run(

--- a/python/samples/azure_functions/07_single_agent_orchestration_hitl/function_app.py
+++ b/python/samples/azure_functions/07_single_agent_orchestration_hitl/function_app.py
@@ -1,0 +1,402 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+"""Iterate on generated content with a human-in-the-loop Durable orchestration.
+
+Components used in this sample:
+- FoundryChatClient for a single writer agent that emits structured JSON.
+- AgentFunctionApp with Durable orchestration, HTTP triggers, and activity triggers.
+- External events that pause the workflow until a human decision arrives or times out.
+
+Prerequisites: configure `FOUNDRY_PROJECT_ENDPOINT`, `FOUNDRY_MODEL`, and sign in with Azure CLI before running `func start`."""
+
+import json
+import logging
+import os
+from collections.abc import Generator, Mapping
+from datetime import timedelta
+from typing import Any
+
+import azure.functions as func
+from agent_framework import Agent
+from agent_framework.foundry import FoundryChatClient
+from agent_framework_azurefunctions import AgentFunctionApp
+from azure.durable_functions import DurableOrchestrationClient, DurableOrchestrationContext
+from azure.identity.aio import AzureCliCredential
+from pydantic import BaseModel, ValidationError
+
+logger = logging.getLogger(__name__)
+
+# 1. Define orchestration constants used throughout the workflow.
+WRITER_AGENT_NAME = "WriterAgent"
+HUMAN_APPROVAL_EVENT = "HumanApproval"
+
+
+class ContentGenerationInput(BaseModel):
+    topic: str
+    max_review_attempts: int = 3
+    approval_timeout_hours: float = 72
+
+
+class GeneratedContent(BaseModel):
+    title: str
+    content: str
+
+
+class HumanApproval(BaseModel):
+    approved: bool
+    feedback: str = ""
+
+
+# 2. Create the writer agent that produces structured JSON responses.
+def _create_writer_agent() -> Any:
+    instructions = (
+        "You are a professional content writer who creates high-quality articles on various topics. "
+        "You write engaging, informative, and well-structured content that follows best practices for readability and accuracy. "
+        "Return your response as JSON with 'title' and 'content' fields."
+    )
+
+    _client = FoundryChatClient(
+        project_endpoint=os.environ["FOUNDRY_PROJECT_ENDPOINT"],
+        model=os.environ["FOUNDRY_MODEL"],
+        credential=AzureCliCredential(),
+    )
+    return Agent(
+        client=_client,
+        name=WRITER_AGENT_NAME,
+        instructions=instructions,
+    )
+
+
+app = AgentFunctionApp(agents=[_create_writer_agent()], enable_health_check=True)
+
+
+# 3. Activities encapsulate external work for review notifications and publishing.
+@app.activity_trigger(input_name="content")
+def notify_user_for_approval(content: dict) -> None:
+    model = GeneratedContent.model_validate(content)
+    logger.info("NOTIFICATION: Please review the following content for approval:")
+    logger.info("Title: %s", model.title or "(untitled)")
+    logger.info("Content: %s", model.content)
+    logger.info("Use the approval endpoint to approve or reject this content.")
+
+
+@app.activity_trigger(input_name="content")
+def publish_content(content: dict) -> None:
+    model = GeneratedContent.model_validate(content)
+    logger.info("PUBLISHING: Content has been published successfully:")
+    logger.info("Title: %s", model.title or "(untitled)")
+    logger.info("Content: %s", model.content)
+
+
+# 4. Orchestration loops until the human approves, times out, or attempts are exhausted.
+@app.orchestration_trigger(context_name="context")
+def content_generation_hitl_orchestration(context: DurableOrchestrationContext) -> Generator[Any, Any, dict[str, str]]:
+    payload_raw = context.get_input()
+    if not isinstance(payload_raw, Mapping):
+        raise ValueError("Content generation input is required")
+
+    try:
+        payload = ContentGenerationInput.model_validate(payload_raw)
+    except ValidationError as exc:
+        raise ValueError(f"Invalid content generation input: {exc}") from exc
+
+    writer = app.get_agent(context, WRITER_AGENT_NAME)
+    writer_session = writer.create_session()
+
+    context.set_custom_status(f"Starting content generation for topic: {payload.topic}")
+
+    initial_raw = yield writer.run(
+        messages=f"Write a short article about '{payload.topic}'.",
+        session=writer_session,
+        options={"response_format": GeneratedContent},
+    )
+
+    content = initial_raw.value
+
+    if content is None:
+        raise ValueError("Agent returned no content after extraction.")
+
+    attempt = 0
+    while attempt < payload.max_review_attempts:
+        attempt += 1
+        context.set_custom_status(
+            f"Requesting human feedback. Iteration #{attempt}. Timeout: {payload.approval_timeout_hours} hour(s)."
+        )
+
+        yield context.call_activity("notify_user_for_approval", content.model_dump())  # type: ignore[misc]
+
+        approval_task = context.wait_for_external_event(HUMAN_APPROVAL_EVENT)
+        timeout_task = context.create_timer(
+            context.current_utc_datetime + timedelta(hours=payload.approval_timeout_hours)
+        )
+
+        winner = yield context.task_any([approval_task, timeout_task])
+
+        if winner == approval_task:
+            timeout_task.cancel()  # type: ignore[attr-defined]  # ty: ignore[unresolved-attribute]
+            approval_payload = _parse_human_approval(approval_task.result)
+
+            if approval_payload.approved:
+                context.set_custom_status("Content approved by human reviewer. Publishing content...")
+                yield context.call_activity("publish_content", content.model_dump())  # type: ignore[misc]
+                context.set_custom_status(
+                    f"Content published successfully at {context.current_utc_datetime:%Y-%m-%dT%H:%M:%S}"
+                )
+                return {"content": content.content}
+
+            context.set_custom_status("Content rejected by human reviewer. Incorporating feedback and regenerating...")
+
+            # Check if we've exhausted attempts
+            if attempt >= payload.max_review_attempts:
+                break
+
+            rewrite_prompt = (
+                "The content was rejected by a human reviewer. Please rewrite the article incorporating their feedback.\n\n"
+                f"Human Feedback: {approval_payload.feedback or 'No feedback provided.'}"
+            )
+            rewritten_raw = yield writer.run(
+                messages=rewrite_prompt,
+                session=writer_session,
+                options={"response_format": GeneratedContent},
+            )
+
+            try:
+                content = rewritten_raw.value
+            except Exception as ex:
+                raise ValueError("Agent returned no content after rewrite.") from ex
+        else:
+            context.set_custom_status(
+                f"Human approval timed out after {payload.approval_timeout_hours} hour(s). Treating as rejection."
+            )
+            raise TimeoutError(f"Human approval timed out after {payload.approval_timeout_hours} hour(s).")
+
+    # If we exit the loop without returning, max attempts were exhausted
+    context.set_custom_status("Max review attempts exhausted.")
+    raise RuntimeError(f"Content could not be approved after {payload.max_review_attempts} iteration(s).")
+
+
+# 5. HTTP endpoint that starts the human-in-the-loop orchestration.
+@app.route(route="hitl/run", methods=["POST"])
+@app.durable_client_input(client_name="client")
+async def start_content_generation(
+    req: func.HttpRequest,
+    client: DurableOrchestrationClient,
+) -> func.HttpResponse:
+    try:
+        body = req.get_json()
+    except ValueError:
+        body = None
+
+    if not isinstance(body, Mapping):
+        return func.HttpResponse(
+            body=json.dumps({"error": "Request body must be valid JSON."}),
+            status_code=400,
+            mimetype="application/json",
+        )
+
+    try:
+        payload = ContentGenerationInput.model_validate(body)
+    except ValidationError as exc:
+        return func.HttpResponse(
+            body=json.dumps({"error": f"Invalid content generation input: {exc}"}),
+            status_code=400,
+            mimetype="application/json",
+        )
+
+    instance_id = await client.start_new(
+        orchestration_function_name="content_generation_hitl_orchestration",
+        client_input=payload.model_dump(),
+    )
+
+    status_url = _build_status_url(req.url, instance_id, route="hitl")
+
+    payload_json = {
+        "message": "HITL content generation orchestration started.",
+        "topic": payload.topic,
+        "instanceId": instance_id,
+        "statusQueryGetUri": status_url,
+    }
+
+    return func.HttpResponse(
+        body=json.dumps(payload_json),
+        status_code=202,
+        mimetype="application/json",
+    )
+
+
+# 6. Endpoint that delivers human approval or rejection back into the orchestration.
+@app.route(route="hitl/approve/{instanceId}", methods=["POST"])
+@app.durable_client_input(client_name="client")
+async def send_human_approval(
+    req: func.HttpRequest,
+    client: DurableOrchestrationClient,
+) -> func.HttpResponse:
+    instance_id = req.route_params.get("instanceId")
+    if not instance_id:
+        return func.HttpResponse(
+            body=json.dumps({"error": "Missing instanceId in route."}),
+            status_code=400,
+            mimetype="application/json",
+        )
+
+    try:
+        body = req.get_json()
+    except ValueError:
+        body = None
+
+    if not isinstance(body, Mapping):
+        return func.HttpResponse(
+            body=json.dumps({"error": "Approval response is required"}),
+            status_code=400,
+            mimetype="application/json",
+        )
+
+    try:
+        approval = HumanApproval.model_validate(body)
+    except ValidationError as exc:
+        return func.HttpResponse(
+            body=json.dumps({"error": f"Invalid approval payload: {exc}"}),
+            status_code=400,
+            mimetype="application/json",
+        )
+
+    await client.raise_event(instance_id, HUMAN_APPROVAL_EVENT, approval.model_dump())
+
+    payload_json = {
+        "message": "Human approval sent to orchestration.",
+        "instanceId": instance_id,
+        "approved": approval.approved,
+    }
+
+    return func.HttpResponse(
+        body=json.dumps(payload_json),
+        status_code=200,
+        mimetype="application/json",
+    )
+
+
+# 7. Endpoint that mirrors Durable Functions status plus custom workflow messaging.
+@app.route(route="hitl/status/{instanceId}", methods=["GET"])
+@app.durable_client_input(client_name="client")
+async def get_orchestration_status(
+    req: func.HttpRequest,
+    client: DurableOrchestrationClient,
+) -> func.HttpResponse:
+    instance_id = req.route_params.get("instanceId")
+    if not instance_id:
+        return func.HttpResponse(
+            body=json.dumps({"error": "Missing instanceId"}),
+            status_code=400,
+            mimetype="application/json",
+        )
+
+    status = await client.get_status(
+        instance_id,
+        show_history=False,
+        show_history_output=False,
+        show_input=True,
+    )
+
+    # Check if status is None or if the instance doesn't exist (runtime_status is None)
+    if getattr(status, "runtime_status", None) is None:
+        return func.HttpResponse(
+            body=json.dumps({"error": "Instance not found."}),
+            status_code=404,
+            mimetype="application/json",
+        )
+
+    response_data: dict[str, Any] = {
+        "instanceId": getattr(status, "instance_id", None),
+        "runtimeStatus": getattr(status.runtime_status, "name", None)
+        if getattr(status, "runtime_status", None)
+        else None,
+        "workflowStatus": getattr(status, "custom_status", None),
+    }
+
+    if getattr(status, "input_", None) is not None:
+        response_data["input"] = status.input_
+
+    if getattr(status, "output", None) is not None:
+        response_data["output"] = status.output
+
+    failure_details = getattr(status, "failure_details", None)
+    if failure_details is not None:
+        response_data["failureDetails"] = failure_details
+
+    return func.HttpResponse(
+        body=json.dumps(response_data),
+        status_code=200,
+        mimetype="application/json",
+    )
+
+
+# 8. Helper utilities keep parsing logic deterministic.
+def _build_status_url(request_url: str, instance_id: str, *, route: str) -> str:
+    base_url, _, _ = request_url.partition("/api/")
+    if not base_url:
+        base_url = request_url.rstrip("/")
+    return f"{base_url}/api/{route}/status/{instance_id}"
+
+
+def _parse_human_approval(raw: Any) -> HumanApproval:
+    if isinstance(raw, Mapping):
+        return HumanApproval.model_validate(raw)
+
+    if isinstance(raw, str):
+        stripped = raw.strip()
+        if not stripped:
+            return HumanApproval(approved=False, feedback="")
+        try:
+            parsed = json.loads(stripped)
+            if isinstance(parsed, Mapping):
+                return HumanApproval.model_validate(parsed)
+        except json.JSONDecodeError:
+            logger.debug(
+                "[HITL] Approval payload is not valid JSON; using string heuristics.",
+                exc_info=True,
+            )
+
+        affirmative = {"true", "yes", "approved", "y", "1"}
+        negative = {"false", "no", "rejected", "n", "0"}
+        lower = stripped.lower()
+        if lower in affirmative:
+            return HumanApproval(approved=True, feedback="")
+        if lower in negative:
+            return HumanApproval(approved=False, feedback="")
+        return HumanApproval(approved=False, feedback=stripped)
+
+    raise ValueError("Approval payload must be a JSON object or string.")
+
+
+"""
+Expected response from `POST /api/hitl/run`:
+
+HTTP/1.1 202 Accepted
+{
+    "message": "HITL content generation orchestration started.",
+    "topic": "Contoso launch",
+    "instanceId": "<durable-instance-id>",
+    "statusQueryGetUri": "http://localhost:7071/api/hitl/status/<durable-instance-id>"
+}
+
+Expected response after approving via `POST /api/hitl/approve/{instanceId}`:
+
+HTTP/1.1 200 OK
+{
+    "message": "Human approval sent to orchestration.",
+    "instanceId": "<durable-instance-id>",
+    "approved": true
+}
+
+Expected response from `GET /api/hitl/status/{instanceId}` once published:
+
+HTTP/1.1 200 OK
+{
+    "instanceId": "<durable-instance-id>",
+    "runtimeStatus": "Completed",
+    "workflowStatus": "Content published successfully at 2024-01-01T12:00:00",
+    "output": {
+        "content": "Thank you for joining the Contoso product launch..."
+    }
+}
+"""

--- a/python/samples/azure_functions/07_single_agent_orchestration_hitl/host.json
+++ b/python/samples/azure_functions/07_single_agent_orchestration_hitl/host.json
@@ -1,0 +1,12 @@
+{
+  "version": "2.0",
+  "extensionBundle": {
+    "id": "Microsoft.Azure.Functions.ExtensionBundle",
+    "version": "[4.*, 5.0.0)"
+  },
+  "extensions": {
+    "durableTask": {
+      "hubName": "%TASKHUB_NAME%"
+    }
+  }
+}

--- a/python/samples/azure_functions/07_single_agent_orchestration_hitl/local.settings.json.template
+++ b/python/samples/azure_functions/07_single_agent_orchestration_hitl/local.settings.json.template
@@ -1,0 +1,11 @@
+{
+  "IsEncrypted": false,
+  "Values": {
+    "FUNCTIONS_WORKER_RUNTIME": "python",
+    "AzureWebJobsStorage": "UseDevelopmentStorage=true",
+    "DURABLE_TASK_SCHEDULER_CONNECTION_STRING": "Endpoint=http://localhost:8080;TaskHub=default;Authentication=None",
+    "TASKHUB_NAME": "default",
+    "FOUNDRY_PROJECT_ENDPOINT": "<FOUNDRY_PROJECT_ENDPOINT>",
+    "FOUNDRY_MODEL": "<FOUNDRY_MODEL>"
+  }
+}

--- a/python/samples/azure_functions/07_single_agent_orchestration_hitl/requirements.txt
+++ b/python/samples/azure_functions/07_single_agent_orchestration_hitl/requirements.txt
@@ -1,0 +1,14 @@
+# Agent Framework packages
+# To use the deployed version, uncomment the lines below and comment out the local installation lines
+# agent-framework-foundry
+# agent-framework-azurefunctions
+
+# Local installation (for development and testing)
+# Each package must be listed explicitly because pip doesn't resolve uv workspace sources.
+# Without explicit entries, pip would fetch transitive dependencies from PyPI instead of local source.
+agent-framework-foundry>=1.10.1,<2  # Foundry support from PyPI (pulls in core)
+-e ../../../packages/durabletask  # Durable Task support - dependency of azurefunctions
+-e ../../../packages/azurefunctions  # Azure Functions integration - the main package for this sample
+
+# Azure authentication
+azure-identity

--- a/python/samples/azure_functions/08_mcp_server/README.md
+++ b/python/samples/azure_functions/08_mcp_server/README.md
@@ -94,7 +94,7 @@ Note: StockAdvisor does not have HTTP endpoints and is only accessible via MCP t
 **MCP Tool Responses** will be visible in:
 - The terminal where `func start` is running
 - Your MCP client interface
-- The DTS dashboard at `http://localhost:8080` (if using Durable Task Scheduler)
+- The DTS dashboard at `http://localhost:8082` (if using Durable Task Scheduler)
 
 ## Health Check
 

--- a/python/samples/azure_functions/08_mcp_server/README.md
+++ b/python/samples/azure_functions/08_mcp_server/README.md
@@ -1,0 +1,198 @@
+# Agent as MCP Tool Sample
+
+This sample demonstrates how to configure AI agents to be accessible as both HTTP endpoints and [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) tools, enabling flexible integration patterns for AI agent consumption.
+
+## Key Concepts Demonstrated
+
+- **Multi-trigger Agent Configuration**: Configure agents to support HTTP triggers, MCP tool triggers, or both
+- **Microsoft Agent Framework Integration**: Use the framework to define AI agents with specific roles and capabilities
+- **Flexible Agent Registration**: Register agents with customizable trigger configurations
+- **MCP Server Hosting**: Expose agents as MCP tools for consumption by MCP-compatible clients
+
+## Sample Architecture
+
+This sample creates three agents with different trigger configurations:
+
+| Agent | Role | HTTP Trigger | MCP Tool Trigger | Description |
+|-------|------|--------------|------------------|-------------|
+| **Joker** | Comedy specialist | ✅ Enabled | ❌ Disabled | Accessible only via HTTP requests |
+| **StockAdvisor** | Financial data | ❌ Disabled | ✅ Enabled | Accessible only as MCP tool |
+| **PlantAdvisor** | Indoor plant recommendations | ✅ Enabled | ✅ Enabled | Accessible via both HTTP and MCP |
+
+## Environment Setup
+
+See the [README.md](../README.md) file in the parent directory for complete setup instructions, including:
+
+- Prerequisites installation
+- Azure OpenAI configuration
+- Durable Task Scheduler setup
+- Storage emulator configuration
+
+## Configuration
+
+Update your `local.settings.json` with your Foundry project settings:
+
+```json
+{
+  "Values": {
+    "FOUNDRY_PROJECT_ENDPOINT": "https://your-project.services.ai.azure.com/api/projects/your-project",
+    "FOUNDRY_MODEL": "your-deployment-name"
+  }
+}
+```
+
+## Running the Sample
+
+1. **Start the Function App**:
+   ```bash
+   cd python/samples/azure_functions/08_mcp_server
+   func start
+   ```
+
+2. **Note the MCP Server Endpoint**: When the app starts, you'll see the MCP server endpoint in the terminal output. It will look like:
+   ```
+   MCP server endpoint:  http://localhost:7071/runtime/webhooks/mcp
+   ```
+
+## Testing MCP Tool Integration
+
+### Using MCP Inspector
+
+1. Install the [MCP Inspector](https://modelcontextprotocol.io/docs/tools/inspector)
+2. Connect using the MCP server endpoint from your terminal output
+3. Select **"Streamable HTTP"** as the transport method
+4. Test the available MCP tools:
+   - `StockAdvisor` - Available only as MCP tool
+   - `PlantAdvisor` - Available as both HTTP and MCP tool
+
+### Using Other MCP Clients
+
+Any MCP-compatible client can connect to the server endpoint and utilize the exposed agent tools. The agents will appear as callable tools within the MCP protocol.
+
+## Testing HTTP Endpoints
+
+For agents with HTTP triggers enabled (Joker and PlantAdvisor), you can test them using curl:
+
+```bash
+# Test Joker agent (HTTP only)
+curl -X POST http://localhost:7071/api/agents/Joker/run \
+  -H "Content-Type: application/json" \
+  -d '{"message": "Tell me a joke"}'
+
+# Test PlantAdvisor agent (HTTP and MCP)
+curl -X POST http://localhost:7071/api/agents/PlantAdvisor/run \
+  -H "Content-Type: application/json" \
+  -d '{"message": "Recommend an indoor plant"}'
+```
+
+Note: StockAdvisor does not have HTTP endpoints and is only accessible via MCP tool triggers.
+
+## Expected Output
+
+**HTTP Responses** will be returned directly to your HTTP client.
+
+**MCP Tool Responses** will be visible in:
+- The terminal where `func start` is running
+- Your MCP client interface
+- The DTS dashboard at `http://localhost:8080` (if using Durable Task Scheduler)
+
+## Health Check
+
+Check the health endpoint to see which agents have which triggers enabled:
+
+```bash
+curl http://localhost:7071/api/health
+```
+
+Expected response:
+
+```json
+{
+  "status": "healthy",
+  "agents": [
+    {
+      "name": "Joker",
+      "type": "Agent",
+      "http_endpoint_enabled": true,
+      "mcp_tool_enabled": false
+    },
+    {
+      "name": "StockAdvisor",
+      "type": "Agent",
+      "http_endpoint_enabled": false,
+      "mcp_tool_enabled": true
+    },
+    {
+      "name": "PlantAdvisor",
+      "type": "Agent",
+      "http_endpoint_enabled": true,
+      "mcp_tool_enabled": true
+    }
+  ],
+  "agent_count": 3
+}
+```
+
+## Code Structure
+
+The sample shows how to enable MCP tool triggers with flexible agent configuration:
+
+```python
+import os
+
+from agent_framework import Agent
+from agent_framework_azurefunctions import AgentFunctionApp
+from agent_framework.foundry import FoundryChatClient
+from azure.identity.aio import AzureCliCredential
+
+# Create Foundry chat client
+client = FoundryChatClient(
+    project_endpoint=os.environ["FOUNDRY_PROJECT_ENDPOINT"],
+    model=os.environ["FOUNDRY_MODEL"],
+    credential=AzureCliCredential(),
+)
+
+# Define agents with different roles
+joker_agent = Agent(
+    client=client,
+    name="Joker",
+    instructions="You are good at telling jokes.",
+)
+
+stock_agent = Agent(
+    client=client,
+    name="StockAdvisor",
+    instructions="Check stock prices.",
+)
+
+plant_agent = Agent(
+    client=client,
+    name="PlantAdvisor",
+    instructions="Recommend plants.",
+    description="Get plant recommendations.",
+)
+
+# Create the AgentFunctionApp
+app = AgentFunctionApp(enable_health_check=True)
+
+# Configure agents with different trigger combinations:
+# HTTP trigger only (default)
+app.add_agent(joker_agent)
+
+# MCP tool trigger only (HTTP disabled)
+app.add_agent(stock_agent, enable_http_endpoint=False, enable_mcp_tool_trigger=True)
+
+# Both HTTP and MCP tool triggers enabled
+app.add_agent(plant_agent, enable_http_endpoint=True, enable_mcp_tool_trigger=True)
+```
+
+This automatically creates the following endpoints based on agent configuration:
+- `POST /api/agents/{AgentName}/run` - HTTP endpoint (when `enable_http_endpoint=True`)
+- MCP tool triggers for agents with `enable_mcp_tool_trigger=True`
+- `GET /api/health` - Health check endpoint showing agent configurations
+
+## Learn More
+
+- [Model Context Protocol Documentation](https://modelcontextprotocol.io/)
+- [Microsoft Agent Framework Documentation](https://github.com/microsoft/agent-framework)
+- [Azure Functions Documentation](https://learn.microsoft.com/azure/azure-functions/)

--- a/python/samples/azure_functions/08_mcp_server/function_app.py
+++ b/python/samples/azure_functions/08_mcp_server/function_app.py
@@ -1,0 +1,79 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+"""Example showing how to configure AI agents with different trigger configurations.
+
+This sample demonstrates how to configure agents to be accessible as both HTTP endpoints
+and Model Context Protocol (MCP) tools, enabling flexible integration patterns for AI agent
+consumption.
+
+Key concepts demonstrated:
+- Multi-trigger Agent Configuration: Configure agents to support HTTP triggers, MCP tool triggers, or both
+- Microsoft Agent Framework Integration: Use the framework to define AI agents with specific roles
+- Flexible Agent Registration: Register agents with customizable trigger configurations
+
+This sample creates three agents with different trigger configurations:
+- Joker: HTTP trigger only (default)
+- StockAdvisor: MCP tool trigger only (HTTP disabled)
+- PlantAdvisor: Both HTTP and MCP tool triggers enabled
+
+Required environment variables:
+- FOUNDRY_PROJECT_ENDPOINT: Your Microsoft Foundry project endpoint
+- FOUNDRY_MODEL: Your Microsoft Foundry deployment name
+
+Authentication uses AzureCliCredential (Azure Identity).
+"""
+
+import os
+
+from agent_framework import Agent
+from agent_framework.foundry import FoundryChatClient
+from agent_framework_azurefunctions import AgentFunctionApp
+from azure.identity.aio import AzureCliCredential
+from dotenv import load_dotenv
+
+load_dotenv()
+
+# Create Foundry chat client
+# This uses AzureCliCredential for authentication (requires 'az login')
+client = FoundryChatClient(
+    project_endpoint=os.environ["FOUNDRY_PROJECT_ENDPOINT"],
+    model=os.environ["FOUNDRY_MODEL"],
+    credential=AzureCliCredential(),
+)
+
+# Define three AI agents with different roles
+# Agent 1: Joker - HTTP trigger only (default)
+agent1 = Agent(
+    client=client,
+    name="Joker",
+    instructions="You are good at telling jokes.",
+)
+
+# Agent 2: StockAdvisor - MCP tool trigger only
+agent2 = Agent(
+    client=client,
+    name="StockAdvisor",
+    instructions="Check stock prices.",
+)
+
+# Agent 3: PlantAdvisor - Both HTTP and MCP tool triggers
+agent3 = Agent(
+    client=client,
+    name="PlantAdvisor",
+    instructions="Recommend plants.",
+    description="Get plant recommendations.",
+)
+
+# Create the AgentFunctionApp with selective trigger configuration
+app = AgentFunctionApp(
+    enable_health_check=True,
+)
+
+# Agent 1: HTTP trigger only (default)
+app.add_agent(agent1)
+
+# Agent 2: Disable HTTP trigger, enable MCP tool trigger only
+app.add_agent(agent2, enable_http_endpoint=False, enable_mcp_tool_trigger=True)
+
+# Agent 3: Enable both HTTP and MCP tool triggers
+app.add_agent(agent3, enable_http_endpoint=True, enable_mcp_tool_trigger=True)

--- a/python/samples/azure_functions/08_mcp_server/host.json
+++ b/python/samples/azure_functions/08_mcp_server/host.json
@@ -1,0 +1,7 @@
+{
+  "version": "2.0",
+  "extensionBundle": {
+    "id": "Microsoft.Azure.Functions.ExtensionBundle",
+    "version": "[4.*, 5.0.0)"
+  }
+}

--- a/python/samples/azure_functions/08_mcp_server/local.settings.json.template
+++ b/python/samples/azure_functions/08_mcp_server/local.settings.json.template
@@ -1,0 +1,10 @@
+{
+  "IsEncrypted": false,
+  "Values": {
+    "FUNCTIONS_WORKER_RUNTIME": "python",
+    "AzureWebJobsStorage": "UseDevelopmentStorage=true",
+    "DURABLE_TASK_SCHEDULER_CONNECTION_STRING": "Endpoint=http://localhost:8080;TaskHub=default;Authentication=None",
+    "FOUNDRY_PROJECT_ENDPOINT": "<FOUNDRY_PROJECT_ENDPOINT>",
+    "FOUNDRY_MODEL": "<FOUNDRY_MODEL>"
+  }
+}

--- a/python/samples/azure_functions/08_mcp_server/requirements.txt
+++ b/python/samples/azure_functions/08_mcp_server/requirements.txt
@@ -1,0 +1,14 @@
+# Agent Framework packages
+# To use the deployed version, uncomment the lines below and comment out the local installation lines
+# agent-framework-foundry
+# agent-framework-azurefunctions
+
+# Local installation (for development and testing)
+# Each package must be listed explicitly because pip doesn't resolve uv workspace sources.
+# Without explicit entries, pip would fetch transitive dependencies from PyPI instead of local source.
+agent-framework-foundry>=1.10.1,<2  # Foundry support from PyPI (pulls in core)
+-e ../../../packages/durabletask  # Durable Task support - dependency of azurefunctions
+-e ../../../packages/azurefunctions  # Azure Functions integration - the main package for this sample
+
+# Azure authentication
+azure-identity

--- a/python/samples/azure_functions/08_mcp_server/requirements.txt
+++ b/python/samples/azure_functions/08_mcp_server/requirements.txt
@@ -12,3 +12,6 @@ agent-framework-foundry>=1.10.1,<2  # Foundry support from PyPI (pulls in core)
 
 # Azure authentication
 azure-identity
+
+# Local environment loading
+python-dotenv

--- a/python/samples/azure_functions/09_workflow_shared_state/.gitignore
+++ b/python/samples/azure_functions/09_workflow_shared_state/.gitignore
@@ -1,0 +1,18 @@
+# Local settings
+local.settings.json
+.env
+
+# Python
+__pycache__/
+*.py[cod]
+.venv/
+venv/
+
+# Azure Functions
+bin/
+obj/
+.python_packages/
+
+# IDE
+.vscode/
+.idea/

--- a/python/samples/azure_functions/09_workflow_shared_state/README.md
+++ b/python/samples/azure_functions/09_workflow_shared_state/README.md
@@ -1,0 +1,99 @@
+# Workflow with SharedState Sample
+
+This sample demonstrates running **Agent Framework workflows with SharedState** in Azure Durable Functions.
+
+## Overview
+
+This sample shows how to use `AgentFunctionApp` to execute a `WorkflowBuilder` workflow that uses SharedState to pass data between executors. SharedState is a local dictionary maintained by the orchestration that allows executors to share data across workflow steps.
+
+## What This Sample Demonstrates
+
+1. **Workflow Execution** - Running `WorkflowBuilder` workflows in Azure Durable Functions
+2. **State APIs** - Using `ctx.set_state()` and `ctx.get_state()` to share data
+3. **Conditional Routing** - Routing messages based on spam detection results
+4. **Agent + Executor Composition** - Combining AI agents with non-AI function executors
+
+## Workflow Architecture
+
+```
+store_email → spam_detector (agent) → to_detection_result → [branch]:
+    ├── If spam: handle_spam → yield "Email marked as spam: {reason}"
+    └── If not spam: submit_to_email_assistant → email_assistant (agent) → finalize_and_send → yield "Email sent: {response}"
+```
+
+### SharedState Usage by Executor
+
+| Executor | SharedState Operations |
+|----------|----------------------|
+| `store_email` | `set_state("email:{id}", email)`, `set_state("current_email_id", id)` |
+| `to_detection_result` | `get_state("current_email_id")` |
+| `submit_to_email_assistant` | `get_state("email:{id}")` |
+
+SharedState allows executors to pass large payloads (like email content) by reference rather than through message routing.
+
+## Prerequisites
+
+1. **Azure OpenAI** - Endpoint and deployment configured
+2. **Azurite** - For local storage emulation
+
+## Setup
+
+1. Copy `local.settings.json.sample` to `local.settings.json` and configure:
+   ```json
+   {
+     "Values": {
+       "FOUNDRY_PROJECT_ENDPOINT": "https://your-project.services.ai.azure.com/api/projects/your-project",
+       "FOUNDRY_MODEL": "gpt-4o"
+     }
+   }
+   ```
+
+2. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+3. Start Azurite:
+   ```bash
+   azurite --silent
+   ```
+
+4. Run the function app:
+   ```bash
+   func start
+   ```
+
+## Testing
+
+Use the `demo.http` file with REST Client extension or curl:
+
+### Test Spam Email
+```bash
+curl -X POST http://localhost:7071/api/workflow/email_triage_shared_state/run \
+  -H "Content-Type: application/json" \
+  -d '"URGENT! You have won $1,000,000! Click here to claim!"'
+```
+
+### Test Legitimate Email
+```bash
+curl -X POST http://localhost:7071/api/workflow/email_triage_shared_state/run \
+  -H "Content-Type: application/json" \
+  -d '"Hi team, reminder about our meeting tomorrow at 10 AM."'
+```
+
+## Expected Output
+
+**Spam email:**
+```
+Email marked as spam: This email exhibits spam characteristics including urgent language, unrealistic claims of monetary winnings, and requests to click suspicious links.
+```
+
+**Legitimate email:**
+```
+Email sent: Hi, Thank you for the reminder about the sprint planning meeting tomorrow at 10 AM. I will review the agenda and come prepared with my updates. See you then!
+```
+
+## Related Samples
+
+- `10_workflow_no_shared_state` - Workflow execution without SharedState usage
+- `06_multi_agent_orchestration_conditionals` - Manual Durable Functions orchestration with agents

--- a/python/samples/azure_functions/09_workflow_shared_state/demo.http
+++ b/python/samples/azure_functions/09_workflow_shared_state/demo.http
@@ -1,0 +1,31 @@
+@endpoint = http://localhost:7071
+
+### Start the workflow with a spam email
+POST {{endpoint}}/api/workflow/email_triage_shared_state/run
+Content-Type: application/json
+
+"URGENT! You have won $1,000,000! Click here to claim your prize now before it expires!"
+
+### Start the workflow with a legitimate email
+POST {{endpoint}}/api/workflow/email_triage_shared_state/run
+Content-Type: application/json
+
+"Hi team, just a reminder about the sprint planning meeting tomorrow at 10 AM. Please review the agenda items in Jira before the call."
+
+### Start the workflow with another legitimate email
+POST {{endpoint}}/api/workflow/email_triage_shared_state/run
+Content-Type: application/json
+
+"Hello, I wanted to follow up on our conversation from last week regarding the project timeline. Could we schedule a brief call this afternoon to discuss the next steps?"
+
+### Start the workflow with a phishing attempt
+POST {{endpoint}}/api/workflow/email_triage_shared_state/run
+Content-Type: application/json
+
+"Dear Customer, Your account has been compromised! Click this link immediately to secure your account: http://totallylegit.suspicious.com/secure"
+
+### Check workflow status (replace {instanceId} with actual instance ID from response)
+GET {{endpoint}}/runtime/webhooks/durabletask/instances/{instanceId}
+
+### Purge all orchestration instances (use for cleanup)
+POST {{endpoint}}/runtime/webhooks/durabletask/instances/purge?createdTimeFrom=2020-01-01T00:00:00Z&createdTimeTo=2030-12-31T23:59:59Z

--- a/python/samples/azure_functions/09_workflow_shared_state/function_app.py
+++ b/python/samples/azure_functions/09_workflow_shared_state/function_app.py
@@ -1,0 +1,288 @@
+# Copyright (c) Microsoft. All rights reserved.
+"""
+Sample: Shared state with agents and conditional routing.
+
+Store an email once by id, classify it with a detector agent, then either draft a reply with an assistant
+agent or finish with a spam notice. Stream events as the workflow runs.
+
+Purpose:
+Show how to:
+- Use shared state to decouple large payloads from messages and pass around lightweight references.
+- Enforce structured agent outputs with Pydantic models via response_format for robust parsing.
+- Route using conditional edges based on a typed intermediate DetectionResult.
+- Compose agent backed executors with function style executors and yield the final output when the workflow completes.
+
+Prerequisites:
+- Configure `FOUNDRY_PROJECT_ENDPOINT` and `FOUNDRY_MODEL` for FoundryChatClient.
+- Authentication uses `AzureCliCredential`; run `az login` before executing the sample.
+- Familiarity with WorkflowBuilder, executors, conditional edges, and streaming runs.
+"""
+
+import logging
+import os
+from dataclasses import dataclass
+from typing import Any
+from uuid import uuid4
+
+from agent_framework import (
+    Agent,
+    AgentExecutorRequest,
+    AgentExecutorResponse,
+    Message,
+    Workflow,
+    WorkflowBuilder,
+    WorkflowContext,
+    executor,
+)
+from agent_framework.foundry import FoundryChatClient
+from agent_framework.openai import OpenAIChatOptions
+from agent_framework_azurefunctions import AgentFunctionApp
+from azure.identity.aio import AzureCliCredential
+from pydantic import BaseModel, ValidationError
+from typing_extensions import Never
+
+logger = logging.getLogger(__name__)
+
+# Environment variable names
+FOUNDRY_PROJECT_ENDPOINT_ENV = "FOUNDRY_PROJECT_ENDPOINT"
+AZURE_OPENAI_DEPLOYMENT_ENV = "FOUNDRY_MODEL"
+
+EMAIL_STATE_PREFIX = "email:"
+CURRENT_EMAIL_ID_KEY = "current_email_id"
+
+
+class DetectionResultAgent(BaseModel):
+    """Structured output returned by the spam detection agent."""
+
+    is_spam: bool
+    reason: str
+
+
+class EmailResponse(BaseModel):
+    """Structured output returned by the email assistant agent."""
+
+    response: str
+
+
+@dataclass
+class DetectionResult:
+    """Internal detection result enriched with the shared state email_id for later lookups."""
+
+    is_spam: bool
+    reason: str
+    email_id: str
+
+
+@dataclass
+class Email:
+    """In memory record stored in shared state to avoid re-sending large bodies on edges."""
+
+    email_id: str
+    email_content: str
+
+
+def get_condition(expected_result: bool):
+    """Create a condition predicate for DetectionResult.is_spam.
+
+    Contract:
+    - If the message is not a DetectionResult, allow it to pass to avoid accidental dead ends.
+    - Otherwise, return True only when is_spam matches expected_result.
+    """
+
+    def condition(message: Any) -> bool:
+        if not isinstance(message, DetectionResult):
+            return True
+        return message.is_spam == expected_result
+
+    return condition
+
+
+@executor(id="store_email")
+async def store_email(email_text: str, ctx: WorkflowContext[AgentExecutorRequest]) -> None:
+    """Persist the raw email content in shared state and trigger spam detection.
+
+    Responsibilities:
+    - Generate a unique email_id (UUID) for downstream retrieval.
+    - Store the Email object under a namespaced key and set the current id pointer.
+    - Emit an AgentExecutorRequest asking the detector to respond.
+    """
+    new_email = Email(email_id=str(uuid4()), email_content=email_text)
+    ctx.set_state(f"{EMAIL_STATE_PREFIX}{new_email.email_id}", new_email)
+    ctx.set_state(CURRENT_EMAIL_ID_KEY, new_email.email_id)
+
+    await ctx.send_message(
+        AgentExecutorRequest(messages=[Message(role="user", contents=[new_email.email_content])], should_respond=True)
+    )
+
+
+@executor(id="to_detection_result")
+async def to_detection_result(response: AgentExecutorResponse, ctx: WorkflowContext[DetectionResult]) -> None:
+    """Parse spam detection JSON into a structured model and enrich with email_id.
+
+    Steps:
+    1) Validate the agent's JSON output into DetectionResultAgent.
+    2) Retrieve the current email_id from shared state.
+    3) Send a typed DetectionResult for conditional routing.
+    """
+    try:
+        parsed = DetectionResultAgent.model_validate_json(response.agent_response.text)
+    except ValidationError:
+        # Fallback for empty or invalid response (e.g. due to content filtering)
+        parsed = DetectionResultAgent(is_spam=True, reason="Agent execution failed or yielded invalid JSON.")
+
+    email_id: str = ctx.get_state(CURRENT_EMAIL_ID_KEY)
+    await ctx.send_message(DetectionResult(is_spam=parsed.is_spam, reason=parsed.reason, email_id=email_id))
+
+
+@executor(id="submit_to_email_assistant")
+async def submit_to_email_assistant(detection: DetectionResult, ctx: WorkflowContext[AgentExecutorRequest]) -> None:
+    """Forward non spam email content to the drafting agent.
+
+    Guard:
+    - This path should only receive non spam. Raise if misrouted.
+    """
+    if detection.is_spam:
+        raise RuntimeError("This executor should only handle non-spam messages.")
+
+    # Load the original content by id from shared state and forward it to the assistant.
+    email: Email = ctx.get_state(f"{EMAIL_STATE_PREFIX}{detection.email_id}")
+    await ctx.send_message(
+        AgentExecutorRequest(messages=[Message(role="user", contents=[email.email_content])], should_respond=True)
+    )
+
+
+@executor(id="finalize_and_send")
+async def finalize_and_send(response: AgentExecutorResponse, ctx: WorkflowContext[Never, str]) -> None:
+    """Validate the drafted reply and yield the final output."""
+    parsed = EmailResponse.model_validate_json(response.agent_response.text)
+    await ctx.yield_output(f"Email sent: {parsed.response}")
+
+
+@executor(id="handle_spam")
+async def handle_spam(detection: DetectionResult, ctx: WorkflowContext[Never, str]) -> None:
+    """Yield output describing why the email was marked as spam."""
+    if detection.is_spam:
+        await ctx.yield_output(f"Email marked as spam: {detection.reason}")
+    else:
+        raise RuntimeError("This executor should only handle spam messages.")
+
+
+# ============================================================================
+# Workflow Creation
+# ============================================================================
+
+
+def _build_client_kwargs() -> dict[str, Any]:
+    """Build Foundry chat client configuration from environment variables."""
+    project_endpoint = os.getenv(FOUNDRY_PROJECT_ENDPOINT_ENV)
+    if not project_endpoint:
+        raise RuntimeError(f"{FOUNDRY_PROJECT_ENDPOINT_ENV} environment variable is required.")
+
+    model = os.getenv(AZURE_OPENAI_DEPLOYMENT_ENV)
+    if not model:
+        raise RuntimeError(f"{AZURE_OPENAI_DEPLOYMENT_ENV} environment variable is required.")
+
+    return {
+        "project_endpoint": project_endpoint,
+        "model": model,
+        "credential": AzureCliCredential(),
+    }
+
+
+def _create_workflow() -> Workflow:
+    """Create the email classification workflow with conditional routing."""
+    client_kwargs = _build_client_kwargs()
+    chat_client = FoundryChatClient(**client_kwargs)
+
+    spam_detection_agent = Agent(
+        client=chat_client,
+        instructions=(
+            "You are a spam detection assistant that identifies spam emails. "
+            "Always return JSON with fields is_spam (bool) and reason (string)."
+        ),
+        default_options=OpenAIChatOptions[Any](response_format=DetectionResultAgent),
+        name="spam_detection_agent",
+    )
+
+    email_assistant_agent = Agent(
+        client=chat_client,
+        instructions=(
+            "You are an email assistant that helps users draft responses to emails with professionalism. "
+            "Return JSON with a single field 'response' containing the drafted reply."
+        ),
+        default_options=OpenAIChatOptions[Any](response_format=EmailResponse),
+        name="email_assistant_agent",
+    )
+
+    # Build the workflow graph with conditional edges.
+    # Flow:
+    #   store_email -> spam_detection_agent -> to_detection_result -> branch:
+    #     False -> submit_to_email_assistant -> email_assistant_agent -> finalize_and_send
+    #     True  -> handle_spam
+    return (
+        WorkflowBuilder(name="email_triage_shared_state", start_executor=store_email)
+        .add_edge(store_email, spam_detection_agent)
+        .add_edge(spam_detection_agent, to_detection_result)
+        .add_edge(to_detection_result, submit_to_email_assistant, condition=get_condition(False))
+        .add_edge(to_detection_result, handle_spam, condition=get_condition(True))
+        .add_edge(submit_to_email_assistant, email_assistant_agent)
+        .add_edge(email_assistant_agent, finalize_and_send)
+        .build()
+    )
+
+
+# ============================================================================
+# Application Entry Point
+# ============================================================================
+
+
+def launch(durable: bool = True) -> AgentFunctionApp | None:
+    """Launch the function app or DevUI.
+
+    Args:
+        durable: If True, returns AgentFunctionApp for Azure Functions.
+                 If False, launches DevUI for local MAF development.
+    """
+    if durable:
+        # Azure Functions mode with Durable Functions
+        # SharedState is enabled by default, which this sample requires for storing emails
+        workflow = _create_workflow()
+        return AgentFunctionApp(workflow=workflow, enable_health_check=True)
+    # Pure MAF mode with DevUI for local development
+    from pathlib import Path
+
+    from agent_framework.devui import serve
+    from dotenv import load_dotenv
+
+    env_path = Path(__file__).parent / ".env"
+    load_dotenv(dotenv_path=env_path)
+
+    logger.info("Starting Workflow Shared State Sample in MAF mode")
+    logger.info("Available at: http://localhost:8096")
+    logger.info("\nThis workflow demonstrates:")
+    logger.info("- Shared state to decouple large payloads from messages")
+    logger.info("- Structured agent outputs with Pydantic models")
+    logger.info("- Conditional routing based on detection results")
+    logger.info("\nFlow: store_email -> spam_detection -> branch (spam/not spam)")
+
+    workflow = _create_workflow()
+    serve(entities=[workflow], port=8096, auto_open=True)
+
+    return None
+
+
+# Default: Azure Functions mode
+# Run with `python function_app.py --maf` for pure MAF mode with DevUI
+app = launch(durable=True)
+
+
+if __name__ == "__main__":
+    import sys
+
+    if "--maf" in sys.argv:
+        # Run in pure MAF mode with DevUI
+        launch(durable=False)
+    else:
+        print("Usage: python function_app.py --maf")
+        print("  --maf    Run in pure MAF mode with DevUI (http://localhost:8096)")
+        print("\nFor Azure Functions mode, use: func start")

--- a/python/samples/azure_functions/09_workflow_shared_state/function_app.py
+++ b/python/samples/azure_functions/09_workflow_shared_state/function_app.py
@@ -45,7 +45,7 @@ logger = logging.getLogger(__name__)
 
 # Environment variable names
 FOUNDRY_PROJECT_ENDPOINT_ENV = "FOUNDRY_PROJECT_ENDPOINT"
-AZURE_OPENAI_DEPLOYMENT_ENV = "FOUNDRY_MODEL"
+FOUNDRY_MODEL_ENV = "FOUNDRY_MODEL"
 
 EMAIL_STATE_PREFIX = "email:"
 CURRENT_EMAIL_ID_KEY = "current_email_id"
@@ -178,9 +178,9 @@ def _build_client_kwargs() -> dict[str, Any]:
     if not project_endpoint:
         raise RuntimeError(f"{FOUNDRY_PROJECT_ENDPOINT_ENV} environment variable is required.")
 
-    model = os.getenv(AZURE_OPENAI_DEPLOYMENT_ENV)
+    model = os.getenv(FOUNDRY_MODEL_ENV)
     if not model:
-        raise RuntimeError(f"{AZURE_OPENAI_DEPLOYMENT_ENV} environment variable is required.")
+        raise RuntimeError(f"{FOUNDRY_MODEL_ENV} environment variable is required.")
 
     return {
         "project_endpoint": project_endpoint,

--- a/python/samples/azure_functions/09_workflow_shared_state/host.json
+++ b/python/samples/azure_functions/09_workflow_shared_state/host.json
@@ -1,0 +1,12 @@
+{
+  "version": "2.0",
+  "extensionBundle": {
+    "id": "Microsoft.Azure.Functions.ExtensionBundle",
+    "version": "[4.*, 5.0.0)"
+  },
+  "extensions": {
+    "durableTask": {
+      "hubName": "%TASKHUB_NAME%"
+    }
+  }
+}

--- a/python/samples/azure_functions/09_workflow_shared_state/local.settings.json.sample
+++ b/python/samples/azure_functions/09_workflow_shared_state/local.settings.json.sample
@@ -1,0 +1,11 @@
+{
+  "IsEncrypted": false,
+  "Values": {
+    "AzureWebJobsStorage": "UseDevelopmentStorage=true",
+    "DURABLE_TASK_SCHEDULER_CONNECTION_STRING": "Endpoint=http://localhost:8080;TaskHub=default;Authentication=None",
+    "TASKHUB_NAME": "default",
+    "FUNCTIONS_WORKER_RUNTIME": "python",
+    "FOUNDRY_PROJECT_ENDPOINT": "<FOUNDRY_PROJECT_ENDPOINT>",
+    "FOUNDRY_MODEL": "<FOUNDRY_MODEL>"
+  }
+}

--- a/python/samples/azure_functions/09_workflow_shared_state/requirements.txt
+++ b/python/samples/azure_functions/09_workflow_shared_state/requirements.txt
@@ -1,0 +1,14 @@
+# Agent Framework packages
+# To use the deployed version, uncomment the lines below and comment out the local installation lines
+# agent-framework-foundry
+# agent-framework-azurefunctions
+
+# Local installation (for development and testing)
+# Each package must be listed explicitly because pip doesn't resolve uv workspace sources.
+# Without explicit entries, pip would fetch transitive dependencies from PyPI instead of local source.
+agent-framework-foundry>=1.10.1,<2  # Foundry support from PyPI (pulls in core)
+-e ../../../packages/durabletask  # Durable Task support - dependency of azurefunctions
+-e ../../../packages/azurefunctions  # Azure Functions integration - the main package for this sample
+
+# Azure authentication
+azure-identity

--- a/python/samples/azure_functions/09_workflow_shared_state/requirements.txt
+++ b/python/samples/azure_functions/09_workflow_shared_state/requirements.txt
@@ -12,3 +12,6 @@ agent-framework-foundry>=1.10.1,<2  # Foundry support from PyPI (pulls in core)
 
 # Azure authentication
 azure-identity
+
+# Local environment loading
+python-dotenv

--- a/python/samples/azure_functions/10_workflow_no_shared_state/.env.sample
+++ b/python/samples/azure_functions/10_workflow_no_shared_state/.env.sample
@@ -1,0 +1,3 @@
+# Foundry Configuration
+FOUNDRY_PROJECT_ENDPOINT=https://your-project.services.ai.azure.com/api/projects/your-project
+FOUNDRY_MODEL=<your-deployment-name>

--- a/python/samples/azure_functions/10_workflow_no_shared_state/.gitignore
+++ b/python/samples/azure_functions/10_workflow_no_shared_state/.gitignore
@@ -1,0 +1,2 @@
+.env
+local.settings.json

--- a/python/samples/azure_functions/10_workflow_no_shared_state/README.md
+++ b/python/samples/azure_functions/10_workflow_no_shared_state/README.md
@@ -1,0 +1,159 @@
+# Workflow Execution Sample
+
+This sample demonstrates running **Agent Framework workflows** in Azure Durable Functions without using SharedState.
+
+## Overview
+
+This sample shows how to use `AgentFunctionApp` with a `WorkflowBuilder` workflow. The workflow is passed directly to `AgentFunctionApp`, which orchestrates execution using Durable Functions:
+
+```python
+workflow = _create_workflow()  # Build the workflow graph
+app = AgentFunctionApp(workflow=workflow)
+```
+
+This approach provides durable, fault-tolerant workflow execution with minimal code.
+
+## What This Sample Demonstrates
+
+1. **Workflow Registration** - Pass a `Workflow` directly to `AgentFunctionApp`
+2. **Durable Execution** - Workflow executes with Durable Functions durability and scalability
+3. **Conditional Routing** - Route messages based on spam detection (is_spam → spam handler, not spam → email assistant)
+4. **Agent + Executor Composition** - Combine AI agents with non-AI executor classes
+
+## Workflow Architecture
+
+```
+SpamDetectionAgent → [branch based on is_spam]:
+    ├── If spam: SpamHandlerExecutor → yield "Email marked as spam: {reason}"
+    └── If not spam: EmailAssistantAgent → EmailSenderExecutor → yield "Email sent: {response}"
+```
+
+### Components
+
+| Component | Type | Description |
+|-----------|------|-------------|
+| `SpamDetectionAgent` | AI Agent | Analyzes emails for spam indicators |
+| `EmailAssistantAgent` | AI Agent | Drafts professional email responses |
+| `SpamHandlerExecutor` | Executor | Handles spam emails (non-AI) |
+| `EmailSenderExecutor` | Executor | Sends email responses (non-AI) |
+
+## Prerequisites
+
+1. **Azure OpenAI** - Endpoint and deployment configured
+2. **Azurite** - For local storage emulation
+
+## Setup
+
+1. Copy configuration files:
+   ```bash
+   cp local.settings.json.sample local.settings.json
+   ```
+
+2. Configure `local.settings.json`:
+
+3. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+4. Start Azurite:
+   ```bash
+   azurite --silent
+   ```
+
+5. Run the function app:
+   ```bash
+   func start
+   ```
+
+## Testing
+
+Use the `demo.http` file with REST Client extension or curl:
+
+### Test Spam Email
+```bash
+curl -X POST http://localhost:7071/api/workflow/email_triage/run \
+  -H "Content-Type: application/json" \
+  -d '{"email_id": "test-001", "email_content": "URGENT! You have won $1,000,000! Click here!"}'
+```
+
+### Test Legitimate Email
+```bash
+curl -X POST http://localhost:7071/api/workflow/email_triage/run \
+  -H "Content-Type: application/json" \
+  -d '{"email_id": "test-002", "email_content": "Hi team, reminder about our meeting tomorrow at 10 AM."}'
+```
+
+### Check Status
+```bash
+curl http://localhost:7071/api/workflow/email_triage/status/{instanceId}
+```
+
+## Expected Output
+
+**Spam email:**
+```
+Email marked as spam: This email exhibits spam characteristics including urgent language, unrealistic claims of monetary winnings, and requests to click suspicious links.
+```
+
+**Legitimate email:**
+```
+Email sent: Hi, Thank you for the reminder about the sprint planning meeting tomorrow at 10 AM. I will be there.
+```
+
+## Code Highlights
+
+### Creating the Workflow
+
+```python
+workflow = (
+    WorkflowBuilder()
+    .set_start_executor(spam_agent)
+    .add_switch_case_edge_group(
+        spam_agent,
+        [
+            Case(condition=is_spam_detected, target=spam_handler),
+            Default(target=email_agent),
+        ],
+    )
+    .add_edge(email_agent, email_sender)
+    .build()
+)
+```
+
+### Registering with AgentFunctionApp
+
+```python
+app = AgentFunctionApp(workflow=workflow, enable_health_check=True)
+```
+
+### Executor Classes
+
+```python
+class SpamHandlerExecutor(Executor):
+    @handler
+    async def handle_spam_result(
+        self,
+        agent_response: AgentExecutorResponse,
+        ctx: WorkflowContext[Never, str],
+    ) -> None:
+        spam_result = SpamDetectionResult.model_validate_json(agent_response.agent_run_response.text)
+        await ctx.yield_output(f"Email marked as spam: {spam_result.reason}")
+```
+
+## Standalone Mode (DevUI)
+
+This sample also supports running standalone for local development:
+
+```python
+# Change launch(durable=True) to launch(durable=False) in function_app.py
+# Then run:
+python function_app.py
+```
+
+This starts the DevUI at `http://localhost:8094` for interactive testing.
+
+## Related Samples
+
+- `09_workflow_shared_state` - Workflow with SharedState for passing data between executors
+- `06_multi_agent_orchestration_conditionals` - Manual Durable Functions orchestration with agents

--- a/python/samples/azure_functions/10_workflow_no_shared_state/README.md
+++ b/python/samples/azure_functions/10_workflow_no_shared_state/README.md
@@ -50,6 +50,8 @@ SpamDetectionAgent → [branch based on is_spam]:
    ```
 
 2. Configure `local.settings.json`:
+   - Set `FOUNDRY_PROJECT_ENDPOINT` to your Microsoft Foundry project endpoint.
+   - Set `FOUNDRY_MODEL` to your deployed model name.
 
 3. Install dependencies:
    ```bash

--- a/python/samples/azure_functions/10_workflow_no_shared_state/README.md
+++ b/python/samples/azure_functions/10_workflow_no_shared_state/README.md
@@ -137,7 +137,7 @@ class SpamHandlerExecutor(Executor):
         agent_response: AgentExecutorResponse,
         ctx: WorkflowContext[Never, str],
     ) -> None:
-        spam_result = SpamDetectionResult.model_validate_json(agent_response.agent_run_response.text)
+        spam_result = SpamDetectionResult.model_validate_json(agent_response.agent_response.text)
         await ctx.yield_output(f"Email marked as spam: {spam_result.reason}")
 ```
 
@@ -145,10 +145,9 @@ class SpamHandlerExecutor(Executor):
 
 This sample also supports running standalone for local development:
 
-```python
-# Change launch(durable=True) to launch(durable=False) in function_app.py
-# Then run:
-python function_app.py
+```bash
+cp .env.sample .env
+python function_app.py --maf
 ```
 
 This starts the DevUI at `http://localhost:8094` for interactive testing.

--- a/python/samples/azure_functions/10_workflow_no_shared_state/demo.http
+++ b/python/samples/azure_functions/10_workflow_no_shared_state/demo.http
@@ -1,0 +1,32 @@
+### Start Workflow Orchestration - Spam Email
+POST http://localhost:7071/api/workflow/email_triage/run
+Content-Type: application/json
+
+{
+  "email_id": "email-001",
+  "email_content": "URGENT! You've won $1,000,000! Click here immediately to claim your prize! Limited time offer - act now!"
+}
+
+###
+
+### Start Workflow Orchestration - Legitimate Email
+POST http://localhost:7071/api/workflow/email_triage/run
+Content-Type: application/json
+
+{
+  "email_id": "email-002",
+  "email_content": "Hi team, just a reminder about our sprint planning meeting tomorrow at 10 AM. Please review the agenda in Jira."
+}
+
+###
+
+### Get Workflow Status
+# Replace {instanceId} with the actual instance ID from the start response
+GET http://localhost:7071/api/workflow/email_triage/status/{instanceId}
+
+###
+
+### Health Check
+GET http://localhost:7071/api/health
+
+###

--- a/python/samples/azure_functions/10_workflow_no_shared_state/function_app.py
+++ b/python/samples/azure_functions/10_workflow_no_shared_state/function_app.py
@@ -1,0 +1,246 @@
+# Copyright (c) Microsoft. All rights reserved.
+"""Workflow Execution within Durable Functions Orchestrator.
+
+This sample demonstrates running agent framework WorkflowBuilder workflows inside
+a Durable Functions orchestrator by manually traversing the workflow graph and
+delegating execution to Durable Entities (for agents) and Activities (for other logic).
+
+Key architectural points:
+- AgentFunctionApp registers agents as DurableAIAgents.
+- WorkflowBuilder uses `DurableAgentDefinition` (a placeholder) to define the graph.
+- The orchestrator (`workflow_orchestration`) iterates through the workflow graph.
+- When an agent node is encountered, it calls the corresponding `DurableAIAgent` entity.
+- When a standard executor node is encountered, it calls an Activity (`ExecuteExecutor`).
+
+This approach allows using the rich structure of `WorkflowBuilder` while leveraging
+the statefulness and durability of `DurableAIAgent`s.
+
+Prerequisites:
+- Configure `FOUNDRY_PROJECT_ENDPOINT` and `FOUNDRY_MODEL`
+- Sign in with Azure CLI (`az login`) for `AzureCliCredential`
+- Ensure Azurite and the Durable Task Scheduler emulator are running
+"""
+
+import logging
+import os
+from pathlib import Path
+from typing import Any
+
+from agent_framework import (
+    Agent,
+    AgentExecutorResponse,
+    Case,
+    Default,
+    Executor,
+    Workflow,
+    WorkflowBuilder,
+    WorkflowContext,
+    handler,
+)
+from agent_framework.foundry import FoundryChatClient
+from agent_framework.openai import OpenAIChatOptions
+from agent_framework_azurefunctions import AgentFunctionApp
+from azure.identity.aio import AzureCliCredential
+from pydantic import BaseModel, ValidationError
+from typing_extensions import Never
+
+logger = logging.getLogger(__name__)
+
+FOUNDRY_PROJECT_ENDPOINT_ENV = "FOUNDRY_PROJECT_ENDPOINT"
+AZURE_OPENAI_DEPLOYMENT_ENV = "FOUNDRY_MODEL"
+SPAM_AGENT_NAME = "SpamDetectionAgent"
+EMAIL_AGENT_NAME = "EmailAssistantAgent"
+
+SPAM_DETECTION_INSTRUCTIONS = (
+    "You are a spam detection assistant that identifies spam emails.\n\n"
+    "Analyze the email content for spam indicators including:\n"
+    "1. Suspicious language (urgent, limited time, act now, free money, etc.)\n"
+    "2. Suspicious links or requests for personal information\n"
+    "3. Poor grammar or spelling\n"
+    "4. Requests for money or financial information\n"
+    "5. Impersonation attempts\n\n"
+    "Return a JSON response with:\n"
+    "- is_spam: boolean indicating if it's spam\n"
+    "- confidence: float between 0.0 and 1.0\n"
+    "- reason: detailed explanation of your classification"
+)
+
+EMAIL_ASSISTANT_INSTRUCTIONS = (
+    "You are an email assistant that helps users draft responses to legitimate emails.\n\n"
+    "When you receive an email that has been verified as legitimate:\n"
+    "1. Draft a professional and appropriate response\n"
+    "2. Match the tone and formality of the original email\n"
+    "3. Be helpful and courteous\n"
+    "4. Keep the response concise but complete\n\n"
+    "Return a JSON response with:\n"
+    "- response: the drafted email response"
+)
+
+
+class SpamDetectionResult(BaseModel):
+    is_spam: bool
+    confidence: float
+    reason: str
+
+
+class EmailResponse(BaseModel):
+    response: str
+
+
+class EmailPayload(BaseModel):
+    email_id: str
+    email_content: str
+
+
+def _build_client_kwargs() -> dict[str, Any]:
+    """Build Foundry chat client configuration from environment variables."""
+    project_endpoint = os.getenv(FOUNDRY_PROJECT_ENDPOINT_ENV)
+    if not project_endpoint:
+        raise RuntimeError(f"{FOUNDRY_PROJECT_ENDPOINT_ENV} environment variable is required.")
+
+    model = os.getenv(AZURE_OPENAI_DEPLOYMENT_ENV)
+    if not model:
+        raise RuntimeError(f"{AZURE_OPENAI_DEPLOYMENT_ENV} environment variable is required.")
+
+    return {
+        "project_endpoint": project_endpoint,
+        "model": model,
+        "credential": AzureCliCredential(),
+    }
+
+
+# Executors for non-AI activities (defined at module level)
+class SpamHandlerExecutor(Executor):
+    """Executor that handles spam emails (non-AI activity)."""
+
+    @handler
+    async def handle_spam_result(
+        self,
+        agent_response: AgentExecutorResponse,
+        ctx: WorkflowContext[Never, str],
+    ) -> None:
+        """Mark email as spam and log the reason."""
+        text = agent_response.agent_response.text
+        try:
+            spam_result = SpamDetectionResult.model_validate_json(text)
+        except ValidationError:
+            spam_result = SpamDetectionResult(is_spam=True, reason="Invalid JSON from agent", confidence=0.0)
+
+        message = f"Email marked as spam: {spam_result.reason}"
+        await ctx.yield_output(message)
+
+
+class EmailSenderExecutor(Executor):
+    """Executor that sends email responses (non-AI activity)."""
+
+    @handler
+    async def handle_email_response(
+        self,
+        agent_response: AgentExecutorResponse,
+        ctx: WorkflowContext[Never, str],
+    ) -> None:
+        """Send the drafted email response."""
+        text = agent_response.agent_response.text
+        try:
+            email_response = EmailResponse.model_validate_json(text)
+        except ValidationError:
+            email_response = EmailResponse(response="Error generating response.")
+
+        message = f"Email sent: {email_response.response}"
+        await ctx.yield_output(message)
+
+
+# Condition function for routing
+def is_spam_detected(message: Any) -> bool:
+    """Check if spam was detected in the email."""
+    if not isinstance(message, AgentExecutorResponse):
+        return False
+    try:
+        result = SpamDetectionResult.model_validate_json(message.agent_response.text)
+        return result.is_spam
+    except Exception:
+        return False
+
+
+def _create_workflow() -> Workflow:
+    """Create the workflow definition."""
+    client_kwargs = _build_client_kwargs()
+    chat_client = FoundryChatClient(**client_kwargs)
+
+    spam_agent = Agent(
+        client=chat_client,
+        name=SPAM_AGENT_NAME,
+        instructions=SPAM_DETECTION_INSTRUCTIONS,
+        default_options=OpenAIChatOptions[Any](response_format=SpamDetectionResult),
+    )
+
+    email_agent = Agent(
+        client=chat_client,
+        name=EMAIL_AGENT_NAME,
+        instructions=EMAIL_ASSISTANT_INSTRUCTIONS,
+        default_options=OpenAIChatOptions[Any](response_format=EmailResponse),
+    )
+
+    # Executors
+    spam_handler = SpamHandlerExecutor(id="spam_handler")
+    email_sender = EmailSenderExecutor(id="email_sender")
+
+    # Build workflow
+    return (
+        WorkflowBuilder(name="email_triage", start_executor=spam_agent)
+        .add_switch_case_edge_group(
+            spam_agent,
+            [
+                Case(condition=is_spam_detected, target=spam_handler),
+                Default(target=email_agent),
+            ],
+        )
+        .add_edge(email_agent, email_sender)
+        .build()
+    )
+
+
+def launch(durable: bool = True) -> AgentFunctionApp | None:
+    workflow: Workflow | None = None
+
+    if durable:
+        # Initialize app
+        workflow = _create_workflow()
+        return AgentFunctionApp(workflow=workflow)
+    # Launch the spam detection workflow in DevUI
+    from agent_framework.devui import serve
+    from dotenv import load_dotenv
+
+    # Load environment variables from .env file
+    env_path = Path(__file__).parent / ".env"
+    load_dotenv(dotenv_path=env_path)
+
+    logger.info("Starting Multi-Agent Spam Detection Workflow")
+    logger.info("Available at: http://localhost:8094")
+    logger.info("\nThis workflow demonstrates:")
+    logger.info("- Conditional routing based on spam detection")
+    logger.info("- Mixing AI agents with non-AI executors (like activity functions)")
+    logger.info("- Path 1 (spam): SpamDetector Agent → SpamHandler Executor")
+    logger.info("- Path 2 (legitimate): SpamDetector Agent → EmailAssistant Agent → EmailSender Executor")
+
+    workflow = _create_workflow()
+    serve(entities=[workflow], port=8094, auto_open=True)
+
+    return None
+
+
+# Default: Azure Functions mode
+# Run with `python function_app.py --maf` for pure MAF mode with DevUI
+app = launch(durable=True)
+
+
+if __name__ == "__main__":
+    import sys
+
+    if "--maf" in sys.argv:
+        # Run in pure MAF mode with DevUI
+        launch(durable=False)
+    else:
+        print("Usage: python function_app.py --maf")
+        print("  --maf    Run in pure MAF mode with DevUI (http://localhost:8094)")
+        print("\nFor Azure Functions mode, use: func start")

--- a/python/samples/azure_functions/10_workflow_no_shared_state/function_app.py
+++ b/python/samples/azure_functions/10_workflow_no_shared_state/function_app.py
@@ -1,19 +1,14 @@
 # Copyright (c) Microsoft. All rights reserved.
-"""Workflow Execution within Durable Functions Orchestrator.
+"""Run an Agent Framework workflow with Azure Durable Functions.
 
-This sample demonstrates running agent framework WorkflowBuilder workflows inside
-a Durable Functions orchestrator by manually traversing the workflow graph and
-delegating execution to Durable Entities (for agents) and Activities (for other logic).
+This sample builds a conditional email-processing workflow with ``WorkflowBuilder``
+and passes the resulting ``Workflow`` directly to ``AgentFunctionApp``. The durable
+hosting extension dispatches agent nodes through durable entities and executor nodes
+through activities without requiring application code to traverse the graph.
 
-Key architectural points:
-- AgentFunctionApp registers agents as DurableAIAgents.
-- WorkflowBuilder uses `DurableAgentDefinition` (a placeholder) to define the graph.
-- The orchestrator (`workflow_orchestration`) iterates through the workflow graph.
-- When an agent node is encountered, it calls the corresponding `DurableAIAgent` entity.
-- When a standard executor node is encountered, it calls an Activity (`ExecuteExecutor`).
-
-This approach allows using the rich structure of `WorkflowBuilder` while leveraging
-the statefulness and durability of `DurableAIAgent`s.
+The workflow routes spam to a handler executor and non-spam messages through an email
+assistant and sender executor. State is carried by typed messages rather than shared
+workflow state.
 
 Prerequisites:
 - Configure `FOUNDRY_PROJECT_ENDPOINT` and `FOUNDRY_MODEL`

--- a/python/samples/azure_functions/10_workflow_no_shared_state/function_app.py
+++ b/python/samples/azure_functions/10_workflow_no_shared_state/function_app.py
@@ -42,7 +42,7 @@ from typing_extensions import Never
 logger = logging.getLogger(__name__)
 
 FOUNDRY_PROJECT_ENDPOINT_ENV = "FOUNDRY_PROJECT_ENDPOINT"
-AZURE_OPENAI_DEPLOYMENT_ENV = "FOUNDRY_MODEL"
+FOUNDRY_MODEL_ENV = "FOUNDRY_MODEL"
 SPAM_AGENT_NAME = "SpamDetectionAgent"
 EMAIL_AGENT_NAME = "EmailAssistantAgent"
 
@@ -93,9 +93,9 @@ def _build_client_kwargs() -> dict[str, Any]:
     if not project_endpoint:
         raise RuntimeError(f"{FOUNDRY_PROJECT_ENDPOINT_ENV} environment variable is required.")
 
-    model = os.getenv(AZURE_OPENAI_DEPLOYMENT_ENV)
+    model = os.getenv(FOUNDRY_MODEL_ENV)
     if not model:
-        raise RuntimeError(f"{AZURE_OPENAI_DEPLOYMENT_ENV} environment variable is required.")
+        raise RuntimeError(f"{FOUNDRY_MODEL_ENV} environment variable is required.")
 
     return {
         "project_endpoint": project_endpoint,

--- a/python/samples/azure_functions/10_workflow_no_shared_state/host.json
+++ b/python/samples/azure_functions/10_workflow_no_shared_state/host.json
@@ -1,0 +1,12 @@
+{
+  "version": "2.0",
+  "extensionBundle": {
+    "id": "Microsoft.Azure.Functions.ExtensionBundle",
+    "version": "[4.*, 5.0.0)"
+  },
+  "extensions": {
+    "durableTask": {
+      "hubName": "%TASKHUB_NAME%"
+    }
+  }
+}

--- a/python/samples/azure_functions/10_workflow_no_shared_state/local.settings.json.sample
+++ b/python/samples/azure_functions/10_workflow_no_shared_state/local.settings.json.sample
@@ -1,0 +1,11 @@
+{
+  "IsEncrypted": false,
+  "Values": {
+    "FUNCTIONS_WORKER_RUNTIME": "python",
+    "AzureWebJobsStorage": "UseDevelopmentStorage=true",
+    "DURABLE_TASK_SCHEDULER_CONNECTION_STRING": "Endpoint=http://localhost:8080;TaskHub=default;Authentication=None",
+    "TASKHUB_NAME": "default",
+    "FOUNDRY_PROJECT_ENDPOINT": "<FOUNDRY_PROJECT_ENDPOINT>",
+    "FOUNDRY_MODEL": "<FOUNDRY_MODEL>"
+  }
+}

--- a/python/samples/azure_functions/10_workflow_no_shared_state/requirements.txt
+++ b/python/samples/azure_functions/10_workflow_no_shared_state/requirements.txt
@@ -1,0 +1,14 @@
+# Agent Framework packages
+# To use the deployed version, uncomment the lines below and comment out the local installation lines
+# agent-framework-foundry
+# agent-framework-azurefunctions
+
+# Local installation (for development and testing)
+# Each package must be listed explicitly because pip doesn't resolve uv workspace sources.
+# Without explicit entries, pip would fetch transitive dependencies from PyPI instead of local source.
+agent-framework-foundry>=1.10.1,<2  # Foundry support from PyPI (pulls in core)
+-e ../../../packages/durabletask  # Durable Task support - dependency of azurefunctions
+-e ../../../packages/azurefunctions  # Azure Functions integration - the main package for this sample
+
+# Azure authentication
+azure-identity

--- a/python/samples/azure_functions/10_workflow_no_shared_state/requirements.txt
+++ b/python/samples/azure_functions/10_workflow_no_shared_state/requirements.txt
@@ -12,3 +12,6 @@ agent-framework-foundry>=1.10.1,<2  # Foundry support from PyPI (pulls in core)
 
 # Azure authentication
 azure-identity
+
+# Local environment loading
+python-dotenv

--- a/python/samples/azure_functions/11_workflow_parallel/.env.template
+++ b/python/samples/azure_functions/11_workflow_parallel/.env.template
@@ -1,0 +1,13 @@
+# Azure Functions Runtime Configuration
+FUNCTIONS_WORKER_RUNTIME=python
+AzureWebJobsStorage=UseDevelopmentStorage=true
+
+# Durable Task Scheduler Configuration
+# For local development with DTS emulator: Endpoint=http://localhost:8080;TaskHub=default;Authentication=None
+# For Azure: Get connection string from Azure portal
+DURABLE_TASK_SCHEDULER_CONNECTION_STRING=Endpoint=http://localhost:8080;TaskHub=default;Authentication=None
+TASKHUB_NAME=default
+
+# Azure OpenAI Configuration
+AZURE_OPENAI_ENDPOINT=https://your-resource.openai.azure.com/
+AZURE_OPENAI_MODEL=your-deployment-name

--- a/python/samples/azure_functions/11_workflow_parallel/.gitignore
+++ b/python/samples/azure_functions/11_workflow_parallel/.gitignore
@@ -1,0 +1,4 @@
+.venv/
+__pycache__/
+local.settings.json
+.env

--- a/python/samples/azure_functions/11_workflow_parallel/README.md
+++ b/python/samples/azure_functions/11_workflow_parallel/README.md
@@ -1,0 +1,194 @@
+# Parallel Workflow Execution Sample
+
+This sample demonstrates **parallel execution** of executors and agents in Azure Durable Functions workflows.
+
+## Overview
+
+This sample showcases three different parallel execution patterns:
+
+1. **Two Executors in Parallel** - Fan-out to multiple activities
+2. **Two Agents in Parallel** - Fan-out to multiple entities
+3. **Mixed Execution** - Agents and executors can run concurrently
+
+## Workflow Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│                         PARALLEL WORKFLOW                                │
+├─────────────────────────────────────────────────────────────────────────┤
+│                                                                          │
+│  Pattern 1: Two Executors in Parallel (Activities)                       │
+│  ─────────────────────────────────────────────────                       │
+│                                                                          │
+│     input_router ──┬──> [word_count_processor] ────┐                     │
+│                    │                               │                     │
+│                    └──> [format_analyzer_processor]┴──> [aggregator]     │
+│                                                                          │
+│  Pattern 2: Two Agents in Parallel (Entities)                            │
+│  ─────────────────────────────────────────────                           │
+│                                                                          │
+│     [prepare_for_agents] ──┬──> [SentimentAgent] ──────┐                 │
+│                            │                           │                 │
+│                            └──> [KeywordAgent] ────────┴──> [prepare_for_│
+│                                                              mixed]      │
+│                                                                          │
+│  Pattern 3: Mixed Agent + Executor in Parallel                           │
+│  ────────────────────────────────────────────────                        │
+│                                                                          │
+│     [prepare_for_mixed] ──┬──> [SummaryAgent] ─────────┐                 │
+│                           │                            │                 │
+│                           └──> [statistics_processor] ─┴──> [final_report│
+│                                                              _executor]  │
+│                                                                          │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+## How Parallel Execution Works
+
+### Activities (Executors)
+When multiple executors are pending in the same iteration (e.g., after a fan-out edge), they are batched and executed using `task_all()`:
+
+```python
+# In _workflow.py - activities execute in parallel
+activity_tasks = [context.call_activity("ExecuteExecutor", input) for ...]
+results = yield context.task_all(activity_tasks)  # All run concurrently!
+```
+
+### Agents (Entities)
+Different agents can also run in parallel when they're pending in the same iteration:
+
+```python
+# Different agents run in parallel
+agent_tasks = [agent_a.run(...), agent_b.run(...)]
+responses = yield context.task_all(agent_tasks)  # Both agents run concurrently!
+```
+
+**Note:** Multiple messages to the *same* agent are processed sequentially to maintain conversation coherence.
+
+## Components
+
+| Component | Type | Description |
+|-----------|------|-------------|
+| `input_router` | Executor | Routes input JSON to parallel processors |
+| `word_count_processor` | Executor | Counts words and characters |
+| `format_analyzer_processor` | Executor | Analyzes document format |
+| `aggregator` | Executor | Combines results from parallel processors |
+| `prepare_for_agents` | Executor | Prepares content for agent analysis |
+| `SentimentAnalysisAgent` | AI Agent | Analyzes text sentiment |
+| `KeywordExtractionAgent` | AI Agent | Extracts keywords and categories |
+| `prepare_for_mixed` | Executor | Prepares content for mixed parallel execution |
+| `SummaryAgent` | AI Agent | Summarizes the document |
+| `statistics_processor` | Executor | Computes document statistics |
+| `FinalReportExecutor` | Executor | Compiles final report from all analyses |
+
+## Prerequisites
+
+1. **Azure OpenAI** - Endpoint and deployment configured
+2. **DTS Emulator** - For durable task scheduling (recommended)
+3. **Azurite** - For Azure Functions internal storage
+
+## Setup
+
+### Option 1: DevUI Mode (Local Development - No Durable Functions)
+
+The sample can run locally without Azure Functions infrastructure using DevUI:
+
+1. Copy the environment template:
+   ```bash
+   cp .env.template .env
+   ```
+
+2. Configure `.env` with your Azure OpenAI credentials (`AZURE_OPENAI_ENDPOINT` and
+   `AZURE_OPENAI_MODEL`)
+
+3. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+4. Run in DevUI mode (set `durable=False` in `function_app.py`):
+   ```bash
+   python function_app.py
+   ```
+
+5. Open `http://localhost:8095` and provide input:
+   ```json
+   {
+     "document_id": "doc-001",
+     "content": "Your document text here..."
+   }
+   ```
+
+### Option 2: Durable Functions Mode (Full Azure Functions)
+
+1. Copy configuration files:
+   ```bash
+   cp .env.template .env
+   cp local.settings.json.sample local.settings.json
+   ```
+
+2. Configure `local.settings.json` with your Azure OpenAI credentials
+
+3. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+4. Start DTS Emulator:
+   ```bash
+   docker run -d --name dts-emulator -p 8080:8080 -p 8082:8082 mcr.microsoft.com/dts/dts-emulator:latest
+   ```
+
+5. Start Azurite (or use VS Code extension):
+   ```bash
+   azurite --silent
+   ```
+
+6. Run the function app (ensure `durable=True` in `function_app.py`):
+   ```bash
+   func start
+   ```
+
+## Testing
+
+Use the `demo.http` file with REST Client extension or curl:
+
+### Analyze a Document
+```bash
+curl -X POST http://localhost:7071/api/workflow/parallel_review/run \
+  -H "Content-Type: application/json" \
+  -d '{
+    "document_id": "doc-001",
+    "content": "The quarterly earnings report shows strong growth in cloud services. Revenue increased by 25%."
+  }'
+```
+
+### Check Status
+```bash
+curl http://localhost:7071/api/workflow/parallel_review/status/{instanceId}
+```
+
+## Observing Parallel Execution
+
+Open the DTS Dashboard at `http://localhost:8082` to observe:
+
+1. **Activity Execution Timeline** - You'll see `word_count_processor` and `format_analyzer_processor` starting at approximately the same time
+2. **Agent Execution Timeline** - `SentimentAnalysisAgent` and `KeywordExtractionAgent` also start concurrently
+3. **Sequential vs Parallel** - Compare with non-parallel samples to see the time savings
+
+## Expected Output
+
+```json
+{
+  "output": [
+    "=== Document Analysis Report ===\n\n--- SentimentAnalysisAgent ---\n{\"sentiment\": \"positive\", \"confidence\": 0.85, \"explanation\": \"...\"}\n\n--- KeywordExtractionAgent ---\n{\"keywords\": [\"earnings\", \"growth\", \"cloud\"], \"categories\": [\"finance\", \"technology\"]}"
+  ]
+}
+```
+
+## Key Takeaways
+
+1. **Parallel execution is automatic** - When multiple executors/agents are pending in the same iteration, they run in parallel
+2. **Workflow graph determines parallelism** - Fan-out edges create parallel execution opportunities
+3. **Mixed parallelism** - Agents and executors can run concurrently if they're in the same iteration
+4. **Same-agent messages are sequential** - To maintain conversation coherence

--- a/python/samples/azure_functions/11_workflow_parallel/README.md
+++ b/python/samples/azure_functions/11_workflow_parallel/README.md
@@ -123,7 +123,6 @@ The sample can run locally without Azure Functions infrastructure using DevUI:
 
 1. Copy configuration files:
    ```bash
-   cp .env.template .env
    cp local.settings.json.sample local.settings.json
    ```
 

--- a/python/samples/azure_functions/11_workflow_parallel/README.md
+++ b/python/samples/azure_functions/11_workflow_parallel/README.md
@@ -106,9 +106,9 @@ The sample can run locally without Azure Functions infrastructure using DevUI:
    pip install -r requirements.txt
    ```
 
-4. Run in DevUI mode (set `durable=False` in `function_app.py`):
+4. Run in DevUI mode:
    ```bash
-   python function_app.py
+   python function_app.py --maf
    ```
 
 5. Open `http://localhost:8095` and provide input:

--- a/python/samples/azure_functions/11_workflow_parallel/README.md
+++ b/python/samples/azure_functions/11_workflow_parallel/README.md
@@ -27,10 +27,10 @@ This sample showcases three different parallel execution patterns:
 │  Pattern 2: Two Agents in Parallel (Entities)                            │
 │  ─────────────────────────────────────────────                           │
 │                                                                          │
-│     [prepare_for_agents] ──┬──> [SentimentAgent] ──────┐                 │
-│                            │                           │                 │
-│                            └──> [KeywordAgent] ────────┴──> [prepare_for_│
-│                                                              mixed]      │
+│     [prepare_for_agents] ──┬──> [SentimentAnalysisAgent] ─┐             │
+│                            └──> [KeywordExtractionAgent] ─┴─┐           │
+│                                                             ▼           │
+│                                                   [prepare_for_mixed]   │
 │                                                                          │
 │  Pattern 3: Mixed Agent + Executor in Parallel                           │
 │  ────────────────────────────────────────────────                        │

--- a/python/samples/azure_functions/11_workflow_parallel/demo.http
+++ b/python/samples/azure_functions/11_workflow_parallel/demo.http
@@ -1,0 +1,29 @@
+### Analyze a document (triggers parallel workflow)
+POST http://localhost:7071/api/workflow/parallel_review/run
+Content-Type: application/json
+
+{
+    "document_id": "doc-001",
+    "content": "The quarterly earnings report shows strong growth in our cloud services division. Revenue increased by 25% compared to last year, driven by enterprise adoption. Customer satisfaction remains high at 92%. However, we face challenges in the mobile segment where competition is intense. Overall, the outlook is positive with expected continued growth in the coming quarters."
+}
+
+###
+
+### Short document test
+POST http://localhost:7071/api/workflow/parallel_review/run
+Content-Type: application/json
+
+{
+    "document_id": "doc-002",
+    "content": "Quick update: Project completed successfully. Team performance exceeded expectations."
+}
+
+###
+
+### Check workflow status
+GET http://localhost:7071/api/workflow/parallel_review/status/{{instanceId}}
+
+###
+
+### Health check
+GET http://localhost:7071/api/health

--- a/python/samples/azure_functions/11_workflow_parallel/function_app.py
+++ b/python/samples/azure_functions/11_workflow_parallel/function_app.py
@@ -1,0 +1,491 @@
+# Copyright (c) Microsoft. All rights reserved.
+"""Parallel Workflow Execution Sample.
+
+This sample demonstrates parallel execution of executors and agents in Azure Durable Functions.
+It showcases three different parallel execution patterns:
+
+1. Two executors running concurrently (fan-out to activities)
+2. Two agents running concurrently (fan-out to entities)
+3. One executor and one agent running concurrently (mixed fan-out)
+
+The workflow simulates a document processing pipeline where:
+- A document is analyzed by multiple processors in parallel
+- Results are aggregated and then processed by agents
+- A summary agent and statistics executor run in parallel
+- Finally, combined into a single output
+
+Key architectural points:
+- FanOut edges enable parallel execution
+- Different agents run in parallel when they're in the same iteration
+- Activities (executors) also run in parallel when pending together
+- Mixed agent/executor fan-outs execute concurrently
+
+Prerequisites:
+- Configure `AZURE_OPENAI_ENDPOINT` and `AZURE_OPENAI_MODEL`
+- Sign in with Azure CLI (`az login`) for `AzureCliCredential`
+- Ensure Azurite and the Durable Task Scheduler emulator are running
+"""
+
+import logging
+import os
+from dataclasses import dataclass
+from typing import Any
+
+from agent_framework import (
+    Agent,
+    AgentExecutorResponse,
+    Executor,
+    Workflow,
+    WorkflowBuilder,
+    WorkflowContext,
+    executor,
+    handler,
+)
+from agent_framework.openai import OpenAIChatCompletionClient, OpenAIChatCompletionOptions
+from agent_framework_azurefunctions import AgentFunctionApp
+from azure.identity.aio import AzureCliCredential, get_bearer_token_provider
+from pydantic import BaseModel
+from typing_extensions import Never
+
+logger = logging.getLogger(__name__)
+
+# Agent names
+SENTIMENT_AGENT_NAME = "SentimentAnalysisAgent"
+KEYWORD_AGENT_NAME = "KeywordExtractionAgent"
+SUMMARY_AGENT_NAME = "SummaryAgent"
+RECOMMENDATION_AGENT_NAME = "RecommendationAgent"
+
+
+# ============================================================================
+# Pydantic Models for structured outputs
+# ============================================================================
+
+
+class SentimentResult(BaseModel):
+    """Result from sentiment analysis."""
+
+    sentiment: str  # positive, negative, neutral
+    confidence: float
+    explanation: str
+
+
+class KeywordResult(BaseModel):
+    """Result from keyword extraction."""
+
+    keywords: list[str]
+    categories: list[str]
+
+
+class SummaryResult(BaseModel):
+    """Result from summarization."""
+
+    summary: str
+    key_points: list[str]
+
+
+class RecommendationResult(BaseModel):
+    """Result from recommendation engine."""
+
+    recommendations: list[str]
+    priority: str
+
+
+@dataclass
+class DocumentInput:
+    """Input document to be processed."""
+
+    document_id: str
+    content: str
+
+
+@dataclass
+class ProcessorResult:
+    """Result from a document processor (executor)."""
+
+    processor_name: str
+    document_id: str
+    content: str
+    word_count: int
+    char_count: int
+    has_numbers: bool
+
+
+@dataclass
+class AggregatedResults:
+    """Aggregated results from parallel processors."""
+
+    document_id: str
+    content: str
+    processor_results: list[ProcessorResult]
+
+
+@dataclass
+class AgentAnalysis:
+    """Analysis result from an agent."""
+
+    agent_name: str
+    result: str
+
+
+@dataclass
+class FinalReport:
+    """Final combined report."""
+
+    document_id: str
+    analyses: list[AgentAnalysis]
+
+
+# ============================================================================
+# Executor Definitions (Activities - run in parallel when pending together)
+# ============================================================================
+
+
+@executor(id="input_router")
+async def input_router(document: DocumentInput, ctx: WorkflowContext[DocumentInput]) -> None:
+    """Route the input document to the parallel processors.
+
+    The durable engine reconstructs ``DocumentInput`` from the client's JSON
+    payload before delivery, mirroring in-process execution.
+    """
+    logger.info("[input_router] Routing document: %s", document.document_id)
+    await ctx.send_message(document)
+
+
+@executor(id="word_count_processor")
+async def word_count_processor(doc: DocumentInput, ctx: WorkflowContext[ProcessorResult]) -> None:
+    """Process document and count words - runs as an activity."""
+    logger.info("[word_count_processor] Processing document: %s", doc.document_id)
+
+    word_count = len(doc.content.split())
+    char_count = len(doc.content)
+    has_numbers = any(c.isdigit() for c in doc.content)
+
+    result = ProcessorResult(
+        processor_name="word_count",
+        document_id=doc.document_id,
+        content=doc.content,
+        word_count=word_count,
+        char_count=char_count,
+        has_numbers=has_numbers,
+    )
+
+    await ctx.send_message(result)
+
+
+@executor(id="format_analyzer_processor")
+async def format_analyzer_processor(doc: DocumentInput, ctx: WorkflowContext[ProcessorResult]) -> None:
+    """Analyze document format - runs as an activity in parallel with word_count."""
+    logger.info("[format_analyzer_processor] Processing document: %s", doc.document_id)
+
+    # Simple format analysis
+    lines = doc.content.split("\n")
+    word_count = len(lines)  # Using line count as "word count" for this processor
+    char_count = sum(len(line) for line in lines)
+    has_numbers = doc.content.count(".") > 0  # Check for sentences
+
+    result = ProcessorResult(
+        processor_name="format_analyzer",
+        document_id=doc.document_id,
+        content=doc.content,
+        word_count=word_count,
+        char_count=char_count,
+        has_numbers=has_numbers,
+    )
+
+    await ctx.send_message(result)
+
+
+@executor(id="aggregator")
+async def aggregator(results: list[ProcessorResult], ctx: WorkflowContext[AggregatedResults]) -> None:
+    """Aggregate results from parallel processors - receives fan-in input."""
+    logger.info("[aggregator] Aggregating %d results", len(results))
+
+    # Extract document info from the first result (all have the same content)
+    document_id = results[0].document_id if results else "unknown"
+    content = results[0].content if results else ""
+
+    aggregated = AggregatedResults(
+        document_id=document_id,
+        content=content,
+        processor_results=results,
+    )
+
+    await ctx.send_message(aggregated)
+
+
+@executor(id="prepare_for_agents")
+async def prepare_for_agents(aggregated: AggregatedResults, ctx: WorkflowContext[str]) -> None:
+    """Prepare content for agent analysis - broadcasts to multiple agents."""
+    logger.info("[prepare_for_agents] Preparing content for agents")
+
+    # Send the original content to agents for analysis
+    await ctx.send_message(aggregated.content)
+
+
+@executor(id="prepare_for_mixed")
+async def prepare_for_mixed(analyses: list[AgentExecutorResponse], ctx: WorkflowContext[str]) -> None:
+    """Prepare results for mixed agent+executor parallel processing.
+
+    Combines agent analysis results into a string that can be consumed by
+    both the SummaryAgent and the statistics_processor in parallel.
+    """
+    logger.info("[prepare_for_mixed] Preparing for mixed parallel pattern")
+
+    sentiment_text = ""
+    keyword_text = ""
+
+    for analysis in analyses:
+        executor_id = analysis.executor_id
+        text = analysis.agent_response.text if analysis.agent_response else ""
+
+        if executor_id == SENTIMENT_AGENT_NAME:
+            sentiment_text = text
+        elif executor_id == KEYWORD_AGENT_NAME:
+            keyword_text = text
+
+    # Combine into a string that both agent and executor can process
+    combined = f"Sentiment Analysis: {sentiment_text}\n\nKeyword Extraction: {keyword_text}"
+    await ctx.send_message(combined)
+
+
+@executor(id="statistics_processor")
+async def statistics_processor(analysis_text: str, ctx: WorkflowContext[ProcessorResult]) -> None:
+    """Calculate statistics from the analysis - runs in parallel with SummaryAgent."""
+    logger.info("[statistics_processor] Calculating statistics")
+
+    # Calculate some statistics from the combined analysis
+    word_count = len(analysis_text.split())
+    char_count = len(analysis_text)
+    has_numbers = any(c.isdigit() for c in analysis_text)
+
+    result = ProcessorResult(
+        processor_name="statistics",
+        document_id="analysis",
+        content=analysis_text,
+        word_count=word_count,
+        char_count=char_count,
+        has_numbers=has_numbers,
+    )
+    await ctx.send_message(result)
+
+
+class FinalReportExecutor(Executor):
+    """Executor that compiles the final report from agent analyses."""
+
+    @handler
+    async def compile_report(
+        self,
+        analyses: list[AgentExecutorResponse | ProcessorResult],
+        ctx: WorkflowContext[Never, str],
+    ) -> None:
+        """Compile final report from mixed agent + processor results."""
+        logger.info("[final_report] Compiling report from %d analyses", len(analyses))
+
+        report_parts = ["=== Document Analysis Report ===\n"]
+
+        for analysis in analyses:
+            if isinstance(analysis, AgentExecutorResponse):
+                agent_name = analysis.executor_id
+                text = analysis.agent_response.text if analysis.agent_response else "No response"
+            elif isinstance(analysis, ProcessorResult):
+                agent_name = f"Processor: {analysis.processor_name}"
+                text = f"Words: {analysis.word_count}, Chars: {analysis.char_count}"
+            else:
+                continue
+
+            report_parts.append(f"\n--- {agent_name} ---")
+            report_parts.append(text)
+
+        final_report = "\n".join(report_parts)
+        await ctx.yield_output(final_report)
+
+
+class MixedResultCollector(Executor):
+    """Collector for mixed agent/executor results."""
+
+    @handler
+    async def collect_mixed_results(
+        self,
+        results: list[Any],
+        ctx: WorkflowContext[Never, str],
+    ) -> None:
+        """Collect and format results from mixed parallel execution."""
+        logger.info("[mixed_collector] Collecting %d mixed results", len(results))
+
+        output_parts = ["=== Mixed Parallel Execution Results ===\n"]
+
+        for result in results:
+            if isinstance(result, AgentExecutorResponse):
+                output_parts.append(f"[Agent: {result.executor_id}]")
+                output_parts.append(result.agent_response.text if result.agent_response else "No response")
+            elif isinstance(result, ProcessorResult):
+                output_parts.append(f"[Processor: {result.processor_name}]")
+                output_parts.append(f"  Words: {result.word_count}, Chars: {result.char_count}")
+
+        await ctx.yield_output("\n".join(output_parts))
+
+
+# ============================================================================
+# Workflow Construction
+# ============================================================================
+
+
+def _create_workflow() -> Workflow:
+    """Create the parallel workflow definition.
+
+    Workflow structure demonstrating three parallel patterns:
+
+    Pattern 1: Two Executors in Parallel (Fan-out/Fan-in to activities)
+    ────────────────────────────────────────────────────────────────────
+                   ┌─> word_count_processor ─────┐
+    input_router ──┤                             ├──> aggregator
+                   └─> format_analyzer_processor ─┘
+
+    Pattern 2: Two Agents in Parallel (Fan-out to entities)
+    ────────────────────────────────────────────────────────
+    prepare_for_agents ─┬─> SentimentAgent ──┐
+                        └─> KeywordAgent ────┤
+                                             └──> prepare_for_mixed
+
+    Pattern 3: Mixed Agent + Executor in Parallel
+    ──────────────────────────────────────────────
+    prepare_for_mixed ─┬─> SummaryAgent ────────┐
+                       └─> statistics_processor ─┤
+                                                 └──> final_report
+    """
+    credential = AzureCliCredential()
+
+    chat_client = OpenAIChatCompletionClient(
+        model=os.environ["AZURE_OPENAI_MODEL"],
+        credential=get_bearer_token_provider(credential, "https://cognitiveservices.azure.com/.default"),
+    )
+
+    # Create agents for parallel analysis
+    sentiment_agent = Agent(
+        client=chat_client,
+        name=SENTIMENT_AGENT_NAME,
+        instructions=(
+            "You are a sentiment analysis expert. Analyze the sentiment of the given text. "
+            "Return JSON with fields: sentiment (positive/negative/neutral), "
+            "confidence (0.0-1.0), and explanation (brief reasoning)."
+        ),
+        default_options=OpenAIChatCompletionOptions[Any](response_format=SentimentResult),
+    )
+
+    keyword_agent = Agent(
+        client=chat_client,
+        name=KEYWORD_AGENT_NAME,
+        instructions=(
+            "You are a keyword extraction expert. Extract important keywords and categories "
+            "from the given text. Return JSON with fields: keywords (list of strings), "
+            "and categories (list of topic categories)."
+        ),
+        default_options=OpenAIChatCompletionOptions[Any](response_format=KeywordResult),
+    )
+
+    # Create summary agent for Pattern 3 (mixed parallel)
+    summary_agent = Agent(
+        client=chat_client,
+        name=SUMMARY_AGENT_NAME,
+        instructions=(
+            "You are a summarization expert. Given analysis results (sentiment and keywords), "
+            "provide a concise summary. Return JSON with fields: summary (brief text), "
+            "and key_points (list of main takeaways)."
+        ),
+        default_options=OpenAIChatCompletionOptions[Any](response_format=SummaryResult),
+    )
+
+    # Create executor instances
+    final_report_executor = FinalReportExecutor(id="final_report")
+
+    # Build workflow with parallel patterns
+    return (
+        WorkflowBuilder(name="parallel_review", start_executor=input_router)
+        # Pattern 1: Fan-out to two executors (run in parallel)
+        .add_fan_out_edges(
+            source=input_router,
+            targets=[word_count_processor, format_analyzer_processor],
+        )
+        # Fan-in: Both processors send results to aggregator
+        .add_fan_in_edges(
+            sources=[word_count_processor, format_analyzer_processor],
+            target=aggregator,
+        )
+        # Prepare content for agent analysis
+        .add_edge(aggregator, prepare_for_agents)
+        # Pattern 2: Fan-out to two agents (run in parallel)
+        .add_fan_out_edges(
+            source=prepare_for_agents,
+            targets=[sentiment_agent, keyword_agent],
+        )
+        # Fan-in: Collect agent results into prepare_for_mixed
+        .add_fan_in_edges(
+            sources=[sentiment_agent, keyword_agent],
+            target=prepare_for_mixed,
+        )
+        # Pattern 3: Fan-out to one agent + one executor (mixed parallel)
+        .add_fan_out_edges(
+            source=prepare_for_mixed,
+            targets=[summary_agent, statistics_processor],
+        )
+        # Final fan-in: Collect mixed results
+        .add_fan_in_edges(
+            sources=[summary_agent, statistics_processor],
+            target=final_report_executor,
+        )
+        .build()
+    )
+
+
+# ============================================================================
+# Application Entry Point
+# ============================================================================
+
+
+def launch(durable: bool = True) -> AgentFunctionApp | None:
+    """Launch the function app or DevUI."""
+    workflow: Workflow | None = None
+
+    if durable:
+        workflow = _create_workflow()
+        return AgentFunctionApp(
+            workflow=workflow,
+            enable_health_check=True,
+        )
+    from pathlib import Path
+
+    from agent_framework.devui import serve
+    from dotenv import load_dotenv
+
+    env_path = Path(__file__).parent / ".env"
+    load_dotenv(dotenv_path=env_path)
+
+    logger.info("Starting Parallel Workflow Sample")
+    logger.info("Available at: http://localhost:8095")
+    logger.info("\nThis workflow demonstrates:")
+    logger.info("- Pattern 1: Two executors running in parallel")
+    logger.info("- Pattern 2: Two agents running in parallel")
+    logger.info("- Pattern 3: Mixed agent + executor running in parallel")
+    logger.info("- Fan-in aggregation of parallel results")
+
+    workflow = _create_workflow()
+    serve(entities=[workflow], port=8095, auto_open=True)
+
+    return None
+
+
+# Default: Azure Functions mode
+# Run with `python function_app.py --maf` for pure MAF mode with DevUI
+app = launch(durable=True)
+
+
+if __name__ == "__main__":
+    import sys
+
+    if "--maf" in sys.argv:
+        # Run in pure MAF mode with DevUI
+        launch(durable=False)
+    else:
+        print("Usage: python function_app.py --maf")
+        print("  --maf    Run in pure MAF mode with DevUI (http://localhost:8095)")
+        print("\nFor Azure Functions mode, use: func start")

--- a/python/samples/azure_functions/11_workflow_parallel/function_app.py
+++ b/python/samples/azure_functions/11_workflow_parallel/function_app.py
@@ -53,7 +53,6 @@ logger = logging.getLogger(__name__)
 SENTIMENT_AGENT_NAME = "SentimentAnalysisAgent"
 KEYWORD_AGENT_NAME = "KeywordExtractionAgent"
 SUMMARY_AGENT_NAME = "SummaryAgent"
-RECOMMENDATION_AGENT_NAME = "RecommendationAgent"
 
 
 # ============================================================================
@@ -81,13 +80,6 @@ class SummaryResult(BaseModel):
 
     summary: str
     key_points: list[str]
-
-
-class RecommendationResult(BaseModel):
-    """Result from recommendation engine."""
-
-    recommendations: list[str]
-    priority: str
 
 
 @dataclass
@@ -177,11 +169,9 @@ async def format_analyzer_processor(doc: DocumentInput, ctx: WorkflowContext[Pro
     """Analyze document format - runs as an activity in parallel with word_count."""
     logger.info("[format_analyzer_processor] Processing document: %s", doc.document_id)
 
-    # Simple format analysis
-    lines = doc.content.split("\n")
-    word_count = len(lines)  # Using line count as "word count" for this processor
-    char_count = sum(len(line) for line in lines)
-    has_numbers = doc.content.count(".") > 0  # Check for sentences
+    word_count = len(doc.content.split())
+    char_count = len(doc.content)
+    has_numbers = any(character.isdigit() for character in doc.content)
 
     result = ProcessorResult(
         processor_name="format_analyzer",
@@ -298,31 +288,6 @@ class FinalReportExecutor(Executor):
 
         final_report = "\n".join(report_parts)
         await ctx.yield_output(final_report)
-
-
-class MixedResultCollector(Executor):
-    """Collector for mixed agent/executor results."""
-
-    @handler
-    async def collect_mixed_results(
-        self,
-        results: list[Any],
-        ctx: WorkflowContext[Never, str],
-    ) -> None:
-        """Collect and format results from mixed parallel execution."""
-        logger.info("[mixed_collector] Collecting %d mixed results", len(results))
-
-        output_parts = ["=== Mixed Parallel Execution Results ===\n"]
-
-        for result in results:
-            if isinstance(result, AgentExecutorResponse):
-                output_parts.append(f"[Agent: {result.executor_id}]")
-                output_parts.append(result.agent_response.text if result.agent_response else "No response")
-            elif isinstance(result, ProcessorResult):
-                output_parts.append(f"[Processor: {result.processor_name}]")
-                output_parts.append(f"  Words: {result.word_count}, Chars: {result.char_count}")
-
-        await ctx.yield_output("\n".join(output_parts))
 
 
 # ============================================================================

--- a/python/samples/azure_functions/11_workflow_parallel/function_app.py
+++ b/python/samples/azure_functions/11_workflow_parallel/function_app.py
@@ -111,22 +111,6 @@ class AggregatedResults:
     processor_results: list[ProcessorResult]
 
 
-@dataclass
-class AgentAnalysis:
-    """Analysis result from an agent."""
-
-    agent_name: str
-    result: str
-
-
-@dataclass
-class FinalReport:
-    """Final combined report."""
-
-    document_id: str
-    analyses: list[AgentAnalysis]
-
-
 # ============================================================================
 # Executor Definitions (Activities - run in parallel when pending together)
 # ============================================================================

--- a/python/samples/azure_functions/11_workflow_parallel/host.json
+++ b/python/samples/azure_functions/11_workflow_parallel/host.json
@@ -1,0 +1,12 @@
+{
+  "version": "2.0",
+  "extensionBundle": {
+    "id": "Microsoft.Azure.Functions.ExtensionBundle",
+    "version": "[4.*, 5.0.0)"
+  },
+  "extensions": {
+    "durableTask": {
+      "hubName": "%TASKHUB_NAME%"
+    }
+  }
+}

--- a/python/samples/azure_functions/11_workflow_parallel/local.settings.json.sample
+++ b/python/samples/azure_functions/11_workflow_parallel/local.settings.json.sample
@@ -1,0 +1,11 @@
+{
+  "IsEncrypted": false,
+  "Values": {
+    "FUNCTIONS_WORKER_RUNTIME": "python",
+    "AzureWebJobsStorage": "UseDevelopmentStorage=true",
+    "DURABLE_TASK_SCHEDULER_CONNECTION_STRING": "Endpoint=http://localhost:8080;TaskHub=default;Authentication=None",
+    "TASKHUB_NAME": "default",
+    "AZURE_OPENAI_ENDPOINT": "<AZURE_OPENAI_ENDPOINT>",
+    "AZURE_OPENAI_MODEL": "<AZURE_OPENAI_MODEL>"
+  }
+}

--- a/python/samples/azure_functions/11_workflow_parallel/requirements.txt
+++ b/python/samples/azure_functions/11_workflow_parallel/requirements.txt
@@ -12,3 +12,6 @@ agent-framework-openai>=1.10.1,<2  # OpenAI support from PyPI (pulls in core)
 
 # Azure authentication
 azure-identity
+
+# Local environment loading
+python-dotenv

--- a/python/samples/azure_functions/11_workflow_parallel/requirements.txt
+++ b/python/samples/azure_functions/11_workflow_parallel/requirements.txt
@@ -1,0 +1,14 @@
+# Agent Framework packages
+# To use the deployed version, uncomment the lines below and comment out the local installation lines
+# agent-framework-openai
+# agent-framework-azurefunctions
+
+# Local installation (for development and testing)
+# Each package must be listed explicitly because pip doesn't resolve uv workspace sources.
+# Without explicit entries, pip would fetch transitive dependencies from PyPI instead of local source.
+agent-framework-openai>=1.10.1,<2  # OpenAI support from PyPI (pulls in core)
+-e ../../../packages/durabletask  # Durable Task support - dependency of azurefunctions
+-e ../../../packages/azurefunctions  # Azure Functions integration - the main package for this sample
+
+# Azure authentication
+azure-identity

--- a/python/samples/azure_functions/12_workflow_hitl/function_app.py
+++ b/python/samples/azure_functions/12_workflow_hitl/function_app.py
@@ -53,7 +53,7 @@ logger = logging.getLogger(__name__)
 
 # Environment variable names
 FOUNDRY_PROJECT_ENDPOINT_ENV = "FOUNDRY_PROJECT_ENDPOINT"
-AZURE_OPENAI_DEPLOYMENT_ENV = "FOUNDRY_MODEL"
+FOUNDRY_MODEL_ENV = "FOUNDRY_MODEL"
 
 # Agent names
 CONTENT_ANALYZER_AGENT_NAME = "ContentAnalyzerAgent"
@@ -398,9 +398,9 @@ def _build_client_kwargs() -> dict[str, Any]:
     if not project_endpoint:
         raise RuntimeError(f"{FOUNDRY_PROJECT_ENDPOINT_ENV} environment variable is required.")
 
-    model = os.getenv(AZURE_OPENAI_DEPLOYMENT_ENV)
+    model = os.getenv(FOUNDRY_MODEL_ENV)
     if not model:
-        raise RuntimeError(f"{AZURE_OPENAI_DEPLOYMENT_ENV} environment variable is required.")
+        raise RuntimeError(f"{FOUNDRY_MODEL_ENV} environment variable is required.")
 
     return {
         "project_endpoint": project_endpoint,

--- a/python/samples/azure_functions/12_workflow_hitl/requirements.txt
+++ b/python/samples/azure_functions/12_workflow_hitl/requirements.txt
@@ -12,3 +12,6 @@ agent-framework-foundry>=1.10.1,<2  # Foundry support from PyPI (pulls in core)
 
 # Azure authentication
 azure-identity
+
+# Local environment loading
+python-dotenv

--- a/python/samples/azure_functions/13_subworkflow_hitl/requirements.txt
+++ b/python/samples/azure_functions/13_subworkflow_hitl/requirements.txt
@@ -8,3 +8,6 @@
 # This sample hosts no AI agents, so it needs only the core + durabletask + azurefunctions packages.
 -e ../../../packages/durabletask  # Durable Task support - dependency of azurefunctions
 -e ../../../packages/azurefunctions  # Azure Functions integration - the main package for this sample
+
+# Local environment loading
+python-dotenv

--- a/python/samples/azure_functions/README.md
+++ b/python/samples/azure_functions/README.md
@@ -1,0 +1,118 @@
+# Azure Functions Samples
+
+These are common instructions for setting up your environment for every sample in this directory.
+These samples illustrate the Durable extensibility for Agent Framework running in Azure Functions.
+
+All of these samples are set up to run in Azure Functions. Azure Functions has a local development tool called [CoreTools](https://learn.microsoft.com/azure/azure-functions/functions-run-local?tabs=windows%2Cpython%2Cv2&pivots=programming-language-python#install-the-azure-functions-core-tools) which we will set up to run these samples locally.
+
+## Import convention
+
+These samples import `AgentFunctionApp` (and other hosting types) **directly from the extension
+packages** (`agent_framework_azurefunctions`, `agent_framework_durabletask`):
+
+```python
+from agent_framework_azurefunctions import AgentFunctionApp
+```
+
+The same entry-point types are also re-exported from `agent_framework.azure` in the core
+`agent-framework` package for backward compatibility. **New and updated samples should use the
+direct package imports above** — the canonical, self-contained path for this repo — rather than
+routing through the `agent_framework.azure` shim.
+
+## Quick Prerequisites Checklist
+
+Install and verify these tools before [Environment Setup](#environment-setup):
+
+- **[Azure Functions Core Tools](https://learn.microsoft.com/azure/azure-functions/functions-run-local?tabs=windows%2Cpython%2Cv2&pivots=programming-language-python#install-the-azure-functions-core-tools)** – run samples locally with `func start`
+- **[Azurite](https://learn.microsoft.com/azure/storage/common/storage-install-azurite)** – local storage emulator; must be running before `func start`
+- **[uv](https://docs.astral.sh/uv/)** – create virtual environments (recommended, especially on Windows)
+- **[Azure CLI](https://learn.microsoft.com/cli/azure/install-azure-cli)** – authenticate with `az login` for `AzureCliCredential`
+
+**Windows (PowerShell):**
+
+```powershell
+winget install Microsoft.Azure.FunctionsCoreTools
+npm install -g azurite
+irm https://astral.sh/uv/install.ps1 | iex
+winget install Microsoft.AzureCLI
+```
+
+**macOS:**
+
+```bash
+brew tap azure/functions
+brew install azure-functions-core-tools@4
+npm install -g azurite
+curl -LsSf https://astral.sh/uv/install.sh | sh
+# Azure CLI: https://learn.microsoft.com/cli/azure/install-azure-cli
+```
+
+**Linux:**
+
+```bash
+npm install -g azure-functions-core-tools@4 --unsafe-perm true
+npm install -g azurite
+curl -LsSf https://astral.sh/uv/install.sh | sh
+# Azure CLI: https://learn.microsoft.com/cli/azure/install-azure-cli
+```
+
+**Verify:**
+
+```bash
+func --version
+azurite --version
+uv --version
+az account show
+```
+
+Start Azurite in a separate terminal before `func start`:
+
+```bash
+azurite
+```
+
+## Environment Setup
+
+### 1. Install dependencies and create appropriate services
+
+- Install [Azure Functions Core Tools 4.x](https://learn.microsoft.com/azure/azure-functions/functions-run-local?tabs=windows%2Cpython%2Cv2&pivots=programming-language-python#install-the-azure-functions-core-tools)
+
+- Install [Azurite storage emulator](https://learn.microsoft.com/azure/storage/common/storage-install-azurite?toc=%2Fazure%2Fstorage%2Fblobs%2Ftoc.json&bc=%2Fazure%2Fstorage%2Fblobs%2Fbreadcrumb%2Ftoc.json&tabs=visual-studio%2Cblob-storage)
+
+- Create a [Microsoft Foundry project](https://learn.microsoft.com/azure/ai-foundry/) with an OpenAI model deployment. Note the Foundry project endpoint and deployment name, and ensure you can authenticate with `AzureCliCredential`.
+
+- Install a tool to execute HTTP calls, for example the [REST Client extension](https://marketplace.visualstudio.com/items?itemName=humao.rest-client)
+
+- [Optionally] Create an [Azure Function Python app](https://learn.microsoft.com/azure/azure-functions/functions-create-function-app-portal?tabs=core-tools&pivots=flex-consumption-plan) to later deploy your app to Azure if you so desire.
+
+### 2. Create and activate a virtual environment
+
+Using [uv](https://docs.astral.sh/uv/) (recommended):
+
+**Windows (PowerShell):**
+
+```powershell
+uv venv .venv
+.venv\Scripts\Activate.ps1
+```
+
+**Linux/macOS:**
+
+```bash
+uv venv .venv
+source .venv/bin/activate
+```
+
+> [!NOTE]
+> The `python -m venv .venv` command also works, but can hang indefinitely on Windows with Microsoft Store Python due to a known `ensurepip` issue. Use `uv venv .venv` to avoid this.
+
+### 3. Running the samples
+
+- [Start the Azurite emulator](https://learn.microsoft.com/azure/storage/common/storage-install-azurite?tabs=npm%2Cblob-storage#run-azurite)
+
+- Inside each sample:
+  - Install Python dependencies – from the sample directory, run `pip install -r requirements.txt` (or the equivalent in your active virtual environment).
+  - Copy `local.settings.json.template` to `local.settings.json`, then update `FOUNDRY_PROJECT_ENDPOINT` and `FOUNDRY_MODEL`. The samples use `AzureCliCredential`, so ensure you're logged in via `az login`.
+    - Keep `TASKHUB_NAME` set to `default` unless you plan to change the durable task hub name.
+  - Run the command `func start` from the root of the sample
+  - Follow each sample's README for scenario-specific steps, and use its `demo.http` file (or provided curl examples) to trigger the hosted HTTP endpoints.

--- a/python/samples/azure_functions/README.md
+++ b/python/samples/azure_functions/README.md
@@ -25,6 +25,8 @@ Install and verify these tools before [Environment Setup](#environment-setup):
 
 - **[Azure Functions Core Tools](https://learn.microsoft.com/azure/azure-functions/functions-run-local?tabs=windows%2Cpython%2Cv2&pivots=programming-language-python#install-the-azure-functions-core-tools)** – run samples locally with `func start`
 - **[Azurite](https://learn.microsoft.com/azure/storage/common/storage-install-azurite)** – local storage emulator; must be running before `func start`
+- **[Docker](https://docs.docker.com/get-docker/)** – run the local Durable Task Scheduler emulator
+- **[Durable Task Scheduler emulator](https://learn.microsoft.com/azure/durable-task/scheduler/develop-with-durable-task-scheduler#durable-task-scheduler-emulator)** – local durable task backend; must be running before `func start`
 - **[uv](https://docs.astral.sh/uv/)** – create virtual environments (recommended, especially on Windows)
 - **[Azure CLI](https://learn.microsoft.com/cli/azure/install-azure-cli)** – authenticate with `az login` for `AzureCliCredential`
 
@@ -61,15 +63,21 @@ curl -LsSf https://astral.sh/uv/install.sh | sh
 ```bash
 func --version
 azurite --version
+docker --version
 uv --version
 az account show
 ```
 
-Start Azurite in a separate terminal before `func start`:
+Start the Durable Task Scheduler emulator and Azurite before `func start`:
 
 ```bash
+docker run -d --name dts-emulator -p 8080:8080 -p 8082:8082 \
+  mcr.microsoft.com/dts/dts-emulator:latest
 azurite
 ```
+
+The scheduler endpoint is `http://localhost:8080`; its dashboard is available at
+`http://localhost:8082`.
 
 ## Environment Setup
 
@@ -78,6 +86,8 @@ azurite
 - Install [Azure Functions Core Tools 4.x](https://learn.microsoft.com/azure/azure-functions/functions-run-local?tabs=windows%2Cpython%2Cv2&pivots=programming-language-python#install-the-azure-functions-core-tools)
 
 - Install [Azurite storage emulator](https://learn.microsoft.com/azure/storage/common/storage-install-azurite?toc=%2Fazure%2Fstorage%2Fblobs%2Ftoc.json&bc=%2Fazure%2Fstorage%2Fblobs%2Fbreadcrumb%2Ftoc.json&tabs=visual-studio%2Cblob-storage)
+
+- Install [Docker](https://docs.docker.com/get-docker/) and run the [Durable Task Scheduler emulator](https://learn.microsoft.com/azure/durable-task/scheduler/develop-with-durable-task-scheduler#durable-task-scheduler-emulator)
 
 - Create a [Microsoft Foundry project](https://learn.microsoft.com/azure/ai-foundry/) with an OpenAI model deployment. Note the Foundry project endpoint and deployment name, and ensure you can authenticate with `AzureCliCredential`.
 
@@ -108,7 +118,7 @@ source .venv/bin/activate
 
 ### 3. Running the samples
 
-- [Start the Azurite emulator](https://learn.microsoft.com/azure/storage/common/storage-install-azurite?tabs=npm%2Cblob-storage#run-azurite)
+- Start the Durable Task Scheduler emulator and [Azurite](https://learn.microsoft.com/azure/storage/common/storage-install-azurite?tabs=npm%2Cblob-storage#run-azurite) as shown above.
 
 - Inside each sample:
   - Install Python dependencies – from the sample directory, run `pip install -r requirements.txt` (or the equivalent in your active virtual environment).

--- a/python/samples/azure_functions/README.md
+++ b/python/samples/azure_functions/README.md
@@ -112,7 +112,8 @@ source .venv/bin/activate
 
 - Inside each sample:
   - Install Python dependencies – from the sample directory, run `pip install -r requirements.txt` (or the equivalent in your active virtual environment).
-  - Copy `local.settings.json.template` to `local.settings.json`, then update `FOUNDRY_PROJECT_ENDPOINT` and `FOUNDRY_MODEL`. The samples use `AzureCliCredential`, so ensure you're logged in via `az login`.
+  - Copy the supplied `local.settings.json.template` or `local.settings.json.sample` to `local.settings.json`.
+  - Configure the provider variables in that file (`FOUNDRY_*` or `AZURE_OPENAI_*`). The samples use `AzureCliCredential`, so ensure you're logged in via `az login`.
     - Keep `TASKHUB_NAME` set to `default` unless you plan to change the durable task hub name.
   - Run the command `func start` from the root of the sample
   - Follow each sample's README for scenario-specific steps, and use its `demo.http` file (or provided curl examples) to trigger the hosted HTTP endpoints.


### PR DESCRIPTION
## Summary
- migrate Azure Functions Python samples 01-11 into the extension and update sample indexes, paths, dependencies, and documentation
- sync workflow input normalization fixes and use direct `agent_framework_durabletask` / `agent_framework_azurefunctions` imports
- add end-to-end MCP coverage for sample 08 and a PR-gate invariant requiring every Azure Functions sample to have an enabled integration-test marker
- fix DTS/Azurite readiness probes and configure Azure OIDC login for model-backed integration tests
- address Copilot review findings in samples 02, 10, and 11 and declare `python-dotenv` everywhere it is imported

## Validation
- `ruff check samples/azure_functions packages/azurefunctions`
- `ruff format --check samples/azure_functions packages/azurefunctions`
- `mypy --config-file pyproject.toml packages/azurefunctions/tests`
- `pytest packages/durabletask/tests packages/azurefunctions/tests -m "not integration"`
- Azure Functions integration collection covers samples 01-13 with no unconditional skips
- all 13 `function_app.py` files compile successfully

## Integration environment setup required
The `integration` GitHub environment currently has no configured secrets. Before the model-backed suite can execute, maintainers must provision:
- `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, `AZURE_SUBSCRIPTION_ID` (OIDC federated identity)
- `FOUNDRY_PROJECT_ENDPOINT`, `FOUNDRY_MODEL`
- `AZURE_OPENAI_ENDPOINT`, `AZURE_OPENAI_MODEL`

The workflow now fails explicitly when these are absent instead of reporting a false green with every sample test skipped.