### PR TITLE
Release pipeline: package validation + 1ES NuGet compliance

### DIFF
--- a/eng/ci/package-release.yml
+++ b/eng/ci/package-release.yml
@@ -53,14 +53,21 @@ extends:
             parameters:
               artifactName: ${{ parameters.artifactName }}
 
-      - stage: PublishPackages
-        displayName: 'Publish packages'
-        dependsOn: BuildPackages
-        jobs:
-          - template: /eng/templates/official/jobs/publish-packages.yml@self
-            parameters:
-              artifactName: ${{ parameters.artifactName }}
-              publishDotNet: ${{ parameters.publishDotNet }}
-              publishPython: ${{ parameters.publishPython }}
-              nugetServiceConnection: ${{ parameters.nugetServiceConnection }}
-              esrpMainPublisher: ${{ parameters.esrpMainPublisher }}
+      # Gate the entire publish stage at compile time (not with a runtime `condition`).
+      # 1ES validates referenced service connections even for jobs that would be
+      # skipped by a runtime condition, so a dry run (both flags false) would still
+      # fail on the publish service connections. A compile-time `${{ if }}` removes the
+      # stage from the pipeline entirely when nothing is being published, so a dry run
+      # only runs BuildPackages and requires no publishing credentials.
+      - ${{ if or(eq(parameters.publishDotNet, true), eq(parameters.publishPython, true)) }}:
+        - stage: PublishPackages
+          displayName: 'Publish packages'
+          dependsOn: BuildPackages
+          jobs:
+            - template: /eng/templates/official/jobs/publish-packages.yml@self
+              parameters:
+                artifactName: ${{ parameters.artifactName }}
+                publishDotNet: ${{ parameters.publishDotNet }}
+                publishPython: ${{ parameters.publishPython }}
+                nugetServiceConnection: ${{ parameters.nugetServiceConnection }}
+                esrpMainPublisher: ${{ parameters.esrpMainPublisher }}

--- a/eng/ci/package-release.yml
+++ b/eng/ci/package-release.yml
@@ -18,10 +18,10 @@ parameters:
     type: string
     default: 'agent-framework-durable-extension-nuget-org'
     displayName: 'NuGet.org service connection'
-  - name: pypiServiceConnection
+  - name: esrpMainPublisher
     type: string
-    default: 'agent-framework-durable-extension-pypi'
-    displayName: 'PyPI service connection'
+    default: 'agent-framework-durable-extension'
+    displayName: 'ESRP main publisher label (PyPI release)'
 
 resources:
   repositories:
@@ -63,4 +63,4 @@ extends:
               publishDotNet: ${{ parameters.publishDotNet }}
               publishPython: ${{ parameters.publishPython }}
               nugetServiceConnection: ${{ parameters.nugetServiceConnection }}
-              pypiServiceConnection: ${{ parameters.pypiServiceConnection }}
+              esrpMainPublisher: ${{ parameters.esrpMainPublisher }}

--- a/eng/templates/official/jobs/build-packages.yml
+++ b/eng/templates/official/jobs/build-packages.yml
@@ -104,8 +104,13 @@ jobs:
               } else {
                 $reader = New-Object System.IO.StreamReader($entry.Open())
                 try { [xml]$nuspec = $reader.ReadToEnd() } finally { $reader.Dispose() }
-                $id = $nuspec.package.metadata.id
-                $version = $nuspec.package.metadata.version
+                # Extract id/version via XPath with local-name() so the lookup is
+                # namespace-agnostic: the generated .nuspec declares a default xmlns
+                # (nuspec.xsd), and namespace-qualified element access is fragile.
+                $idNode = $nuspec.SelectSingleNode("/*[local-name()='package']/*[local-name()='metadata']/*[local-name()='id']")
+                $versionNode = $nuspec.SelectSingleNode("/*[local-name()='package']/*[local-name()='metadata']/*[local-name()='version']")
+                $id = $idNode.InnerText
+                $version = $versionNode.InnerText
                 if ([string]::IsNullOrWhiteSpace($id) -or [string]::IsNullOrWhiteSpace($version)) {
                   Write-Host "##[error]$($pkg.Name) is missing id or version in its .nuspec."
                   $failed = $true

--- a/eng/templates/official/jobs/build-packages.yml
+++ b/eng/templates/official/jobs/build-packages.yml
@@ -103,22 +103,35 @@ jobs:
                 $failed = $true
               } else {
                 $reader = New-Object System.IO.StreamReader($entry.Open())
-                try { [xml]$nuspec = $reader.ReadToEnd() } finally { $reader.Dispose() }
-                # Extract id/version via XPath with local-name() so the lookup is
-                # namespace-agnostic: the generated .nuspec declares a default xmlns
-                # (nuspec.xsd), and namespace-qualified element access is fragile.
-                $idNode = $nuspec.SelectSingleNode("/*[local-name()='package']/*[local-name()='metadata']/*[local-name()='id']")
-                $versionNode = $nuspec.SelectSingleNode("/*[local-name()='package']/*[local-name()='metadata']/*[local-name()='version']")
-                # SelectSingleNode returns $null when the element is absent; guard so a
-                # missing id/version is reported cleanly instead of throwing (which would
-                # also occur under Set-StrictMode).
-                $id = if ($null -ne $idNode) { $idNode.InnerText } else { $null }
-                $version = if ($null -ne $versionNode) { $versionNode.InnerText } else { $null }
-                if ([string]::IsNullOrWhiteSpace($id) -or [string]::IsNullOrWhiteSpace($version)) {
-                  Write-Host "##[error]$($pkg.Name) is missing id or version in its .nuspec."
+                try { $nuspecXml = $reader.ReadToEnd() } finally { $reader.Dispose() }
+                # Parse defensively: an empty or malformed .nuspec would make the [xml]
+                # cast throw and abort the whole loop, skipping remaining packages and
+                # the aggregated summary below. Treat a parse failure as this package's
+                # validation failure and continue.
+                $nuspec = $null
+                try {
+                  $nuspec = [xml]$nuspecXml
+                } catch {
+                  Write-Host "##[error]$($pkg.Name) has an invalid or empty .nuspec: $($_.Exception.Message)"
                   $failed = $true
-                } else {
-                  Write-Host "Validated $id $version ($($pkg.Name))"
+                }
+                if ($null -ne $nuspec) {
+                  # Extract id/version via XPath with local-name() so the lookup is
+                  # namespace-agnostic: the generated .nuspec declares a default xmlns
+                  # (nuspec.xsd), and namespace-qualified element access is fragile.
+                  $idNode = $nuspec.SelectSingleNode("/*[local-name()='package']/*[local-name()='metadata']/*[local-name()='id']")
+                  $versionNode = $nuspec.SelectSingleNode("/*[local-name()='package']/*[local-name()='metadata']/*[local-name()='version']")
+                  # SelectSingleNode returns $null when the element is absent; guard so a
+                  # missing id/version is reported cleanly instead of throwing (which would
+                  # also occur under Set-StrictMode).
+                  $id = if ($null -ne $idNode) { $idNode.InnerText } else { $null }
+                  $version = if ($null -ne $versionNode) { $versionNode.InnerText } else { $null }
+                  if ([string]::IsNullOrWhiteSpace($id) -or [string]::IsNullOrWhiteSpace($version)) {
+                    Write-Host "##[error]$($pkg.Name) is missing id or version in its .nuspec."
+                    $failed = $true
+                  } else {
+                    Write-Host "Validated $id $version ($($pkg.Name))"
+                  }
                 }
               }
             } finally {
@@ -173,9 +186,10 @@ jobs:
       # Validate the built Python distributions without uploading. `twine check`
       # verifies the package metadata (including that the long description renders on
       # PyPI), catching issues that would otherwise only surface at publish time.
-      # twine is installed from the internal feed (pip is authenticated above).
+      # twine is installed from the internal feed (pip is authenticated above) and
+      # pinned for reproducible CI, consistent with the pinned uv version.
       - pwsh: |
-          python -m pip install twine
+          python -m pip install twine==6.1.0
           $pythonDir = "$(Build.ArtifactStagingDirectory)/packages/python"
           $dists = @(Get-ChildItem -File -Path $pythonDir |
             Where-Object { $_.Name.EndsWith(".whl") -or $_.Name.EndsWith(".tar.gz") })

--- a/eng/templates/official/jobs/build-packages.yml
+++ b/eng/templates/official/jobs/build-packages.yml
@@ -109,8 +109,11 @@ jobs:
                 # (nuspec.xsd), and namespace-qualified element access is fragile.
                 $idNode = $nuspec.SelectSingleNode("/*[local-name()='package']/*[local-name()='metadata']/*[local-name()='id']")
                 $versionNode = $nuspec.SelectSingleNode("/*[local-name()='package']/*[local-name()='metadata']/*[local-name()='version']")
-                $id = $idNode.InnerText
-                $version = $versionNode.InnerText
+                # SelectSingleNode returns $null when the element is absent; guard so a
+                # missing id/version is reported cleanly instead of throwing (which would
+                # also occur under Set-StrictMode).
+                $id = if ($null -ne $idNode) { $idNode.InnerText } else { $null }
+                $version = if ($null -ne $versionNode) { $versionNode.InnerText } else { $null }
                 if ([string]::IsNullOrWhiteSpace($id) -or [string]::IsNullOrWhiteSpace($version)) {
                   Write-Host "##[error]$($pkg.Name) is missing id or version in its .nuspec."
                   $failed = $true

--- a/eng/templates/official/jobs/build-packages.yml
+++ b/eng/templates/official/jobs/build-packages.yml
@@ -75,6 +75,54 @@ jobs:
         workingDirectory: dotnet
         displayName: 'Pack .NET packages'
 
+      # Validate the packed .NET packages without pushing to a registry. This catches
+      # packaging regressions early in a dry run: a missing co-located symbol package
+      # (.snupkg), a missing/empty .nuspec, or a missing id/version. The symbol-package
+      # check specifically guards the IncludeSymbols/snupkg setup in nuget-package.props.
+      - pwsh: |
+          $dotnetDir = "$(Build.ArtifactStagingDirectory)/packages/dotnet"
+          $nupkgs = @(Get-ChildItem -File -Path $dotnetDir -Filter *.nupkg)
+          if ($nupkgs.Count -eq 0) {
+            throw "No .nupkg packages were produced in $dotnetDir."
+          }
+
+          Add-Type -AssemblyName System.IO.Compression.FileSystem
+          $failed = $false
+          foreach ($pkg in $nupkgs) {
+            $snupkg = [System.IO.Path]::ChangeExtension($pkg.FullName, ".snupkg")
+            if (-not (Test-Path $snupkg)) {
+              Write-Host "##[error]Missing symbol package for $($pkg.Name) (expected $([System.IO.Path]::GetFileName($snupkg)))."
+              $failed = $true
+            }
+
+            $zip = [System.IO.Compression.ZipFile]::OpenRead($pkg.FullName)
+            try {
+              $entry = $zip.Entries | Where-Object { $_.FullName.EndsWith(".nuspec") } | Select-Object -First 1
+              if ($null -eq $entry) {
+                Write-Host "##[error]$($pkg.Name) does not contain a .nuspec."
+                $failed = $true
+              } else {
+                $reader = New-Object System.IO.StreamReader($entry.Open())
+                try { [xml]$nuspec = $reader.ReadToEnd() } finally { $reader.Dispose() }
+                $id = $nuspec.package.metadata.id
+                $version = $nuspec.package.metadata.version
+                if ([string]::IsNullOrWhiteSpace($id) -or [string]::IsNullOrWhiteSpace($version)) {
+                  Write-Host "##[error]$($pkg.Name) is missing id or version in its .nuspec."
+                  $failed = $true
+                } else {
+                  Write-Host "Validated $id $version ($($pkg.Name))"
+                }
+              }
+            } finally {
+              $zip.Dispose()
+            }
+          }
+
+          if ($failed) {
+            throw "One or more .NET packages failed validation."
+          }
+        displayName: 'Validate .NET packages'
+
       - pwsh: uv sync --all-packages --group dev --group test
         workingDirectory: python
         displayName: 'Sync Python workspace'
@@ -113,6 +161,21 @@ jobs:
           # uv build resolves the build backend (flit-core) in an isolated environment.
           # The governed pool blocks PyPI, so point uv at the authenticated internal feed.
           UV_INDEX_URL: $(PIP_INDEX_URL)
+
+      # Validate the built Python distributions without uploading. `twine check`
+      # verifies the package metadata (including that the long description renders on
+      # PyPI), catching issues that would otherwise only surface at publish time.
+      # twine is installed from the internal feed (pip is authenticated above).
+      - pwsh: |
+          python -m pip install twine
+          $pythonDir = "$(Build.ArtifactStagingDirectory)/packages/python"
+          $dists = @(Get-ChildItem -File -Path $pythonDir |
+            Where-Object { $_.Name.EndsWith(".whl") -or $_.Name.EndsWith(".tar.gz") })
+          if ($dists.Count -eq 0) {
+            throw "No Python distributions were produced in $pythonDir."
+          }
+          python -m twine check @($dists.FullName)
+        displayName: 'Validate Python package (twine check)'
 
       - pwsh: Get-ChildItem -Recurse "$(Build.ArtifactStagingDirectory)/packages" | Select-Object -ExpandProperty FullName
         displayName: 'List package artifacts'

--- a/eng/templates/official/jobs/build-packages.yml
+++ b/eng/templates/official/jobs/build-packages.yml
@@ -70,8 +70,14 @@ jobs:
 
       - pwsh: |
           New-Item -ItemType Directory -Force -Path "$(Build.ArtifactStagingDirectory)/packages/dotnet" | Out-Null
-          dotnet pack src/Microsoft.Agents.AI.DurableTask/Microsoft.Agents.AI.DurableTask.csproj --configuration Release --no-build --output "$(Build.ArtifactStagingDirectory)/packages/dotnet"
-          dotnet pack src/Microsoft.Agents.AI.Hosting.AzureFunctions/Microsoft.Agents.AI.Hosting.AzureFunctions.csproj --configuration Release --no-build --output "$(Build.ArtifactStagingDirectory)/packages/dotnet"
+          # Pass the output directory as an explicit MSBuild property rather than the
+          # `dotnet pack --output` switch. On .NET SDK 10.0.3xx, `--output` is forwarded
+          # to MSBuild as a bare `PackageOutputPath=<dir>` token (missing the -p: prefix),
+          # which MSBuild treats as a second project and fails with MSB1008 ("Only one
+          # project can be specified"). The whole -p: arg is quoted so PowerShell passes
+          # it through as a single literal argument.
+          dotnet pack src/Microsoft.Agents.AI.DurableTask/Microsoft.Agents.AI.DurableTask.csproj --configuration Release --no-build "-p:PackageOutputPath=$(Build.ArtifactStagingDirectory)/packages/dotnet"
+          dotnet pack src/Microsoft.Agents.AI.Hosting.AzureFunctions/Microsoft.Agents.AI.Hosting.AzureFunctions.csproj --configuration Release --no-build "-p:PackageOutputPath=$(Build.ArtifactStagingDirectory)/packages/dotnet"
         workingDirectory: dotnet
         displayName: 'Pack .NET packages'
 

--- a/eng/templates/official/jobs/build-packages.yml
+++ b/eng/templates/official/jobs/build-packages.yml
@@ -101,7 +101,13 @@ jobs:
               $failed = $true
             }
 
-            $zip = [System.IO.Compression.ZipFile]::OpenRead($pkg.FullName)
+            try {
+              $zip = [System.IO.Compression.ZipFile]::OpenRead($pkg.FullName)
+            } catch {
+              Write-Host "##[error]Unable to read $($pkg.Name) as a NuGet package: $($_.Exception.Message)"
+              $failed = $true
+              continue
+            }
             try {
               $entry = $zip.Entries | Where-Object { $_.FullName.EndsWith(".nuspec") } | Select-Object -First 1
               if ($null -eq $entry) {

--- a/eng/templates/official/jobs/publish-packages.yml
+++ b/eng/templates/official/jobs/publish-packages.yml
@@ -122,7 +122,7 @@ jobs:
     steps:
       - checkout: none
 
-      - task: EsrpRelease@9
+      - task: SFP.release-tasks.custom-build-release-task.EsrpRelease@9
         displayName: 'ESRP release Python package to PyPI'
         inputs:
           connectedservicename: ${{ parameters.esrpServiceConnection }}

--- a/eng/templates/official/jobs/publish-packages.yml
+++ b/eng/templates/official/jobs/publish-packages.yml
@@ -34,42 +34,50 @@ jobs:
     dependsOn: ValidateRelease
     condition: and(succeeded(), ${{ eq(parameters.publishDotNet, true) }})
     displayName: 'Publish .NET packages'
+    templateContext:
+      outputs:
+        # 1ES requires NuGet packages to be published through its `output: nuget`
+        # construct (or the 1ES.PublishNuget@1 inline task). The raw NuGetCommand@2
+        # push task is blocked by the governed 1ES.Official template
+        # (see https://aka.ms/1espt/outputs/nuget).
+        #
+        # useDotNetTask runs `dotnet nuget push`, which also auto-publishes the
+        # co-located .snupkg symbol packages (IncludeSymbols + SymbolPackageFormat
+        # =snupkg in dotnet/nuget/nuget-package.props) to NuGet.org's symbol server,
+        # so no separate symbol-package push step is needed.
+        #
+        # packageParentPath must be a sub-directory (not the Pipeline.Workspace or
+        # ArtifactStagingDirectory root): 1ES injects SDL binary analysis on it.
+        #
+        # Note on reruns: pushing an already-published version fails with HTTP 409.
+        # Releases bump the version each time and publishing is gated behind the
+        # manual validation above, so on a partial failure, bump the version or
+        # remove the already-published package before rerunning.
+        - output: nuget
+          useDotNetTask: true
+          packagesToPush: '$(Pipeline.Workspace)/${{ parameters.artifactName }}/dotnet/*.nupkg'
+          packageParentPath: '$(Pipeline.Workspace)/${{ parameters.artifactName }}/dotnet'
+          nuGetFeedType: external
+          publishFeedCredentials: ${{ parameters.nugetServiceConnection }}
+          publishPackageMetadata: true
     steps:
       - checkout: none
 
       - download: current
         artifact: ${{ parameters.artifactName }}
 
-      # Note on reruns: NuGetCommand@2's skip-duplicate (allowPackageConflicts) only
-      # applies to Azure Artifacts feeds, not external registries like NuGet.org, so it
-      # is not set here. A rerun that re-pushes an already-published version will fail
-      # with HTTP 409. Releases bump the package version each time, and publishing is
-      # gated behind the manual validation above, so this is expected: on a partial
-      # failure, bump the version or remove the already-published package before rerunning.
-      - task: NuGetCommand@2
-        displayName: 'Push .NET packages to NuGet.org'
-        inputs:
-          command: push
-          packagesToPush: '$(Pipeline.Workspace)/${{ parameters.artifactName }}/dotnet/*.nupkg'
-          nuGetFeedType: external
-          publishFeedCredentials: ${{ parameters.nugetServiceConnection }}
-
-      # NuGetCommand@2 does not auto-push co-located symbol packages, so publish the
-      # .snupkg files explicitly. The repo produces symbol packages (IncludeSymbols +
-      # SymbolPackageFormat=snupkg in dotnet/nuget/nuget-package.props); without this
-      # step, symbols would silently stop reaching NuGet.org's symbol server.
-      - task: NuGetCommand@2
-        displayName: 'Push .NET symbol packages to NuGet.org'
-        inputs:
-          command: push
-          packagesToPush: '$(Pipeline.Workspace)/${{ parameters.artifactName }}/dotnet/*.snupkg'
-          nuGetFeedType: external
-          publishFeedCredentials: ${{ parameters.nugetServiceConnection }}
-
   - job: PublishPython
     dependsOn: ValidateRelease
     condition: and(succeeded(), ${{ eq(parameters.publishPython, true) }})
     displayName: 'Publish Python package'
+    # NOTE: This job publishes to PyPI directly via `twine upload`. That works for a
+    # standard-network agent, but the governed 1ES pool cannot reach upload.pypi.org,
+    # so a real release from that pool will require the sanctioned partner-drops path
+    # instead (stage the wheel/sdist to the azure-sdk-partner-drops blob, then trigger
+    # the Azure SDK partner-release pipeline that publishes to PyPI). 1ES has no native
+    # PyPI output construct. This is left as direct twine for now because publishing is
+    # disabled by default (publishPython=false) and the dry run never runs this job;
+    # revisit before enabling a real Python release.
     steps:
       - checkout: none
 

--- a/eng/templates/official/jobs/publish-packages.yml
+++ b/eng/templates/official/jobs/publish-packages.yml
@@ -111,11 +111,16 @@ jobs:
       type: releaseJob
       isProduction: true
       environment: ${{ parameters.pypiEnvironment }}
+      # 1ES release jobs disallow the raw `- download` step; declare the build
+      # artifact as a pipelineArtifact input instead (see https://aka.ms/1espt/inputs).
+      # No `pipeline:` resource is needed for a current-run artifact — it downloads the
+      # artifact produced by the BuildPackages stage of this same run to targetPath.
+      inputs:
+        - input: pipelineArtifact
+          artifactName: ${{ parameters.artifactName }}
+          targetPath: '$(Pipeline.Workspace)/${{ parameters.artifactName }}'
     steps:
       - checkout: none
-
-      - download: current
-        artifact: ${{ parameters.artifactName }}
 
       - task: EsrpRelease@9
         displayName: 'ESRP release Python package to PyPI'
@@ -128,7 +133,7 @@ jobs:
           intent: 'PackageDistribution'
           contenttype: 'PyPi'
           # Point ESRP at the folder holding the built wheel/sdist that the
-          # BuildPackages stage produced and this job downloaded.
+          # BuildPackages stage produced and the pipelineArtifact input downloaded.
           contentsource: 'Folder'
           folderlocation: '$(Pipeline.Workspace)/${{ parameters.artifactName }}/python'
           waitforreleasecompletion: true

--- a/eng/templates/official/jobs/publish-packages.yml
+++ b/eng/templates/official/jobs/publish-packages.yml
@@ -75,12 +75,15 @@ jobs:
     displayName: 'Publish Python package'
     # NOTE: This job publishes to PyPI directly via `twine upload`. That works for a
     # standard-network agent, but the governed 1ES pool cannot reach upload.pypi.org,
-    # so a real release from that pool will require the sanctioned partner-drops path
-    # instead (stage the wheel/sdist to the azure-sdk-partner-drops blob, then trigger
-    # the Azure SDK partner-release pipeline that publishes to PyPI). 1ES has no native
-    # PyPI output construct. This is left as direct twine for now because publishing is
-    # disabled by default (publishPython=false) and the dry run never runs this job;
-    # revisit before enabling a real Python release.
+    # and direct twine upload is not the sanctioned Microsoft release path. The
+    # recommended approach (used by the sibling microsoft/durabletask-python project)
+    # is the ESRP Release task (EsrpRelease@9 with contenttype: PyPi) inside a
+    # templateContext releaseJob gated by an ADO environment, reusing the Durable Task
+    # team's ESRP service connection / key vault / signing cert. ESRP can also publish
+    # NuGet (contenttype: NuGet), so both package types could eventually be unified
+    # under it. This is left as direct twine for now because publishing is disabled by
+    # default (publishPython=false) and the dry run never runs this job; replace with
+    # the ESRP releaseJob before enabling a real Python release.
     steps:
       - checkout: none
 

--- a/eng/templates/official/jobs/publish-packages.yml
+++ b/eng/templates/official/jobs/publish-packages.yml
@@ -11,9 +11,38 @@ parameters:
   - name: nugetServiceConnection
     type: string
     default: 'agent-framework-durable-extension-nuget-org'
-  - name: pypiServiceConnection
+  # ESRP is the sanctioned Microsoft release path for PyPI (there is no 1ES PyPI
+  # output and the governed pool cannot reach pypi.org). These defaults reuse the
+  # Durable Task team's existing ESRP registration, matching the sibling
+  # microsoft/durabletask-python pipeline. Credentials are never in the repo: ESRP
+  # authenticates via a managed identity and a Key Vault signing certificate.
+  - name: esrpServiceConnection
     type: string
-    default: 'agent-framework-durable-extension-pypi'
+    default: 'dtfx-internal-esrp-prod'
+  - name: esrpKeyVaultName
+    type: string
+    default: 'durable-esrp-akv'
+  - name: esrpSignCertName
+    type: string
+    default: 'dts-esrp-cert'
+  - name: esrpClientId
+    type: string
+    default: '0b3ed1a4-0727-4a50-b82a-02c2bd9dec89'
+  - name: esrpDomainTenantId
+    type: string
+    default: '33e01921-4d64-4f8c-a055-5bdaffd5e33d'
+  # ESRP release label. It is NOT bound to the target registry: durabletask-python
+  # publishes Python packages with a "durabletask-java" value against this same ESRP
+  # registration, confirming it is a free-form label. Set to this project's name.
+  - name: esrpMainPublisher
+    type: string
+    default: 'agent-framework-durable-extension'
+  # ADO environment used to satisfy the 1ES release-job requirement. Defaults to the
+  # Durable Task team's existing PyPI production environment so it resolves without
+  # provisioning a new one; switch to a dedicated environment later if desired.
+  - name: pypiEnvironment
+    type: string
+    default: 'durabletask-pypi-prod'
 
 jobs:
   - job: ValidateRelease
@@ -73,59 +102,40 @@ jobs:
     dependsOn: ValidateRelease
     condition: and(succeeded(), ${{ eq(parameters.publishPython, true) }})
     displayName: 'Publish Python package'
-    # NOTE: This job publishes to PyPI directly via `twine upload`. That works for a
-    # standard-network agent, but the governed 1ES pool cannot reach upload.pypi.org,
-    # and direct twine upload is not the sanctioned Microsoft release path. The
-    # recommended approach (used by the sibling microsoft/durabletask-python project)
-    # is the ESRP Release task (EsrpRelease@9 with contenttype: PyPi) inside a
-    # templateContext releaseJob gated by an ADO environment, reusing the Durable Task
-    # team's ESRP service connection / key vault / signing cert. ESRP can also publish
-    # NuGet (contenttype: NuGet), so both package types could eventually be unified
-    # under it. This is left as direct twine for now because publishing is disabled by
-    # default (publishPython=false) and the dry run never runs this job; replace with
-    # the ESRP releaseJob before enabling a real Python release.
+    # Publishes to PyPI through ESRP, the sanctioned Microsoft release path (used by
+    # the sibling microsoft/durabletask-python project), reusing the Durable Task
+    # team's ESRP registration. ESRP authenticates with a managed identity + Key Vault
+    # signing certificate, so no PyPI credentials live in this repo. 1ES requires
+    # production release work to run in a releaseJob bound to an environment.
+    templateContext:
+      type: releaseJob
+      isProduction: true
+      environment: ${{ parameters.pypiEnvironment }}
     steps:
       - checkout: none
 
       - download: current
         artifact: ${{ parameters.artifactName }}
 
-      - task: UsePythonVersion@0
-        displayName: 'Use Python 3.13'
+      - task: EsrpRelease@9
+        displayName: 'ESRP release Python package to PyPI'
         inputs:
-          versionSpec: '3.13'
-
-      # Authenticate to the internal feed before installing twine. The governed pool
-      # cannot reach PyPI directly, so pip must install twine from the authenticated
-      # feed (via the PIP_INDEX_URL this task sets).
-      - task: PipAuthenticate@1
-        displayName: 'Authenticate to Azure Artifacts feed'
-        inputs:
-          artifactFeeds: 'internal/upstream'
-
-      - pwsh: python -m pip install --upgrade pip twine
-        displayName: 'Install Twine'
-
-      - task: TwineAuthenticate@1
-        displayName: 'Authenticate to PyPI'
-        inputs:
-          pythonUploadServiceConnection: ${{ parameters.pypiServiceConnection }}
-
-      # TwineAuthenticate writes a .pypirc whose repository section is named after the
-      # service connection, so `--repository` must be that same service connection name
-      # (this matches the documented pattern for external PyPI upload connections).
-      - pwsh: |
-          # Force array context with @(...) so .Count is reliable even when
-          # Get-ChildItem returns nothing ($null) or a single item.
-          $packages = @(Get-ChildItem -File "$(Pipeline.Workspace)/${{ parameters.artifactName }}/python" |
-            Where-Object { $_.Name.EndsWith(".whl") -or $_.Name.EndsWith(".tar.gz") })
-          if ($packages.Count -eq 0) {
-            throw "No Python packages were found."
-          }
-
-          python -m twine upload `
-            --non-interactive `
-            --repository "${{ parameters.pypiServiceConnection }}" `
-            --config-file "$(PYPIRC_PATH)" `
-            @($packages.FullName)
-        displayName: 'Upload Python package to PyPI'
+          connectedservicename: ${{ parameters.esrpServiceConnection }}
+          usemanagedidentity: true
+          keyvaultname: ${{ parameters.esrpKeyVaultName }}
+          signcertname: ${{ parameters.esrpSignCertName }}
+          clientid: ${{ parameters.esrpClientId }}
+          intent: 'PackageDistribution'
+          contenttype: 'PyPi'
+          # Point ESRP at the folder holding the built wheel/sdist that the
+          # BuildPackages stage produced and this job downloaded.
+          contentsource: 'Folder'
+          folderlocation: '$(Pipeline.Workspace)/${{ parameters.artifactName }}/python'
+          waitforreleasecompletion: true
+          # Auto-populate owner/approver from whoever queued the run so no personal
+          # emails are hardcoded in source (matches the durabletask-python pattern).
+          owners: $(Build.RequestedForEmail)
+          approvers: $(Build.RequestedForEmail)
+          serviceendpointurl: 'https://api.esrp.microsoft.com'
+          mainpublisher: ${{ parameters.esrpMainPublisher }}
+          domaintenantid: ${{ parameters.esrpDomainTenantId }}

--- a/eng/templates/official/jobs/publish-packages.yml
+++ b/eng/templates/official/jobs/publish-packages.yml
@@ -41,10 +41,13 @@ jobs:
         # push task is blocked by the governed 1ES.Official template
         # (see https://aka.ms/1espt/outputs/nuget).
         #
-        # useDotNetTask runs `dotnet nuget push`, which also auto-publishes the
-        # co-located .snupkg symbol packages (IncludeSymbols + SymbolPackageFormat
-        # =snupkg in dotnet/nuget/nuget-package.props) to NuGet.org's symbol server,
-        # so no separate symbol-package push step is needed.
+        # useDotNetTask runs `dotnet nuget push`. Unlike nuget.exe, `dotnet nuget push`
+        # does NOT auto-publish a co-located .snupkg when pushing the .nupkg, so the
+        # symbol packages (IncludeSymbols + SymbolPackageFormat=snupkg in
+        # dotnet/nuget/nuget-package.props) are pushed explicitly by including the
+        # *.snupkg pattern below. The *.nupkg pattern is listed first so the primary
+        # package publishes before its symbols. nuget.org routes .snupkg to its symbol
+        # server, so this does not conflict with the primary package push.
         #
         # packageParentPath must be a sub-directory (not the Pipeline.Workspace or
         # ArtifactStagingDirectory root): 1ES injects SDL binary analysis on it.
@@ -55,7 +58,7 @@ jobs:
         # remove the already-published package before rerunning.
         - output: nuget
           useDotNetTask: true
-          packagesToPush: '$(Pipeline.Workspace)/${{ parameters.artifactName }}/dotnet/*.nupkg'
+          packagesToPush: '$(Pipeline.Workspace)/${{ parameters.artifactName }}/dotnet/*.nupkg;$(Pipeline.Workspace)/${{ parameters.artifactName }}/dotnet/*.snupkg'
           packageParentPath: '$(Pipeline.Workspace)/${{ parameters.artifactName }}/dotnet'
           nuGetFeedType: external
           publishFeedCredentials: ${{ parameters.nugetServiceConnection }}

--- a/eng/templates/official/jobs/publish-packages.yml
+++ b/eng/templates/official/jobs/publish-packages.yml
@@ -59,88 +59,90 @@ jobs:
             Confirm package versions are correct and have not already been published.
             Resume only when ready to publish selected package types.
 
-  - job: PublishDotNet
-    dependsOn: ValidateRelease
-    condition: and(succeeded(), ${{ eq(parameters.publishDotNet, true) }})
-    displayName: 'Publish .NET packages'
-    templateContext:
-      outputs:
-        # 1ES requires NuGet packages to be published through its `output: nuget`
-        # construct (or the 1ES.PublishNuget@1 inline task). The raw NuGetCommand@2
-        # push task is blocked by the governed 1ES.Official template
-        # (see https://aka.ms/1espt/outputs/nuget).
-        #
-        # useDotNetTask runs `dotnet nuget push`. Unlike nuget.exe, `dotnet nuget push`
-        # does NOT auto-publish a co-located .snupkg when pushing the .nupkg, so the
-        # symbol packages (IncludeSymbols + SymbolPackageFormat=snupkg in
-        # dotnet/nuget/nuget-package.props) are pushed explicitly by including the
-        # *.snupkg pattern below. The *.nupkg pattern is listed first so the primary
-        # package publishes before its symbols. nuget.org routes .snupkg to its symbol
-        # server, so this does not conflict with the primary package push.
-        #
-        # packageParentPath must be a sub-directory (not the Pipeline.Workspace or
-        # ArtifactStagingDirectory root): 1ES injects SDL binary analysis on it.
-        #
-        # Note on reruns: pushing an already-published version fails with HTTP 409.
-        # Releases bump the version each time and publishing is gated behind the
-        # manual validation above, so on a partial failure, bump the version or
-        # remove the already-published package before rerunning.
-        - output: nuget
-          useDotNetTask: true
-          packagesToPush: '$(Pipeline.Workspace)/${{ parameters.artifactName }}/dotnet/*.nupkg;$(Pipeline.Workspace)/${{ parameters.artifactName }}/dotnet/*.snupkg'
-          packageParentPath: '$(Pipeline.Workspace)/${{ parameters.artifactName }}/dotnet'
-          nuGetFeedType: external
-          publishFeedCredentials: ${{ parameters.nugetServiceConnection }}
-          publishPackageMetadata: true
-    steps:
-      - checkout: none
+  - ${{ if eq(parameters.publishDotNet, true) }}:
+    - job: PublishDotNet
+      dependsOn: ValidateRelease
+      condition: succeeded()
+      displayName: 'Publish .NET packages'
+      templateContext:
+        outputs:
+          # 1ES requires NuGet packages to be published through its `output: nuget`
+          # construct (or the 1ES.PublishNuget@1 inline task). The raw NuGetCommand@2
+          # push task is blocked by the governed 1ES.Official template
+          # (see https://aka.ms/1espt/outputs/nuget).
+          #
+          # useDotNetTask runs `dotnet nuget push`. Unlike nuget.exe, `dotnet nuget push`
+          # does NOT auto-publish a co-located .snupkg when pushing the .nupkg, so the
+          # symbol packages (IncludeSymbols + SymbolPackageFormat=snupkg in
+          # dotnet/nuget/nuget-package.props) are pushed explicitly by including the
+          # *.snupkg pattern below. The *.nupkg pattern is listed first so the primary
+          # package publishes before its symbols. nuget.org routes .snupkg to its symbol
+          # server, so this does not conflict with the primary package push.
+          #
+          # packageParentPath must be a sub-directory (not the Pipeline.Workspace or
+          # ArtifactStagingDirectory root): 1ES injects SDL binary analysis on it.
+          #
+          # Note on reruns: pushing an already-published version fails with HTTP 409.
+          # Releases bump the version each time and publishing is gated behind the
+          # manual validation above, so on a partial failure, bump the version or
+          # remove the already-published package before rerunning.
+          - output: nuget
+            useDotNetTask: true
+            packagesToPush: '$(Pipeline.Workspace)/${{ parameters.artifactName }}/dotnet/*.nupkg;$(Pipeline.Workspace)/${{ parameters.artifactName }}/dotnet/*.snupkg'
+            packageParentPath: '$(Pipeline.Workspace)/${{ parameters.artifactName }}/dotnet'
+            nuGetFeedType: external
+            publishFeedCredentials: ${{ parameters.nugetServiceConnection }}
+            publishPackageMetadata: true
+      steps:
+        - checkout: none
 
-      - download: current
-        artifact: ${{ parameters.artifactName }}
+        - download: current
+          artifact: ${{ parameters.artifactName }}
 
-  - job: PublishPython
-    dependsOn: ValidateRelease
-    condition: and(succeeded(), ${{ eq(parameters.publishPython, true) }})
-    displayName: 'Publish Python package'
-    # Publishes to PyPI through ESRP, the sanctioned Microsoft release path (used by
-    # the sibling microsoft/durabletask-python project), reusing the Durable Task
-    # team's ESRP registration. ESRP authenticates with a managed identity + Key Vault
-    # signing certificate, so no PyPI credentials live in this repo. 1ES requires
-    # production release work to run in a releaseJob bound to an environment.
-    templateContext:
-      type: releaseJob
-      isProduction: true
-      environment: ${{ parameters.pypiEnvironment }}
-      # 1ES release jobs disallow the raw `- download` step; declare the build
-      # artifact as a pipelineArtifact input instead (see https://aka.ms/1espt/inputs).
-      # No `pipeline:` resource is needed for a current-run artifact — it downloads the
-      # artifact produced by the BuildPackages stage of this same run to targetPath.
-      inputs:
-        - input: pipelineArtifact
-          artifactName: ${{ parameters.artifactName }}
-          targetPath: '$(Pipeline.Workspace)/${{ parameters.artifactName }}'
-    steps:
-      - checkout: none
-
-      - task: SFP.release-tasks.custom-build-release-task.EsrpRelease@9
-        displayName: 'ESRP release Python package to PyPI'
+  - ${{ if eq(parameters.publishPython, true) }}:
+    - job: PublishPython
+      dependsOn: ValidateRelease
+      condition: succeeded()
+      displayName: 'Publish Python package'
+      # Publishes to PyPI through ESRP, the sanctioned Microsoft release path (used by
+      # the sibling microsoft/durabletask-python project), reusing the Durable Task
+      # team's ESRP registration. ESRP authenticates with a managed identity + Key Vault
+      # signing certificate, so no PyPI credentials live in this repo. 1ES requires
+      # production release work to run in a releaseJob bound to an environment.
+      templateContext:
+        type: releaseJob
+        isProduction: true
+        environment: ${{ parameters.pypiEnvironment }}
+        # 1ES release jobs disallow the raw `- download` step; declare the build
+        # artifact as a pipelineArtifact input instead (see https://aka.ms/1espt/inputs).
+        # No `pipeline:` resource is needed for a current-run artifact — it downloads the
+        # artifact produced by the BuildPackages stage of this same run to targetPath.
         inputs:
-          connectedservicename: ${{ parameters.esrpServiceConnection }}
-          usemanagedidentity: true
-          keyvaultname: ${{ parameters.esrpKeyVaultName }}
-          signcertname: ${{ parameters.esrpSignCertName }}
-          clientid: ${{ parameters.esrpClientId }}
-          intent: 'PackageDistribution'
-          contenttype: 'PyPi'
-          # Point ESRP at the folder holding the built wheel/sdist that the
-          # BuildPackages stage produced and the pipelineArtifact input downloaded.
-          contentsource: 'Folder'
-          folderlocation: '$(Pipeline.Workspace)/${{ parameters.artifactName }}/python'
-          waitforreleasecompletion: true
-          # Auto-populate owner/approver from whoever queued the run so no personal
-          # emails are hardcoded in source (matches the durabletask-python pattern).
-          owners: $(Build.RequestedForEmail)
-          approvers: $(Build.RequestedForEmail)
-          serviceendpointurl: 'https://api.esrp.microsoft.com'
-          mainpublisher: ${{ parameters.esrpMainPublisher }}
-          domaintenantid: ${{ parameters.esrpDomainTenantId }}
+          - input: pipelineArtifact
+            artifactName: ${{ parameters.artifactName }}
+            targetPath: '$(Pipeline.Workspace)/${{ parameters.artifactName }}'
+      steps:
+        - checkout: none
+
+        - task: SFP.release-tasks.custom-build-release-task.EsrpRelease@9
+          displayName: 'ESRP release Python package to PyPI'
+          inputs:
+            connectedservicename: ${{ parameters.esrpServiceConnection }}
+            usemanagedidentity: true
+            keyvaultname: ${{ parameters.esrpKeyVaultName }}
+            signcertname: ${{ parameters.esrpSignCertName }}
+            clientid: ${{ parameters.esrpClientId }}
+            intent: 'PackageDistribution'
+            contenttype: 'PyPi'
+            # Point ESRP at the folder holding the built wheel/sdist that the
+            # BuildPackages stage produced and the pipelineArtifact input downloaded.
+            contentsource: 'Folder'
+            folderlocation: '$(Pipeline.Workspace)/${{ parameters.artifactName }}/python'
+            waitforreleasecompletion: true
+            # Auto-populate owner/approver from whoever queued the run so no personal
+            # emails are hardcoded in source (matches the durabletask-python pattern).
+            owners: $(Build.RequestedForEmail)
+            approvers: $(Build.RequestedForEmail)
+            serviceendpointurl: 'https://api.esrp.microsoft.com'
+            mainpublisher: ${{ parameters.esrpMainPublisher }}
+            domaintenantid: ${{ parameters.esrpDomainTenantId }}

--- a/python/packages/durabletask/agent_framework_durabletask/_workflows/orchestrator.py
+++ b/python/packages/durabletask/agent_framework_durabletask/_workflows/orchestrator.py
@@ -889,13 +889,11 @@ def _prepare_all_tasks(
 
     for executor_id, messages_with_sources in pending_messages.items():
         executor = workflow.executors[executor_id]
-        is_agent = isinstance(executor, AgentExecutor)
-        is_subworkflow = isinstance(executor, WorkflowExecutor)
 
         for message, source_executor_id in messages_with_sources:
-            if is_agent:
+            if isinstance(executor, AgentExecutor):
                 agent_messages_by_executor[executor_id].append((executor_id, message, source_executor_id))
-            elif is_subworkflow:
+            elif isinstance(executor, WorkflowExecutor):
                 # Derive a deterministic, globally-unique child instance id. The counter
                 # persists across supersteps, so two invocations of the same node (in the
                 # same or different supersteps, e.g. fan-out) never collide, and the ids

--- a/python/packages/durabletask/agent_framework_durabletask/_workflows/orchestrator.py
+++ b/python/packages/durabletask/agent_framework_durabletask/_workflows/orchestrator.py
@@ -890,10 +890,11 @@ def _prepare_all_tasks(
     for executor_id, messages_with_sources in pending_messages.items():
         executor = workflow.executors[executor_id]
 
-        for message, source_executor_id in messages_with_sources:
-            if isinstance(executor, AgentExecutor):
+        if isinstance(executor, AgentExecutor):
+            for message, source_executor_id in messages_with_sources:
                 agent_messages_by_executor[executor_id].append((executor_id, message, source_executor_id))
-            elif isinstance(executor, WorkflowExecutor):
+        elif isinstance(executor, WorkflowExecutor):
+            for message, source_executor_id in messages_with_sources:
                 # Derive a deterministic, globally-unique child instance id. The counter
                 # persists across supersteps, so two invocations of the same node (in the
                 # same or different supersteps, e.g. fan-out) never collide, and the ids
@@ -923,7 +924,8 @@ def _prepare_all_tasks(
                         child_instance_id=child_instance_id,
                     )
                 )
-            else:
+        else:
+            for message, source_executor_id in messages_with_sources:
                 logger.debug("Preparing activity task: %s", executor_id)
                 task = _prepare_activity_task(
                     ctx, executor_id, message, source_executor_id, shared_state, workflow.name, address


### PR DESCRIPTION
Prepares the release pipeline (`eng/ci/package-release.yml`) so it can be created and dry-run under the governed 1ES.Official template.

## Changes

**1. 1ES NuGet compliance**
The 1ES.Official template blocks the raw `NuGetCommand@2` push task. Replaced it with the 1ES `output: nuget` construct (`useDotNetTask`). Because `dotnet nuget push` does **not** auto-publish a co-located `.snupkg`, the `*.snupkg` pattern is included explicitly in `packagesToPush`.

**2. Governed Python release path**
Replaced direct `twine upload` with the Durable Task team's ESRP registration through the fully-qualified `EsrpRelease@9` task (`contenttype: PyPi`). The configured publisher label is `agent-framework-durable-extension`. Publishing remains opt-in and disabled by default.

**3. Safe, useful dry runs**
Added package-integrity validation to the build stage: `.nupkg`/`.snupkg`/`.nuspec` validation and `twine check` for Python artifacts. Publish stage and each publish job use compile-time gates, preventing 1ES from validating unused NuGet or ESRP service connections during dry runs or single-ecosystem releases.

**4. Discovered Python type-safety correction**
The dry run surfaced a pre-existing mypy error in Durable Task subworkflow dispatch. The dispatch branches now narrow the executor type once per executor rather than once per message; behavior and message ordering remain unchanged.

## Verification
ADO dry run `20260724.5` (build `292870`) completed successfully from this branch with both publish flags false. It built, tested, packed, validated, and published package artifacts without releasing packages.