### PR TITLE
Use "session" instead of "thread" terminology

### DIFF
--- a/TRANSPARENCY_FAQ.md
+++ b/TRANSPARENCY_FAQ.md
@@ -68,7 +68,7 @@ Microsoft Agent Framework relies on existing LLMs. Using the framework retains c
 
 - **Tool Integration**: Careful selection and validation of external tools and MCP servers 
 
-- **Type Safety**: Strong typing and compatibility validation between agents and threads 
+- **Type Safety**: Strong typing and compatibility validation between agents and sessions 
 
  
 
@@ -88,13 +88,13 @@ Microsoft Agent Framework relies on existing LLMs. Using the framework retains c
 
  
 
-**How do I provide feedback on Microsoft Agent Framework?**
+**How do I provide feedback on the Durable Task Extension for Microsoft Agent Framework?**
 
-- **Bug Reports**: File issues at https://github.com/microsoft/agent-framework-durable-extension/issues
+- **Bug Reports**: File issues at <https://github.com/microsoft/agent-framework-durable-extension/issues>
 
 **What are external services and how does Microsoft Agent Framework use them?**
 
-The framework supports multiple external service types: 
+The framework supports multiple external service types:
 
 - **Native Functions**: Custom Python/C# functions that agents can invoke
 - **A2A (Agent2Agent)Integration**: Agent-to-agent communication and coordination

--- a/docs/features/durable-agents/README.md
+++ b/docs/features/durable-agents/README.md
@@ -75,9 +75,12 @@ The recommended production hosting model. A single call to `ConfigureDurableAgen
 
 - Registers agent entities with the Durable Task worker.
 - Generates HTTP endpoints at `/api/agents/{agentName}/run` for each registered agent.
-- Supports `thread_id` query parameter / JSON field and the `x-ms-thread-id` response header for session continuity.
+- Supports the `session_id` query parameter / JSON field and the `x-ms-session-id` response header for session continuity.
 - Supports fire-and-forget via the `x-ms-wait-for-response: false` header (returns HTTP 202).
 - Optionally exposes agents as MCP tools.
+
+> [!NOTE]
+> Preview versions of this extension used `thread_id` instead of `session_id`. The `session_id` parameter is now preferred over the deprecated `thread_id`, and responses only ever return `session_id` / `x-ms-session-id`. If both names are provided they must carry the same value; conflicting values are rejected with HTTP 400.
 
 **C# example:**
 

--- a/dotnet/samples/DurableAgents/AzureFunctions/01_SingleAgent/README.md
+++ b/dotnet/samples/DurableAgents/AzureFunctions/01_SingleAgent/README.md
@@ -44,10 +44,10 @@ curl -X POST http://localhost:7071/api/agents/Joker/run \
     -d '{"message": "Tell me a joke about a pirate."}'
 ```
 
-To continue a conversation, include the `thread_id` in the query string or JSON body:
+To continue a conversation, include the `session_id` in the query string or JSON body:
 
 ```bash
-curl -X POST "http://localhost:7071/api/agents/Joker/run?thread_id=your-thread-id" \
+curl -X POST "http://localhost:7071/api/agents/Joker/run?session_id=your-session-id" \
     -H "Content-Type: application/json" \
     -H "Accept: application/json" \
     -d '{"message": "Tell me another one."}'
@@ -64,7 +64,7 @@ The expected `application/json` output will look something like:
 ```json
 {
   "status": 200,
-  "thread_id": "ee6e47a0-f24b-40b1-ade8-16fcebb9eb40",
+  "session_id": "ee6e47a0-f24b-40b1-ade8-16fcebb9eb40",
   "response": {
     "Messages": [
       {

--- a/dotnet/samples/DurableAgents/AzureFunctions/02_AgentOrchestration_Chaining/README.md
+++ b/dotnet/samples/DurableAgents/AzureFunctions/02_AgentOrchestration_Chaining/README.md
@@ -44,7 +44,7 @@ The response will be a JSON object that looks something like the following, whic
 The orchestration will proceed to run the WriterAgent twice in sequence:
 
 1. First, it writes an inspirational sentence about learning
-2. Then, it refines the initial output using the same conversation thread
+2. Then, it refines the initial output using the same conversation session
 
 Once the orchestration has completed, you can get the status of the orchestration by sending a GET request to the `statusQueryGetUri` URL. The response will be a JSON object that looks something like the following:
 

--- a/dotnet/samples/DurableAgents/AzureFunctions/06_LongRunningTools/README.md
+++ b/dotnet/samples/DurableAgents/AzureFunctions/06_LongRunningTools/README.md
@@ -28,7 +28,7 @@ curl -i -X POST http://localhost:7071/api/agents/publisher/run \
     -H "Content-Type: text/plain" \
     -d 'Start a content generation workflow for the topic \"The Future of Artificial Intelligence\"'
 
-# Save the Session ID to a variable and print it to the terminal
+# Save the session ID to a variable and print it to the terminal
 sessionId=$(cat headers.txt | grep "x-ms-session-id" | cut -d' ' -f2)
 echo "Session ID: $sessionId"
 ```
@@ -42,7 +42,7 @@ Invoke-RestMethod -Method Post `
     -ContentType text/plain `
     -Body 'Start a content generation workflow for the topic \"The Future of Artificial Intelligence\"' `
 
-# Save the Session ID to a variable and print it to the console
+# Save the session ID to a variable and print it to the console
 $sessionId = $ResponseHeaders['x-ms-session-id']
 Write-Host "Session ID: $sessionId"
 ```
@@ -57,7 +57,7 @@ x-ms-session-id: 351ec855-7f4d-4527-a60d-498301ced36d
 The content generation workflow for the topic "The Future of Artificial Intelligence" has been successfully started, and the instance ID is **6a04276e8d824d8d941e1dc4142cc254**. If you need any further assistance or updates on the workflow, feel free to ask!
 ```
 
-The `x-ms-session-id` response header contains the Session ID, which can be used to continue the conversation by passing it as a query parameter (`session_id`) to the `run` endpoint. The commands above show how to save the Session ID to a `$sessionId` variable for use in subsequent requests.
+The `x-ms-session-id` response header contains the session ID, which can be used to continue the conversation by passing it as a query parameter (`session_id`) to the `run` endpoint. The commands above show how to save the session ID to a `$sessionId` variable for use in subsequent requests.
 
 Behind the scenes, the publisher agent will:
 

--- a/dotnet/samples/DurableAgents/AzureFunctions/06_LongRunningTools/README.md
+++ b/dotnet/samples/DurableAgents/AzureFunctions/06_LongRunningTools/README.md
@@ -28,9 +28,9 @@ curl -i -X POST http://localhost:7071/api/agents/publisher/run \
     -H "Content-Type: text/plain" \
     -d 'Start a content generation workflow for the topic \"The Future of Artificial Intelligence\"'
 
-# Save the thread ID to a variable and print it to the terminal
-threadId=$(cat headers.txt | grep "x-ms-thread-id" | cut -d' ' -f2)
-echo "Thread ID: $threadId"
+# Save the Session ID to a variable and print it to the terminal
+sessionId=$(cat headers.txt | grep "x-ms-session-id" | cut -d' ' -f2)
+echo "Session ID: $sessionId"
 ```
 
 PowerShell:
@@ -42,9 +42,9 @@ Invoke-RestMethod -Method Post `
     -ContentType text/plain `
     -Body 'Start a content generation workflow for the topic \"The Future of Artificial Intelligence\"' `
 
-# Save the thread ID to a variable and print it to the console
-$threadId = $ResponseHeaders['x-ms-thread-id']
-Write-Host "Thread ID: $threadId"
+# Save the Session ID to a variable and print it to the console
+$sessionId = $ResponseHeaders['x-ms-session-id']
+Write-Host "Session ID: $sessionId"
 ```
 
 The response will be a text string that looks something like the following, indicating that the agent request has been received and will be processed:
@@ -52,12 +52,12 @@ The response will be a text string that looks something like the following, indi
 ```http
 HTTP/1.1 200 OK
 Content-Type: text/plain
-x-ms-thread-id: 351ec855-7f4d-4527-a60d-498301ced36d
+x-ms-session-id: 351ec855-7f4d-4527-a60d-498301ced36d
 
 The content generation workflow for the topic "The Future of Artificial Intelligence" has been successfully started, and the instance ID is **6a04276e8d824d8d941e1dc4142cc254**. If you need any further assistance or updates on the workflow, feel free to ask!
 ```
 
-The `x-ms-thread-id` response header contains the thread ID, which can be used to continue the conversation by passing it as a query parameter (`thread_id`) to the `run` endpoint. The commands above show how to save the thread ID to a `$threadId` variable for use in subsequent requests.
+The `x-ms-session-id` response header contains the Session ID, which can be used to continue the conversation by passing it as a query parameter (`session_id`) to the `run` endpoint. The commands above show how to save the Session ID to a `$sessionId` variable for use in subsequent requests.
 
 Behind the scenes, the publisher agent will:
 
@@ -70,12 +70,12 @@ Bash (Linux/macOS/WSL):
 
 ```bash
 # Approve the content
-curl -X POST "http://localhost:7071/api/agents/publisher/run?thread_id=$threadId" \
+curl -X POST "http://localhost:7071/api/agents/publisher/run?session_id=$sessionId" \
     -H "Content-Type: text/plain" \
     -d 'Approve the content'
 
 # Reject the content with feedback
-curl -X POST "http://localhost:7071/api/agents/publisher/run?thread_id=$threadId" \
+curl -X POST "http://localhost:7071/api/agents/publisher/run?session_id=$sessionId" \
     -H "Content-Type: text/plain" \
     -d 'Reject the content with feedback: The article needs more technical depth and better examples.'
 ```
@@ -85,13 +85,13 @@ PowerShell:
 ```powershell
 # Approve the content
 Invoke-RestMethod -Method Post `
-    -Uri "http://localhost:7071/api/agents/publisher/run?thread_id=$threadId" `
+    -Uri "http://localhost:7071/api/agents/publisher/run?session_id=$sessionId" `
     -ContentType text/plain `
     -Body 'Approve the content'
 
 # Reject the content with feedback
 Invoke-RestMethod -Method Post `
-    -Uri "http://localhost:7071/api/agents/publisher/run?thread_id=$threadId" `
+    -Uri "http://localhost:7071/api/agents/publisher/run?session_id=$sessionId" `
     -ContentType text/plain `
     -Body 'Reject the content with feedback: The article needs more technical depth and better examples.'
 ```
@@ -101,7 +101,7 @@ Once the workflow has completed, you can get the status by prompting the publish
 Bash (Linux/macOS/WSL):
 
 ```bash
-curl -X POST "http://localhost:7071/api/agents/publisher/run?thread_id=$threadId" \
+curl -X POST "http://localhost:7071/api/agents/publisher/run?session_id=$sessionId" \
     -H "Content-Type: text/plain" \
     -d 'Get the status of the workflow you previously started'
 ```
@@ -110,7 +110,7 @@ PowerShell:
 
 ```powershell
 Invoke-RestMethod -Method Post `
-    -Uri "http://localhost:7071/api/agents/publisher/run?thread_id=$threadId" `
+    -Uri "http://localhost:7071/api/agents/publisher/run?session_id=$sessionId" `
     -ContentType text/plain `
     -Body 'Get the status of the workflow you previously started'
 ```

--- a/dotnet/samples/DurableAgents/AzureFunctions/06_LongRunningTools/demo.http
+++ b/dotnet/samples/DurableAgents/AzureFunctions/06_LongRunningTools/demo.http
@@ -6,7 +6,7 @@ Start a content generation workflow for the topic 'The Future of Artificial Inte
 
 
 ### Save the session ID from the response to continue the conversation
-@sessionId = <YOUR_session_id>
+@sessionId = <YOUR_SESSION_ID>
 
 ### Check the status of the workflow
 POST http://localhost:7071/api/agents/publisher/run?session_id={{sessionId}}

--- a/dotnet/samples/DurableAgents/AzureFunctions/06_LongRunningTools/demo.http
+++ b/dotnet/samples/DurableAgents/AzureFunctions/06_LongRunningTools/demo.http
@@ -6,22 +6,22 @@ Start a content generation workflow for the topic 'The Future of Artificial Inte
 
 
 ### Save the session ID from the response to continue the conversation
-@threadId = <YOUR_THREAD_ID>
+@sessionId = <YOUR_session_id>
 
 ### Check the status of the workflow
-POST http://localhost:7071/api/agents/publisher/run?thread_id={{threadId}}
+POST http://localhost:7071/api/agents/publisher/run?session_id={{sessionId}}
 Content-Type: text/plain
 
 Check the status of the workflow you previously started
 
 ### Reject content with feedback
-POST http://localhost:7071/api/agents/publisher/run?thread_id={{threadId}}
+POST http://localhost:7071/api/agents/publisher/run?session_id={{sessionId}}
 Content-Type: text/plain
 
 Reject the content with feedback: The article needs more technical depth and better examples.
 
 ### Approve content
-POST http://localhost:7071/api/agents/publisher/run?thread_id={{threadId}}
+POST http://localhost:7071/api/agents/publisher/run?session_id={{sessionId}}
 Content-Type: text/plain
 
 Approve the content

--- a/dotnet/samples/DurableAgents/AzureFunctions/08_ReliableStreaming/README.md
+++ b/dotnet/samples/DurableAgents/AzureFunctions/08_ReliableStreaming/README.md
@@ -192,7 +192,7 @@ The `id` field is the Redis stream entry ID - use it as the `cursor` parameter t
 
 ### Data Flow
 
-1. **Client sends prompt**: The `Create` endpoint receives the prompt and generates a new agent thread.
+1. **Client sends prompt**: The `Create` endpoint receives the prompt and generates a new agent session.
 
 2. **Agent invoked**: The durable entity (`AgentEntity`) is signaled to run the travel planner agent. This is fire-and-forget from the HTTP request's perspective.
 

--- a/dotnet/samples/DurableAgents/ConsoleApps/01_SingleAgent/README.md
+++ b/dotnet/samples/DurableAgents/ConsoleApps/01_SingleAgent/README.md
@@ -6,7 +6,7 @@ This sample demonstrates how to use the durable agents extension to create a sim
 
 - Using the Microsoft Agent Framework to define a simple AI agent with a name and instructions.
 - Registering durable agents with the console app and running them interactively.
-- Conversation management (via threads) for isolated interactions.
+- Conversation management (via sessions) for isolated interactions.
 
 ## Environment Setup
 

--- a/dotnet/samples/DurableAgents/ConsoleApps/02_AgentOrchestration_Chaining/README.md
+++ b/dotnet/samples/DurableAgents/ConsoleApps/02_AgentOrchestration_Chaining/README.md
@@ -39,7 +39,7 @@ Result: Learning serves as the key, opening doors to boundless opportunities and
 The orchestration will proceed to run the WriterAgent twice in sequence:
 
 1. First, it writes an inspirational sentence about learning
-2. Then, it refines the initial output using the same conversation thread
+2. Then, it refines the initial output using the same conversation session
 
 ## Viewing Orchestration State
 

--- a/dotnet/samples/DurableAgents/ConsoleApps/07_ReliableStreaming/README.md
+++ b/dotnet/samples/DurableAgents/ConsoleApps/07_ReliableStreaming/README.md
@@ -94,7 +94,7 @@ You can view the state of the agent in the Durable Task Scheduler dashboard:
    - **Agents**: View the state of the TravelPlanner agent, including conversation history and current state
    - **Orchestrations**: View any orchestrations that may have been triggered by the agent
 
-The conversation ID displayed in the console output (shown as "Starting new conversation: {conversationId}") corresponds to the agent's conversation thread. You can use this to identify the agent in the dashboard and inspect:
+The conversation ID displayed in the console output (shown as "Starting new conversation: {conversationId}") corresponds to the agent's conversation session. You can use this to identify the agent in the dashboard and inspect:
 
 - The agent's conversation state
 - Tool calls made by the agent (weather and events lookups)
@@ -137,7 +137,7 @@ Note that while the console app streams responses from Redis, the agent state in
 
 ### Data Flow
 
-1. **Client sends prompt**: The console app reads the prompt from stdin and generates a new agent thread.
+1. **Client sends prompt**: The console app reads the prompt from stdin and generates a new agent session.
 
 2. **Agent invoked**: The durable agent is signaled to run the travel planner agent. This is fire-and-forget from the console app's perspective.
 

--- a/dotnet/src/Microsoft.Agents.AI.DurableTask/CHANGELOG.md
+++ b/dotnet/src/Microsoft.Agents.AI.DurableTask/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-- Use "session" instead of "thread" terminology in documentation and API comments ([#46](https://github.com/microsoft/agent-framework-durable-extension/issues/46))
+- Use "session" instead of "thread" terminology in documentation and API comments ([#47](https://github.com/microsoft/agent-framework-durable-extension/pull/47))
 - Wrap RequestPort external responses in a controlled `DurableExecutorOutput` envelope so that only the `result` property is populated during deserialization ([#20](https://github.com/microsoft/agent-framework-durable-extension/pull/20))
 - Bound the live workflow status to a trailing event window so multi-executor workflows with large typed outputs no longer overflow the Durable Task 16&#160;KB custom status cap ([#6775](https://github.com/microsoft/agent-framework/pull/6775))
 - Fixed `WorkflowOutputEvent` streaming deserialization to read `executorId` instead of the renamed `sourceId` property, with fallback for backward compatibility ([#6896](https://github.com/microsoft/agent-framework/pull/6896))

--- a/dotnet/src/Microsoft.Agents.AI.DurableTask/CHANGELOG.md
+++ b/dotnet/src/Microsoft.Agents.AI.DurableTask/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Use "session" instead of "thread" terminology in documentation and API comments ([#46](https://github.com/microsoft/agent-framework-durable-extension/issues/46))
 - Wrap RequestPort external responses in a controlled `DurableExecutorOutput` envelope so that only the `result` property is populated during deserialization ([#20](https://github.com/microsoft/agent-framework-durable-extension/pull/20))
 - Bound the live workflow status to a trailing event window so multi-executor workflows with large typed outputs no longer overflow the Durable Task 16&#160;KB custom status cap ([#6775](https://github.com/microsoft/agent-framework/pull/6775))
 - Fixed `WorkflowOutputEvent` streaming deserialization to read `executorId` instead of the renamed `sourceId` property, with fallback for backward compatibility ([#6896](https://github.com/microsoft/agent-framework/pull/6896))

--- a/dotnet/src/Microsoft.Agents.AI.DurableTask/DurableAgentContext.cs
+++ b/dotnet/src/Microsoft.Agents.AI.DurableTask/DurableAgentContext.cs
@@ -49,7 +49,7 @@ public class DurableAgentContext
     public DurableTaskClient Client { get; }
 
     /// <summary>
-    /// Gets the current agent thread.
+    /// Gets the current agent session.
     /// </summary>
     public DurableAgentSession CurrentSession { get; }
 

--- a/dotnet/src/Microsoft.Agents.AI.DurableTask/DurableAgentSession.cs
+++ b/dotnet/src/Microsoft.Agents.AI.DurableTask/DurableAgentSession.cs
@@ -40,7 +40,7 @@ public sealed class DurableAgentSession : AgentSession
     /// <summary>
     /// Deserializes a DurableAgentSession from JSON.
     /// </summary>
-    /// <param name="serializedSession">The serialized thread data.</param>
+    /// <param name="serializedSession">The serialized session data.</param>
     /// <param name="jsonSerializerOptions">Optional JSON serializer options.</param>
     /// <returns>The deserialized DurableAgentSession.</returns>
     internal static DurableAgentSession Deserialize(JsonElement serializedSession, JsonSerializerOptions? jsonSerializerOptions = null)

--- a/dotnet/src/Microsoft.Agents.AI.DurableTask/State/README.md
+++ b/dotnet/src/Microsoft.Agents.AI.DurableTask/State/README.md
@@ -1,6 +1,6 @@
 # Durable Agent State
 
-Durable agents are represented as durable entities, with each session (i.e. thread) of conversation history stored as JSON-serialized state for an individual entity instance.
+Durable agents are represented as durable entities, with each session of conversation history stored as JSON-serialized state for an individual entity instance.
 
 ## State Schema
 

--- a/dotnet/src/Microsoft.Agents.AI.Hosting.AzureFunctions/BuiltInFunctions.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Hosting.AzureFunctions/BuiltInFunctions.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System.Diagnostics.CodeAnalysis;
 using System.Net;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -24,6 +25,22 @@ internal static class BuiltInFunctions
     internal const string RespondFunctionSuffix = "-respond";
 
     private const string WaitForResponseHeaderName = "x-ms-wait-for-response";
+
+    private const string SessionIdHeaderName = "x-ms-session-id";
+    private const string SessionIdParameterName = "session_id";
+    private const string SessionIdMcpArgumentName = "sessionId";
+
+    /// <summary>
+    /// Deprecated alias for <see cref="SessionIdParameterName"/>. Still accepted on incoming requests,
+    /// but never emitted on responses.
+    /// </summary>
+    private const string LegacyThreadIdParameterName = "thread_id";
+
+    /// <summary>
+    /// Deprecated alias for <see cref="SessionIdMcpArgumentName"/>. Still accepted on incoming MCP tool
+    /// invocations, but no longer advertised as a tool property.
+    /// </summary>
+    private const string LegacyThreadIdMcpArgumentName = "threadId";
 
     internal static readonly string RunAgentHttpFunctionEntryPoint = $"{typeof(BuiltInFunctions).FullName!}.{nameof(RunAgentHttpAsync)}";
     internal static readonly string RunAgentEntityFunctionEntryPoint = $"{typeof(BuiltInFunctions).FullName!}.{nameof(InvokeAgentAsync)}";
@@ -260,7 +277,8 @@ internal static class BuiltInFunctions
     {
         // Parse request body - support both JSON and plain text
         string? message = null;
-        string? threadIdFromBody = null;
+        string? sessionIdFromBody = null;
+        string? legacyThreadIdFromBody = null;
 
         if (req.Headers.TryGetValues("Content-Type", out IEnumerable<string>? contentTypeValues) &&
             contentTypeValues.Any(ct => ct.Contains("application/json", StringComparison.OrdinalIgnoreCase)))
@@ -270,7 +288,8 @@ internal static class BuiltInFunctions
             if (requestBody != null)
             {
                 message = requestBody.Message;
-                threadIdFromBody = requestBody.ThreadId;
+                sessionIdFromBody = requestBody.SessionId;
+                legacyThreadIdFromBody = requestBody.ThreadId;
             }
         }
         else
@@ -279,29 +298,26 @@ internal static class BuiltInFunctions
             message = await req.ReadAsStringAsync();
         }
 
-        // The session ID can come from query string or JSON body
-        string? threadIdFromQuery = req.Query["thread_id"];
-
-        // Validate that if thread_id is specified in both places, they must match
-        if (!string.IsNullOrEmpty(threadIdFromQuery) && !string.IsNullOrEmpty(threadIdFromBody) &&
-            !string.Equals(threadIdFromQuery, threadIdFromBody, StringComparison.Ordinal))
+        // The session ID can come from the query string or the JSON body, under either the canonical
+        // "session_id" name or the deprecated "thread_id" alias. Conflicting values are rejected.
+        if (!TryResolveSessionKey(
+                sessionIdFromBody,
+                legacyThreadIdFromBody,
+                req.Query[SessionIdParameterName],
+                req.Query[LegacyThreadIdParameterName],
+                out string? sessionIdValue,
+                out string? sessionKeyError))
         {
-            return await CreateErrorResponseAsync(
-                req,
-                context,
-                HttpStatusCode.BadRequest,
-                "thread_id specified in both query string and request body must match.");
+            return await CreateErrorResponseAsync(req, context, HttpStatusCode.BadRequest, sessionKeyError);
         }
 
-        string? threadIdValue = threadIdFromBody ?? threadIdFromQuery;
-
-        // The thread_id is treated as a session key (not a full session ID).
+        // The caller-supplied value is treated as a session key (not a full session ID).
         // If no session key is provided, use the function invocation ID as the session key
         // to help correlate the session with the function invocation.
         string agentName = GetAgentName(context);
-        AgentSessionId sessionId = string.IsNullOrEmpty(threadIdValue)
+        AgentSessionId sessionId = string.IsNullOrEmpty(sessionIdValue)
             ? new AgentSessionId(agentName, context.InvocationId)
-            : new AgentSessionId(agentName, threadIdValue);
+            : new AgentSessionId(agentName, sessionIdValue);
 
         if (string.IsNullOrWhiteSpace(message))
         {
@@ -365,10 +381,23 @@ internal static class BuiltInFunctions
 
         string agentName = context.Name;
 
-        // Bind the caller-supplied threadId as a session key under the current agent name,
-        // mirroring the behavior of RunAgentHttpAsync.
-        AgentSessionId sessionId = context.Arguments.TryGetValue("threadId", out object? threadObj) && threadObj is string threadId && !string.IsNullOrWhiteSpace(threadId)
-            ? new AgentSessionId(agentName, threadId)
+        // Bind the caller-supplied session key under the current agent name, mirroring the behavior of
+        // RunAgentHttpAsync. "sessionId" is the only advertised tool property, but the deprecated
+        // "threadId" argument is still honored for clients that have not been updated yet.
+        // Unlike the HTTP path, a conflicting pair cannot be surfaced as a 400 here, so the canonical
+        // value simply wins.
+        string? sessionKey = null;
+        if (context.Arguments.TryGetValue(SessionIdMcpArgumentName, out object? sessionObj) && sessionObj is string sessionArg && !string.IsNullOrWhiteSpace(sessionArg))
+        {
+            sessionKey = sessionArg;
+        }
+        else if (context.Arguments.TryGetValue(LegacyThreadIdMcpArgumentName, out object? threadObj) && threadObj is string threadArg && !string.IsNullOrWhiteSpace(threadArg))
+        {
+            sessionKey = threadArg;
+        }
+
+        AgentSessionId sessionId = sessionKey is not null
+            ? new AgentSessionId(agentName, sessionKey)
             : new AgentSessionId(agentName, functionContext.InvocationId);
 
         AIAgent agentProxy = client.AsDurableAgentProxy(functionContext, agentName);
@@ -568,7 +597,7 @@ internal static class BuiltInFunctions
         AgentResponse agentResponse)
     {
         HttpResponseData response = req.CreateResponse(statusCode);
-        response.Headers.Add("x-ms-thread-id", sessionId);
+        response.Headers.Add(SessionIdHeaderName, sessionId);
 
         if (AcceptsJson(req))
         {
@@ -597,7 +626,7 @@ internal static class BuiltInFunctions
         string sessionId)
     {
         HttpResponseData response = req.CreateResponse(HttpStatusCode.Accepted);
-        response.Headers.Add("x-ms-thread-id", sessionId);
+        response.Headers.Add(SessionIdHeaderName, sessionId);
 
         if (AcceptsJson(req))
         {
@@ -639,6 +668,75 @@ internal static class BuiltInFunctions
                 .SelectMany(v => v.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
                 .Select(v => v.Split(';', 2)[0].Trim())
                 .Contains("application/json", StringComparer.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Resolves the session key for an agent run request from the four places a caller may supply it:
+    /// the canonical <c>session_id</c> and its deprecated <c>thread_id</c> alias, in both the request body
+    /// and the query string. Blank values are treated as absent. Any two non-blank values that disagree —
+    /// whether within one source or across the body and query string — are rejected.
+    /// </summary>
+    /// <param name="bodySessionId">The <c>session_id</c> value from the request body, if any.</param>
+    /// <param name="bodyThreadId">The deprecated <c>thread_id</c> value from the request body, if any.</param>
+    /// <param name="querySessionId">The <c>session_id</c> value from the query string, if any.</param>
+    /// <param name="queryThreadId">The deprecated <c>thread_id</c> value from the query string, if any.</param>
+    /// <param name="sessionKey">The resolved session key, or <see langword="null"/> when none was supplied.</param>
+    /// <param name="errorMessage">The error to return to the caller when resolution fails.</param>
+    /// <returns><see langword="false"/> when conflicting values were supplied; otherwise <see langword="true"/>.</returns>
+    internal static bool TryResolveSessionKey(
+        string? bodySessionId,
+        string? bodyThreadId,
+        string? querySessionId,
+        string? queryThreadId,
+        out string? sessionKey,
+        [NotNullWhen(false)] out string? errorMessage)
+    {
+        sessionKey = null;
+
+        if (!TryCombineSessionIdAliases(bodySessionId, bodyThreadId, out string? bodyValue))
+        {
+            errorMessage = $"{SessionIdParameterName} and {LegacyThreadIdParameterName} specified in the request body must match.";
+            return false;
+        }
+
+        if (!TryCombineSessionIdAliases(querySessionId, queryThreadId, out string? queryValue))
+        {
+            errorMessage = $"{SessionIdParameterName} and {LegacyThreadIdParameterName} specified in the query string must match.";
+            return false;
+        }
+
+        if (!TryCombineSessionIdAliases(bodyValue, queryValue, out sessionKey))
+        {
+            errorMessage = "The session identifier specified in both the query string and request body must match.";
+            return false;
+        }
+
+        errorMessage = null;
+        return true;
+    }
+
+    /// <summary>
+    /// Combines the canonical <c>session_id</c> value with its deprecated <c>thread_id</c> alias from a single
+    /// source (the request body or the query string). The canonical value wins when only one is supplied.
+    /// Blank values are treated as absent, matching how the MCP tool trigger resolves its arguments.
+    /// </summary>
+    /// <param name="sessionId">The canonical <c>session_id</c> value, if any.</param>
+    /// <param name="legacyThreadId">The deprecated <c>thread_id</c> value, if any.</param>
+    /// <param name="result">The resolved value, or <see langword="null"/> when neither was supplied.</param>
+    /// <returns><see langword="false"/> when both values are supplied but differ; otherwise <see langword="true"/>.</returns>
+    internal static bool TryCombineSessionIdAliases(string? sessionId, string? legacyThreadId, out string? result)
+    {
+        bool hasSessionId = !string.IsNullOrWhiteSpace(sessionId);
+        bool hasLegacyThreadId = !string.IsNullOrWhiteSpace(legacyThreadId);
+
+        if (hasSessionId && hasLegacyThreadId && !string.Equals(sessionId, legacyThreadId, StringComparison.Ordinal))
+        {
+            result = null;
+            return false;
+        }
+
+        result = hasSessionId ? sessionId : hasLegacyThreadId ? legacyThreadId : null;
+        return true;
     }
 
     private static string GetAgentName(FunctionContext context)
@@ -694,9 +792,11 @@ internal static class BuiltInFunctions
     /// Represents a request to run an agent.
     /// </summary>
     /// <param name="Message">The message to send to the agent.</param>
-    /// <param name="ThreadId">The optional session ID to continue a conversation.</param>
-    private sealed record AgentRunRequest(
+    /// <param name="SessionId">The optional session ID to continue a conversation.</param>
+    /// <param name="ThreadId">Deprecated alias for <paramref name="SessionId"/>.</param>
+    internal sealed record AgentRunRequest(
         [property: JsonPropertyName("message")] string? Message,
+        [property: JsonPropertyName("session_id")] string? SessionId,
         [property: JsonPropertyName("thread_id")] string? ThreadId);
 
     /// <summary>
@@ -712,21 +812,21 @@ internal static class BuiltInFunctions
     /// Represents a successful agent run response.
     /// </summary>
     /// <param name="Status">The HTTP status code.</param>
-    /// <param name="ThreadId">The session ID for the conversation.</param>
+    /// <param name="SessionId">The session ID for the conversation.</param>
     /// <param name="Response">The agent response.</param>
-    private sealed record AgentRunSuccessResponse(
+    internal sealed record AgentRunSuccessResponse(
         [property: JsonPropertyName("status")] int Status,
-        [property: JsonPropertyName("thread_id")] string ThreadId,
+        [property: JsonPropertyName("session_id")] string SessionId,
         [property: JsonPropertyName("response")] AgentResponse Response);
 
     /// <summary>
     /// Represents an accepted (fire-and-forget) agent run response.
     /// </summary>
     /// <param name="Status">The HTTP status code.</param>
-    /// <param name="ThreadId">The session ID for the conversation.</param>
-    private sealed record AgentRunAcceptedResponse(
+    /// <param name="SessionId">The session ID for the conversation.</param>
+    internal sealed record AgentRunAcceptedResponse(
         [property: JsonPropertyName("status")] int Status,
-        [property: JsonPropertyName("thread_id")] string ThreadId);
+        [property: JsonPropertyName("session_id")] string SessionId);
 
     /// <summary>
     /// Represents a request to respond to a pending RequestPort in a workflow.

--- a/dotnet/src/Microsoft.Agents.AI.Hosting.AzureFunctions/BuiltInFunctions.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Hosting.AzureFunctions/BuiltInFunctions.cs
@@ -717,8 +717,9 @@ internal static class BuiltInFunctions
 
     /// <summary>
     /// Combines the canonical <c>session_id</c> value with its deprecated <c>thread_id</c> alias from a single
-    /// source (the request body or the query string). The canonical value wins when only one is supplied.
-    /// Blank values are treated as absent, matching how the MCP tool trigger resolves its arguments.
+    /// source (the request body or the query string). Whichever non-blank value is present is returned; when
+    /// both are present they must be equal, otherwise the pair is rejected. Blank values are treated as absent,
+    /// matching how the MCP tool trigger resolves its arguments.
     /// </summary>
     /// <param name="sessionId">The canonical <c>session_id</c> value, if any.</param>
     /// <param name="legacyThreadId">The deprecated <c>thread_id</c> value, if any.</param>

--- a/dotnet/src/Microsoft.Agents.AI.Hosting.AzureFunctions/CHANGELOG.md
+++ b/dotnet/src/Microsoft.Agents.AI.Hosting.AzureFunctions/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- [BREAKING] Replace "thread" with "session" in HTTP and MCP APIs ([#46](https://github.com/microsoft/agent-framework-durable-extension/issues/46))
 - [BREAKING] Renamed `AddWorkflow` parameters `exposeStatusEndpoint` and `exposeMcpToolTrigger` to `enableStatusEndpoint` and `enableMcpToolTrigger` for consistency with `AddAIAgent` ([#35](https://github.com/microsoft/agent-framework-durable-extension/pull/35))
 - Scope workflow status/respond endpoints to the route workflow name ([#6608](https://github.com/microsoft/agent-framework/pull/6608))
 - Bind MCP threadId to the current agent and guard cross-agent session dispatch ([#6531](https://github.com/microsoft/agent-framework/pull/6531))

--- a/dotnet/src/Microsoft.Agents.AI.Hosting.AzureFunctions/CHANGELOG.md
+++ b/dotnet/src/Microsoft.Agents.AI.Hosting.AzureFunctions/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [Unreleased]
 
-- [BREAKING] Replace "thread" with "session" in HTTP and MCP APIs ([#46](https://github.com/microsoft/agent-framework-durable-extension/issues/46))
+- [BREAKING] Replace "thread" with "session" in HTTP and MCP APIs ([#47](https://github.com/microsoft/agent-framework-durable-extension/pull/47))
 - [BREAKING] Renamed `AddWorkflow` parameters `exposeStatusEndpoint` and `exposeMcpToolTrigger` to `enableStatusEndpoint` and `enableMcpToolTrigger` for consistency with `AddAIAgent` ([#35](https://github.com/microsoft/agent-framework-durable-extension/pull/35))
 - Scope workflow status/respond endpoints to the route workflow name ([#6608](https://github.com/microsoft/agent-framework/pull/6608))
 - Bind MCP threadId to the current agent and guard cross-agent session dispatch ([#6531](https://github.com/microsoft/agent-framework/pull/6531))

--- a/dotnet/src/Microsoft.Agents.AI.Hosting.AzureFunctions/DurableAgentFunctionMetadataTransformer.cs
+++ b/dotnet/src/Microsoft.Agents.AI.Hosting.AzureFunctions/DurableAgentFunctionMetadataTransformer.cs
@@ -75,9 +75,9 @@ internal sealed class DurableAgentFunctionMetadataTransformer : IFunctionMetadat
             Language = "dotnet-isolated",
             RawBindings =
             [
-                $$"""{"name":"context","type":"mcpToolTrigger","direction":"In","toolName":"{{agentName}}","description":"{{description}}","toolProperties":"[{\"propertyName\":\"query\",\"propertyType\":\"string\",\"description\":\"The query to send to the agent.\",\"isRequired\":true,\"isArray\":false},{\"propertyName\":\"threadId\",\"propertyType\":\"string\",\"description\":\"Optional thread identifier.\",\"isRequired\":false,\"isArray\":false}]"}""",
+                $$"""{"name":"context","type":"mcpToolTrigger","direction":"In","toolName":"{{agentName}}","description":"{{description}}","toolProperties":"[{\"propertyName\":\"query\",\"propertyType\":\"string\",\"description\":\"The query to send to the agent.\",\"isRequired\":true,\"isArray\":false},{\"propertyName\":\"sessionId\",\"propertyType\":\"string\",\"description\":\"Optional session identifier.\",\"isRequired\":false,\"isArray\":false}]"}""",
                 """{"name":"query","type":"mcpToolProperty","direction":"In","propertyName":"query","description":"The query to send to the agent","isRequired":true,"dataType":"String","propertyType":"string"}""",
-                """{"name":"threadId","type":"mcpToolProperty","direction":"In","propertyName":"threadId","description":"The thread identifier.","isRequired":false,"dataType":"String","propertyType":"string"}""",
+                """{"name":"sessionId","type":"mcpToolProperty","direction":"In","propertyName":"sessionId","description":"The session identifier.","isRequired":false,"dataType":"String","propertyType":"string"}""",
                 """{"name":"client","type":"durableClient","direction":"In"}"""
             ],
             EntryPoint = BuiltInFunctions.RunAgentMcpToolFunctionEntryPoint,

--- a/dotnet/tests/Microsoft.Agents.AI.Hosting.AzureFunctions.IntegrationTests/SamplesValidation.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Hosting.AzureFunctions.IntegrationTests/SamplesValidation.cs
@@ -83,9 +83,12 @@ public sealed class SamplesValidation(ITestOutputHelper outputHelper) : IAsyncLi
             this._outputHelper.WriteLine($"Agent run response: {responseText}");
 
             // The response headers should include the agent session ID, which can be used to continue the conversation.
-            string? sessionId = response.Headers.GetValues("x-ms-thread-id")?.FirstOrDefault();
+            string? sessionId = response.Headers.GetValues("x-ms-session-id")?.FirstOrDefault();
             Assert.NotNull(sessionId);
             Assert.NotEmpty(sessionId);
+
+            // The deprecated x-ms-thread-id header is no longer emitted.
+            Assert.False(response.Headers.Contains("x-ms-thread-id"));
 
             this._outputHelper.WriteLine($"Agent session ID: {sessionId}");
 
@@ -294,7 +297,7 @@ public sealed class SamplesValidation(ITestOutputHelper outputHelper) : IAsyncLi
             this._outputHelper.WriteLine($"Agent response: {startResponseText}");
 
             // The response should be deserializable as an AgentResponse object and have a valid session ID
-            startResponse.Headers.TryGetValues("x-ms-thread-id", out IEnumerable<string>? agentIdValues);
+            startResponse.Headers.TryGetValues("x-ms-session-id", out IEnumerable<string>? agentIdValues);
             string? sessionId = agentIdValues?.FirstOrDefault();
             Assert.NotNull(sessionId);
             Assert.NotEmpty(sessionId);
@@ -314,7 +317,8 @@ public sealed class SamplesValidation(ITestOutputHelper outputHelper) : IAsyncLi
                 message: "Orchestration is requesting human feedback",
                 timeout: TimeSpan.FromSeconds(180));
 
-            // Approve the content
+            // Approve the content. This request intentionally uses the deprecated thread_id alias
+            // to guard against regressions in backwards compatibility.
             Uri approvalUri = new($"{runAgentUri}?thread_id={sessionId}");
             using HttpContent approvalContent = new StringContent("Approve the content", Encoding.UTF8, "text/plain");
             using HttpResponseMessage approvalResponse = await s_sharedHttpClient.PostAsync(approvalUri, approvalContent);
@@ -335,7 +339,7 @@ public sealed class SamplesValidation(ITestOutputHelper outputHelper) : IAsyncLi
                 timeout: TimeSpan.FromSeconds(180));
 
             // Verify the final orchestration status by asking the agent for the status
-            Uri statusUri = new($"{runAgentUri}?thread_id={sessionId}");
+            Uri statusUri = new($"{runAgentUri}?session_id={sessionId}");
             await this.WaitForConditionAsync(
                 condition: async () =>
                 {

--- a/dotnet/tests/Microsoft.Agents.AI.Hosting.AzureFunctions.UnitTests/BuiltInFunctionsSessionIdAliasTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Hosting.AzureFunctions.UnitTests/BuiltInFunctionsSessionIdAliasTests.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft. All rights reserved.
+﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System.Text.Json;
 using Microsoft.Extensions.AI;

--- a/dotnet/tests/Microsoft.Agents.AI.Hosting.AzureFunctions.UnitTests/BuiltInFunctionsSessionIdAliasTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Hosting.AzureFunctions.UnitTests/BuiltInFunctionsSessionIdAliasTests.cs
@@ -1,0 +1,163 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+using System.Text.Json;
+using Microsoft.Extensions.AI;
+
+namespace Microsoft.Agents.AI.Hosting.AzureFunctions.UnitTests;
+
+/// <summary>
+/// Tests for resolving the canonical <c>session_id</c> value and its deprecated <c>thread_id</c> alias
+/// on incoming requests, and for ensuring only <c>session_id</c> is emitted on responses.
+/// </summary>
+public sealed class BuiltInFunctionsSessionIdAliasTests
+{
+    [Theory]
+    [InlineData(null, null, null)]
+    [InlineData("abc", null, "abc")]
+    [InlineData(null, "abc", "abc")] // deprecated alias is still honored on its own
+    [InlineData("abc", "abc", "abc")]
+    [InlineData("", "abc", "abc")] // blank canonical value defers to the alias
+    [InlineData("abc", "", "abc")] // blank alias defers to the canonical value
+    [InlineData("   ", "abc", "abc")] // whitespace is treated as absent
+    [InlineData("abc", "   ", "abc")]
+    [InlineData("", "", null)]
+    [InlineData("   ", null, null)]
+    public void TryCombineSessionIdAliases_ResolvesValue(string? sessionId, string? threadId, string? expected)
+    {
+        // Act
+        bool succeeded = BuiltInFunctions.TryCombineSessionIdAliases(sessionId, threadId, out string? result);
+
+        // Assert
+        Assert.True(succeeded);
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    [InlineData("abc", "def")]
+    [InlineData("ABC", "abc")] // comparison is ordinal, so casing matters
+    public void TryCombineSessionIdAliases_FailsOnConflict(string sessionId, string threadId)
+    {
+        // Act
+        bool succeeded = BuiltInFunctions.TryCombineSessionIdAliases(sessionId, threadId, out string? result);
+
+        // Assert
+        Assert.False(succeeded);
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void AgentRunRequest_DeserializesBothAliases()
+    {
+        // Arrange
+        const string Json = """{"message":"hi","session_id":"s1","thread_id":"t1"}""";
+
+        // Act
+        BuiltInFunctions.AgentRunRequest? request = JsonSerializer.Deserialize<BuiltInFunctions.AgentRunRequest>(Json);
+
+        // Assert
+        Assert.NotNull(request);
+        Assert.Equal("hi", request.Message);
+        Assert.Equal("s1", request.SessionId);
+        Assert.Equal("t1", request.ThreadId);
+    }
+
+    [Fact]
+    public void AgentRunRequest_DeserializesLegacyAliasOnly()
+    {
+        // Arrange
+        const string Json = """{"message":"hi","thread_id":"t1"}""";
+
+        // Act
+        BuiltInFunctions.AgentRunRequest? request = JsonSerializer.Deserialize<BuiltInFunctions.AgentRunRequest>(Json);
+
+        // Assert
+        Assert.NotNull(request);
+        Assert.Null(request.SessionId);
+        Assert.Equal("t1", request.ThreadId);
+    }
+
+    [Fact]
+    public void AgentRunSuccessResponse_EmitsOnlySessionId()
+    {
+        // Arrange
+        AgentResponse agentResponse = new(new ChatMessage(ChatRole.Assistant, "hello"));
+        BuiltInFunctions.AgentRunSuccessResponse response = new(200, "session-1", agentResponse);
+
+        // Act
+        using JsonDocument document = JsonDocument.Parse(JsonSerializer.Serialize(response));
+
+        // Assert
+        Assert.Equal("session-1", document.RootElement.GetProperty("session_id").GetString());
+        Assert.Equal(200, document.RootElement.GetProperty("status").GetInt32());
+        Assert.False(document.RootElement.TryGetProperty("thread_id", out _));
+    }
+
+    [Fact]
+    public void AgentRunAcceptedResponse_EmitsOnlySessionId()
+    {
+        // Arrange
+        BuiltInFunctions.AgentRunAcceptedResponse response = new(202, "session-2");
+
+        // Act
+        using JsonDocument document = JsonDocument.Parse(JsonSerializer.Serialize(response));
+
+        // Assert
+        Assert.Equal("session-2", document.RootElement.GetProperty("session_id").GetString());
+        Assert.Equal(202, document.RootElement.GetProperty("status").GetInt32());
+        Assert.False(document.RootElement.TryGetProperty("thread_id", out _));
+    }
+
+    [Theory]
+    // bodySessionId, bodyThreadId, querySessionId, queryThreadId, expected
+    [InlineData(null, null, null, null, null)]
+    [InlineData("s", null, null, null, "s")]
+    [InlineData(null, "t", null, null, "t")] // body-only deprecated alias
+    [InlineData(null, null, null, "t", "t")] // query-only deprecated alias
+    [InlineData(null, null, "s", null, "s")]
+    [InlineData(null, "t", "t", null, "t")] // same value under different alias names
+    [InlineData("s", null, null, "s", "s")]
+    [InlineData("s", "s", "s", "s", "s")]
+    [InlineData(null, "   ", null, "t", "t")] // blank body alias falls through to the query
+    [InlineData("s", null, "   ", null, "s")] // blank query value does not conflict with the body
+    public void TryResolveSessionKey_ResolvesValue(
+        string? bodySessionId,
+        string? bodyThreadId,
+        string? querySessionId,
+        string? queryThreadId,
+        string? expected)
+    {
+        // Act
+        bool succeeded = BuiltInFunctions.TryResolveSessionKey(
+            bodySessionId, bodyThreadId, querySessionId, queryThreadId, out string? sessionKey, out string? error);
+
+        // Assert
+        Assert.True(succeeded);
+        Assert.Null(error);
+        Assert.Equal(expected, sessionKey);
+    }
+
+    [Theory]
+    [InlineData("a", "b", null, null, "request body")]
+    [InlineData(null, null, "a", "b", "query string")]
+    [InlineData("a", null, "b", null, "both the query string and request body")]
+    [InlineData(null, "a", null, "b", "both the query string and request body")]
+    [InlineData(null, "a", "b", null, "both the query string and request body")] // mismatch across alias names
+    [InlineData("a", null, null, "b", "both the query string and request body")]
+    public void TryResolveSessionKey_FailsOnConflict(
+        string? bodySessionId,
+        string? bodyThreadId,
+        string? querySessionId,
+        string? queryThreadId,
+        string expectedMessageFragment)
+    {
+        // Act
+        bool succeeded = BuiltInFunctions.TryResolveSessionKey(
+            bodySessionId, bodyThreadId, querySessionId, queryThreadId, out string? sessionKey, out string? error);
+
+        // Assert
+        Assert.False(succeeded);
+        Assert.Null(sessionKey);
+        Assert.NotNull(error);
+        Assert.Contains(expectedMessageFragment, error, StringComparison.Ordinal);
+    }
+}

--- a/dotnet/tests/Microsoft.Agents.AI.Hosting.AzureFunctions.UnitTests/DurableAgentFunctionMetadataTransformerTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Hosting.AzureFunctions.UnitTests/DurableAgentFunctionMetadataTransformerTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System.Diagnostics.CodeAnalysis;
+using System.Text.Json;
 using Microsoft.Azure.Functions.Worker.Core.FunctionMetadata;
 using Microsoft.Extensions.Logging.Abstractions;
 
@@ -142,8 +143,22 @@ public sealed class DurableAgentFunctionMetadataTransformerTests
                 Assert.NotNull(mcpToolMeta.RawBindings);
                 Assert.Equal(4, mcpToolMeta.RawBindings.Count);
                 Assert.Contains("mcpToolTrigger", mcpToolMeta.RawBindings[0]);
-                Assert.Contains("mcpToolProperty", mcpToolMeta.RawBindings[1]); // We expect 2 tool property bindings
-                Assert.Contains("mcpToolProperty", mcpToolMeta.RawBindings[2]);
+
+                // Only the canonical "sessionId" property is advertised; the deprecated "threadId"
+                // alias is still accepted at runtime but is no longer part of the tool schema.
+                // The advertised schema lives in the escaped "toolProperties" string of the trigger
+                // binding, so it has to be parsed rather than substring-matched.
+                using JsonDocument triggerBinding = JsonDocument.Parse(mcpToolMeta.RawBindings[0]);
+                using JsonDocument toolProperties = JsonDocument.Parse(
+                    triggerBinding.RootElement.GetProperty("toolProperties").GetString()!);
+
+                string[] advertisedNames = [.. toolProperties.RootElement.EnumerateArray()
+                    .Select(p => p.GetProperty("propertyName").GetString()!)];
+
+                Assert.Equal(["query", "sessionId"], advertisedNames);
+
+                Assert.Single(mcpToolMeta.RawBindings, b => b.Contains("\"propertyName\":\"sessionId\""));
+                Assert.DoesNotContain(mcpToolMeta.RawBindings, b => b.Contains("threadId"));
             }
         }
     }

--- a/python/packages/azurefunctions/agent_framework_azurefunctions/_app.py
+++ b/python/packages/azurefunctions/agent_framework_azurefunctions/_app.py
@@ -24,12 +24,13 @@ from agent_framework import SupportsAgentRun, Workflow
 from agent_framework_durabletask import (
     DEFAULT_MAX_POLL_RETRIES,
     DEFAULT_POLL_INTERVAL_SECONDS,
+    LEGACY_THREAD_ID_FIELD,
     MIMETYPE_APPLICATION_JSON,
     MIMETYPE_TEXT_PLAIN,
     REQUEST_RESPONSE_FORMAT_JSON,
     REQUEST_RESPONSE_FORMAT_TEXT,
-    THREAD_ID_FIELD,
-    THREAD_ID_HEADER,
+    SESSION_ID_FIELD,
+    SESSION_ID_HEADER,
     WAIT_FOR_RESPONSE_FIELD,
     WAIT_FOR_RESPONSE_HEADER,
     AgentResponseCallbackProtocol,
@@ -944,22 +945,23 @@ class AgentFunctionApp(DFAppBase):
             Expected request body (RunRequest format):
             {
                 "message": "user message to agent",
-                "thread_id": "optional conversation identifier",
+                "session_id": "optional conversation identifier",
                 "role": "user|system" (optional, default: "user"),
                 "response_format": {...} (optional JSON schema for structured responses),
                 "enable_tool_calls": true|false (optional, default: true)
             }
             """
             request_response_format: str = REQUEST_RESPONSE_FORMAT_JSON
-            thread_id: str | None = None
+            session_id: str | None = None
 
             try:
                 req_body, message, request_response_format = self._parse_incoming_request(req)
-                thread_id = self._resolve_thread_id(req=req, req_body=req_body)
+                session_id = self._resolve_session_id(req=req, req_body=req_body)
                 wait_for_response = self._should_wait_for_response(req=req, req_body=req_body)
 
                 logger.debug(
-                    f"[HTTP Trigger] Message: {message}, Thread ID: {thread_id}, wait_for_response: {wait_for_response}"
+                    f"[HTTP Trigger] Message: {message}, Session ID: {session_id}, "
+                    f"wait_for_response: {wait_for_response}"
                 )
 
                 if not message:
@@ -968,20 +970,20 @@ class AgentFunctionApp(DFAppBase):
                         payload={"error": "Message is required"},
                         status_code=400,
                         request_response_format=request_response_format,
-                        thread_id=thread_id,
+                        session_id=session_id,
                     )
 
-                session_id = self._create_session_id(agent_name, thread_id)
+                agent_session_id = self._create_session_id(agent_name, session_id)
                 correlation_id = self._generate_unique_id()
 
                 logger.debug(
-                    f"[HTTP Trigger] Calling entity to run agent using session ID: {session_id} "
+                    f"[HTTP Trigger] Calling entity to run agent using session ID: {agent_session_id} "
                     f"and correlation ID: {correlation_id}"
                 )
 
                 entity_instance_id = df.EntityId(
-                    name=session_id.entity_name,
-                    key=session_id.key,
+                    name=agent_session_id.entity_name,
+                    key=agent_session_id.key,
                 )
                 run_request = self._build_request_data(
                     req_body,
@@ -992,7 +994,7 @@ class AgentFunctionApp(DFAppBase):
                 logger.debug("Signalling entity %s with request: %s", entity_instance_id, run_request)
                 await client.signal_entity(entity_instance_id, "run", run_request)
 
-                logger.debug(f"[HTTP Trigger] Signal sent to entity {session_id}")
+                logger.debug(f"[HTTP Trigger] Signal sent to entity {agent_session_id}")
 
                 if wait_for_response:
                     result = await self._get_response_from_entity(
@@ -1000,7 +1002,7 @@ class AgentFunctionApp(DFAppBase):
                         entity_instance_id=entity_instance_id,
                         correlation_id=correlation_id,
                         message=message,
-                        thread_id=thread_id,
+                        session_id=session_id,
                     )
 
                     logger.debug(f"[HTTP Trigger] Result status: {result.get('status', 'unknown')}")
@@ -1008,20 +1010,20 @@ class AgentFunctionApp(DFAppBase):
                         payload=result,
                         status_code=200 if result.get("status") == "success" else 500,
                         request_response_format=request_response_format,
-                        thread_id=thread_id,
+                        session_id=session_id,
                     )
 
                 logger.debug("[HTTP Trigger] wait_for_response disabled; returning correlation ID")
 
                 accepted_response = self._build_accepted_response(
-                    message=message, thread_id=thread_id, correlation_id=correlation_id
+                    message=message, session_id=session_id, correlation_id=correlation_id
                 )
 
                 return self._create_http_response(
                     payload=accepted_response,
                     status_code=202,
                     request_response_format=request_response_format,
-                    thread_id=thread_id,
+                    session_id=session_id,
                 )
 
             except IncomingRequestError as exc:
@@ -1030,7 +1032,7 @@ class AgentFunctionApp(DFAppBase):
                     payload={"error": str(exc)},
                     status_code=exc.status_code,
                     request_response_format=request_response_format,
-                    thread_id=thread_id,
+                    session_id=session_id,
                 )
             except ValueError as exc:
                 logger.error(f"[HTTP Trigger] Invalid JSON: {exc!s}")
@@ -1038,7 +1040,7 @@ class AgentFunctionApp(DFAppBase):
                     payload={"error": "Invalid JSON"},
                     status_code=400,
                     request_response_format=request_response_format,
-                    thread_id=thread_id,
+                    session_id=session_id,
                 )
             except Exception as exc:
                 logger.error(f"[HTTP Trigger] Error: {exc!s}", exc_info=True)
@@ -1046,7 +1048,7 @@ class AgentFunctionApp(DFAppBase):
                     payload={"error": str(exc)},
                     status_code=500,
                     request_response_format=request_response_format,
-                    thread_id=thread_id,
+                    session_id=session_id,
                 )
 
         _ = http_start
@@ -1105,9 +1107,9 @@ class AgentFunctionApp(DFAppBase):
                 "isArray": False,
             },
             {
-                "propertyName": "threadId",
+                "propertyName": "sessionId",
                 "propertyType": "string",
-                "description": "Optional thread identifier for conversation continuity.",
+                "description": "Optional session identifier for conversation continuity.",
                 "isRequired": False,
                 "isArray": False,
             },
@@ -1130,7 +1132,7 @@ class AgentFunctionApp(DFAppBase):
             """Handle MCP tool invocation for the agent.
 
             Args:
-                context: MCP tool invocation context containing arguments (query, threadId)
+                context: MCP tool invocation context containing arguments (query, sessionId)
                 client: Durable orchestration client for entity communication
 
             Returns:
@@ -1179,20 +1181,27 @@ class AgentFunctionApp(DFAppBase):
         if not query or not isinstance(query, str):
             raise ValueError("MCP Tool invocation is missing required 'query' argument of type string.")
 
-        # Extract optional threadId
-        thread_id = arguments.get("threadId")
+        # Extract the optional session key. "sessionId" is the only advertised tool property, but the
+        # deprecated "threadId" argument is still honored for clients that have not been updated yet.
+        # Blank or non-string values are treated as absent so a valid alias is not shadowed.
+        session_key: str | None = None
+        for argument_name in ("sessionId", "threadId"):
+            candidate = arguments.get(argument_name)
+            if isinstance(candidate, str) and candidate.strip():
+                session_key = candidate
+                break
 
         # Create or parse session ID
-        if thread_id and isinstance(thread_id, str) and thread_id.strip():
+        if session_key:
             try:
-                session_id = AgentSessionId.parse(thread_id, agent_name=agent_name)
+                session_id = AgentSessionId.parse(session_key, agent_name=agent_name)
             except ValueError as e:
                 logger.warning(
-                    "Failed to parse AgentSessionId from thread_id '%s': %s. Falling back to new session ID.",
-                    thread_id,
+                    "Failed to parse AgentSessionId from session identifier '%s': %s. Falling back to new session ID.",
+                    session_key,
                     e,
                 )
-                session_id = AgentSessionId(name=agent_name, key=thread_id)
+                session_id = AgentSessionId(name=agent_name, key=session_key)
         else:
             # Generate new session ID
             session_id = AgentSessionId.with_random_key(agent_name)
@@ -1225,7 +1234,7 @@ class AgentFunctionApp(DFAppBase):
                 entity_instance_id=entity_instance_id,
                 correlation_id=correlation_id,
                 message=query,
-                thread_id=str(session_id),
+                session_id=str(session_id),
             )
 
             # Extract and return response text
@@ -1304,7 +1313,7 @@ class AgentFunctionApp(DFAppBase):
         entity_instance_id: df.EntityId,
         correlation_id: str,
         message: str,
-        thread_id: str,
+        session_id: str,
     ) -> dict[str, Any]:
         """Poll the entity state until a response is available or timeout occurs."""
         max_retries = self.max_poll_retries
@@ -1322,7 +1331,7 @@ class AgentFunctionApp(DFAppBase):
                 entity_instance_id=entity_instance_id,
                 correlation_id=correlation_id,
                 message=message,
-                thread_id=thread_id,
+                session_id=session_id,
             )
             if result is not None:
                 break
@@ -1337,7 +1346,7 @@ class AgentFunctionApp(DFAppBase):
             f"[HTTP Trigger] Response with correlation ID {correlation_id} "
             f"not found in time (waited {max_retries * interval} seconds)"
         )
-        return await self._build_timeout_result(message=message, thread_id=thread_id, correlation_id=correlation_id)
+        return await self._build_timeout_result(message=message, session_id=session_id, correlation_id=correlation_id)
 
     async def _poll_entity_for_response(
         self,
@@ -1345,7 +1354,7 @@ class AgentFunctionApp(DFAppBase):
         entity_instance_id: df.EntityId,
         correlation_id: str,
         message: str,
-        thread_id: str,
+        session_id: str,
     ) -> dict[str, Any] | None:
         result: dict[str, Any] | None = None
         try:
@@ -1359,7 +1368,7 @@ class AgentFunctionApp(DFAppBase):
                 result = self._build_success_result(
                     response_message=agent_response.text,
                     message=message,
-                    thread_id=thread_id,
+                    session_id=session_id,
                     correlation_id=correlation_id,
                     state=state,
                 )
@@ -1375,7 +1384,7 @@ class AgentFunctionApp(DFAppBase):
         *,
         response: str | None,
         message: str,
-        thread_id: str,
+        session_id: str,
         status: str,
         correlation_id: str,
         extra_fields: dict[str, Any] | None = None,
@@ -1384,7 +1393,7 @@ class AgentFunctionApp(DFAppBase):
         payload = {
             "response": response,
             "message": message,
-            THREAD_ID_FIELD: thread_id,
+            SESSION_ID_FIELD: session_id,
             "status": status,
             "correlation_id": correlation_id,
         }
@@ -1392,24 +1401,24 @@ class AgentFunctionApp(DFAppBase):
             payload.update(extra_fields)
         return payload
 
-    async def _build_timeout_result(self, message: str, thread_id: str, correlation_id: str) -> dict[str, Any]:
+    async def _build_timeout_result(self, message: str, session_id: str, correlation_id: str) -> dict[str, Any]:
         """Create the timeout response."""
         return self._build_response_payload(
             response="Agent is still processing or timed out...",
             message=message,
-            thread_id=thread_id,
+            session_id=session_id,
             status="timeout",
             correlation_id=correlation_id,
         )
 
     def _build_success_result(
-        self, response_message: str, message: str, thread_id: str, correlation_id: str, state: DurableAgentState
+        self, response_message: str, message: str, session_id: str, correlation_id: str, state: DurableAgentState
     ) -> dict[str, Any]:
         """Build the success result returned to the HTTP caller."""
         return self._build_response_payload(
             response=response_message,
             message=message,
-            thread_id=thread_id,
+            session_id=session_id,
             status="success",
             correlation_id=correlation_id,
             extra_fields={ApiResponseFields.MESSAGE_COUNT: state.message_count},
@@ -1436,12 +1445,12 @@ class AgentFunctionApp(DFAppBase):
             created_at=datetime.now(timezone.utc),
         ).to_dict()
 
-    def _build_accepted_response(self, message: str, thread_id: str, correlation_id: str) -> dict[str, Any]:
+    def _build_accepted_response(self, message: str, session_id: str, correlation_id: str) -> dict[str, Any]:
         """Build the response returned when not waiting for completion."""
         return self._build_response_payload(
             response="Agent request accepted",
             message=message,
-            thread_id=thread_id,
+            session_id=session_id,
             status="accepted",
             correlation_id=correlation_id,
         )
@@ -1451,11 +1460,11 @@ class AgentFunctionApp(DFAppBase):
         payload: dict[str, Any] | str,
         status_code: int,
         request_response_format: str,
-        thread_id: str | None,
+        session_id: str | None,
     ) -> func.HttpResponse:
         """Create the HTTP response using helper serializers for clarity."""
         if request_response_format == REQUEST_RESPONSE_FORMAT_TEXT:
-            return self._build_plain_text_response(payload=payload, status_code=status_code, thread_id=thread_id)
+            return self._build_plain_text_response(payload=payload, status_code=status_code, session_id=session_id)
 
         return self._build_json_response(payload=payload, status_code=status_code)
 
@@ -1463,11 +1472,11 @@ class AgentFunctionApp(DFAppBase):
         self,
         payload: dict[str, Any] | str,
         status_code: int,
-        thread_id: str | None,
+        session_id: str | None,
     ) -> func.HttpResponse:
-        """Return a plain-text response with optional thread identifier header."""
+        """Return a plain-text response with optional session identifier header."""
         body_text = payload if isinstance(payload, str) else self._convert_payload_to_text(payload)
-        headers = {THREAD_ID_HEADER: thread_id} if thread_id is not None else None
+        headers = {SESSION_ID_HEADER: session_id} if session_id is not None else None
         return func.HttpResponse(body_text, status_code=status_code, mimetype=MIMETYPE_TEXT_PLAIN, headers=headers)
 
     def _build_json_response(self, payload: dict[str, Any] | str, status_code: int) -> func.HttpResponse:
@@ -1496,27 +1505,43 @@ class AgentFunctionApp(DFAppBase):
         """Generate a new unique identifier."""
         return uuid.uuid4().hex
 
-    def _create_session_id(self, agent_name: str, thread_id: str | None) -> AgentSessionId:
-        """Create a session identifier using the provided thread id or a random value."""
-        if thread_id:
-            return AgentSessionId(name=agent_name, key=thread_id)
+    def _create_session_id(self, agent_name: str, session_key: str | None) -> AgentSessionId:
+        """Create a session identifier using the provided session key or a random value."""
+        if session_key:
+            return AgentSessionId(name=agent_name, key=session_key)
         return AgentSessionId.with_random_key(name=agent_name)
 
-    def _resolve_thread_id(self, req: func.HttpRequest, req_body: dict[str, Any]) -> str:
-        """Retrieve the thread identifier from request body or query parameters."""
+    def _resolve_session_id(self, req: func.HttpRequest, req_body: dict[str, Any]) -> str:
+        """Retrieve the session identifier from the request body or query parameters.
+
+        Callers may use the canonical ``session_id`` name or the deprecated ``thread_id`` alias, in
+        either the request body or the query string. Blank values are treated as absent. Any two
+        non-blank values that disagree are rejected, matching the .NET implementation. A random
+        identifier is generated when no name is supplied.
+
+        Raises:
+            IncomingRequestError: If conflicting session identifiers were supplied.
+        """
         params = req.params or {}
 
-        if THREAD_ID_FIELD in req_body:
-            value = req_body.get(THREAD_ID_FIELD)
-            if value is not None:
-                return str(value)
+        candidates: dict[str, str] = {}
+        for source_name, source in (("request body", req_body), ("query string", params)):
+            for field in (SESSION_ID_FIELD, LEGACY_THREAD_ID_FIELD):
+                value = source.get(field)
+                if value is not None and str(value).strip():
+                    candidates[f"{field} in the {source_name}"] = str(value)
 
-        if THREAD_ID_FIELD in params:
-            value = params.get(THREAD_ID_FIELD)
-            if value is not None:
-                return str(value)
+        distinct = set(candidates.values())
+        if len(distinct) > 1:
+            raise IncomingRequestError(
+                "Conflicting session identifiers supplied: "
+                + ", ".join(f"{name}={value!r}" for name, value in sorted(candidates.items()))
+            )
 
-        logger.debug("[HTTP Trigger] No thread identifier provided; using random thread id")
+        if distinct:
+            return distinct.pop()
+
+        logger.debug("[HTTP Trigger] No session identifier provided; using a random session id")
         return self._generate_unique_id()
 
     def _parse_incoming_request(self, req: func.HttpRequest) -> tuple[dict[str, Any], str, str]:

--- a/python/packages/azurefunctions/agent_framework_azurefunctions/_entities.py
+++ b/python/packages/azurefunctions/agent_framework_azurefunctions/_entities.py
@@ -44,7 +44,7 @@ class AzureFunctionEntityStateProvider(AgentEntityStateProviderMixin):
     def _set_state_dict(self, state: dict[str, Any]) -> None:
         self._context.set_state(state)
 
-    def _get_thread_id_from_entity(self) -> str:
+    def _get_session_id_from_entity(self) -> str:
         return str(self._context.entity_key)
 
 

--- a/python/packages/azurefunctions/tests/integration_tests/test_01_single_agent.py
+++ b/python/packages/azurefunctions/tests/integration_tests/test_01_single_agent.py
@@ -15,7 +15,7 @@ Usage:
 """
 
 import pytest
-from agent_framework_durabletask import THREAD_ID_HEADER
+from agent_framework_durabletask import SESSION_ID_HEADER
 
 # Module-level markers - applied to all tests in this file
 pytestmark = [
@@ -46,7 +46,7 @@ class TestSampleSingleAgent:
         """Test sending a simple message with JSON payload."""
         response = self.helper.post_json(
             f"{self.base_url}/run",
-            {"message": "Tell me a short joke about cloud computing.", "thread_id": "test-simple-json"},
+            {"message": "Tell me a short joke about cloud computing.", "session_id": "test-simple-json"},
         )
         # Agent can return 200 (immediate) or 202 (async with wait_for_response=false)
         assert response.status_code in [200, 202]
@@ -59,7 +59,7 @@ class TestSampleSingleAgent:
             assert data["message_count"] >= 1
         else:
             # Async response - check we got correlation info
-            assert "correlation_id" in data or "thread_id" in data
+            assert "correlation_id" in data or "session_id" in data
 
     def test_simple_message_plain_text(self) -> None:
         """Test sending a message with plain text payload."""
@@ -68,26 +68,38 @@ class TestSampleSingleAgent:
 
         # Agent responded with plain text when the request body was text/plain.
         assert response.text.strip()
-        assert response.headers.get(THREAD_ID_HEADER) is not None
+        assert response.headers.get(SESSION_ID_HEADER) is not None
 
-    def test_thread_id_in_query(self) -> None:
-        """Test using thread_id in query parameter."""
+    def test_session_id_in_query(self) -> None:
+        """Test using session_id in query parameter."""
         response = self.helper.post_text(
-            f"{self.base_url}/run?thread_id=test-query-thread", "Tell me a short joke about weather in Texas."
+            f"{self.base_url}/run?session_id=test-query-session", "Tell me a short joke about weather in Texas."
         )
         assert response.status_code in [200, 202]
 
         assert response.text.strip()
-        assert response.headers.get(THREAD_ID_HEADER) == "test-query-thread"
+        assert response.headers.get(SESSION_ID_HEADER) == "test-query-session"
+
+    def test_legacy_thread_id_in_query_still_accepted(self) -> None:
+        """The deprecated thread_id query parameter is still honored on incoming requests."""
+        response = self.helper.post_text(
+            f"{self.base_url}/run?thread_id=test-legacy-query", "Tell me a short joke about weather in Texas."
+        )
+        assert response.status_code in [200, 202]
+
+        assert response.text.strip()
+        assert response.headers.get(SESSION_ID_HEADER) == "test-legacy-query"
+        # The deprecated response header is no longer emitted.
+        assert response.headers.get("x-ms-thread-id") is None
 
     def test_conversation_continuity(self) -> None:
         """Test conversation context is maintained across requests."""
-        thread_id = "test-continuity"
+        session_id = "test-continuity"
 
         # First message
         response1 = self.helper.post_json(
             f"{self.base_url}/run",
-            {"message": "Tell me a short joke about weather in Seattle.", "thread_id": thread_id},
+            {"message": "Tell me a short joke about weather in Seattle.", "session_id": session_id},
         )
         assert response1.status_code in [200, 202]
 
@@ -97,7 +109,7 @@ class TestSampleSingleAgent:
 
             # Second message in same session
             response2 = self.helper.post_json(
-                f"{self.base_url}/run", {"message": "What about San Francisco?", "thread_id": thread_id}
+                f"{self.base_url}/run", {"message": "What about San Francisco?", "session_id": session_id}
             )
             assert response2.status_code == 200
             data2 = response2.json()
@@ -106,7 +118,7 @@ class TestSampleSingleAgent:
             # In async mode, we can't easily test message count
             # Just verify we can make multiple calls
             response2 = self.helper.post_json(
-                f"{self.base_url}/run", {"message": "What about Texas?", "thread_id": thread_id}
+                f"{self.base_url}/run", {"message": "What about Texas?", "session_id": session_id}
             )
             assert response2.status_code == 202
 

--- a/python/packages/azurefunctions/tests/integration_tests/test_02_multi_agent.py
+++ b/python/packages/azurefunctions/tests/integration_tests/test_02_multi_agent.py
@@ -55,7 +55,7 @@ class TestSampleMultiAgent:
 
         assert data["status"] == "accepted"
         assert "correlation_id" in data
-        assert "thread_id" in data
+        assert "session_id" in data
 
 
 if __name__ == "__main__":

--- a/python/packages/azurefunctions/tests/integration_tests/test_03_reliable_streaming.py
+++ b/python/packages/azurefunctions/tests/integration_tests/test_03_reliable_streaming.py
@@ -50,14 +50,14 @@ class TestSampleReliableStreaming:
         assert response.status_code == 202
         data = response.json()
 
-        thread_id = data.get("thread_id")
+        session_id = data.get("session_id")
 
         # Wait a moment for the agent to start writing to Redis
         time.sleep(2)
 
         # Stream response from Redis with longer timeout to account for LLM latency
         stream_response = requests.get(
-            f"{self.stream_url}/{thread_id}",
+            f"{self.stream_url}/{session_id}",
             headers={"Accept": "text/plain"},
             timeout=60,
         )
@@ -72,14 +72,14 @@ class TestSampleReliableStreaming:
         )
         assert response.status_code == 202
         data = response.json()
-        thread_id = data.get("thread_id")
+        session_id = data.get("session_id")
 
         # Wait for agent to start writing
         time.sleep(2)
 
         # Stream with SSE format
         stream_response = requests.get(
-            f"{self.stream_url}/{thread_id}",
+            f"{self.stream_url}/{session_id}",
             headers={"Accept": "text/event-stream"},
             timeout=60,
         )

--- a/python/packages/azurefunctions/tests/test_app.py
+++ b/python/packages/azurefunctions/tests/test_app.py
@@ -16,7 +16,7 @@ from agent_framework import AgentResponse, Message
 from agent_framework_durabletask import (
     MIMETYPE_APPLICATION_JSON,
     MIMETYPE_TEXT_PLAIN,
-    THREAD_ID_HEADER,
+    SESSION_ID_HEADER,
     WAIT_FOR_RESPONSE_FIELD,
     WAIT_FOR_RESPONSE_HEADER,
     AgentEntity,
@@ -27,6 +27,7 @@ from agent_framework_durabletask import (
 
 from agent_framework_azurefunctions import AgentFunctionApp
 from agent_framework_azurefunctions._entities import create_agent_entity
+from agent_framework_azurefunctions._errors import IncomingRequestError
 
 FuncT = TypeVar("FuncT", bound=Callable[..., Any])
 
@@ -36,8 +37,8 @@ def _identity_decorator(func: FuncT) -> FuncT:
 
 
 class _InMemoryStateProvider(AgentEntityStateProviderMixin):
-    def __init__(self, *, thread_id: str = "test-thread", initial_state: dict[str, Any] | None = None) -> None:
-        self._thread_id = thread_id
+    def __init__(self, *, session_id: str = "test-session", initial_state: dict[str, Any] | None = None) -> None:
+        self._session_id = session_id
         self._state_dict: dict[str, Any] = initial_state or {}
 
     def _get_state_dict(self) -> dict[str, Any]:
@@ -46,8 +47,8 @@ class _InMemoryStateProvider(AgentEntityStateProviderMixin):
     def _set_state_dict(self, state: dict[str, Any]) -> None:
         self._state_dict = state
 
-    def _get_thread_id_from_entity(self) -> str:
-        return self._thread_id
+    def _get_session_id_from_entity(self) -> str:
+        return self._session_id
 
 
 class TestAgentFunctionAppInit:
@@ -360,7 +361,7 @@ class TestAgentEntityOperations:
             return_value=AgentResponse(messages=[Message(role="assistant", contents=["Test response"])])
         )
 
-        entity = AgentEntity(mock_agent, state_provider=_InMemoryStateProvider(thread_id="test-conv-123"))
+        entity = AgentEntity(mock_agent, state_provider=_InMemoryStateProvider(session_id="test-conv-123"))
 
         result = await entity.run({
             "message": "Test message",
@@ -378,7 +379,7 @@ class TestAgentEntityOperations:
             return_value=AgentResponse(messages=[Message(role="assistant", contents=["Response 1"])])
         )
 
-        entity = AgentEntity(mock_agent, state_provider=_InMemoryStateProvider(thread_id="conv-1"))
+        entity = AgentEntity(mock_agent, state_provider=_InMemoryStateProvider(session_id="conv-1"))
 
         # Send first message
         await entity.run({"message": "Message 1", "correlationId": "corr-app-entity-2"})
@@ -412,7 +413,7 @@ class TestAgentEntityOperations:
             return_value=AgentResponse(messages=[Message(role="assistant", contents=["Response"])])
         )
 
-        entity = AgentEntity(mock_agent, state_provider=_InMemoryStateProvider(thread_id="conv-1"))
+        entity = AgentEntity(mock_agent, state_provider=_InMemoryStateProvider(session_id="conv-1"))
 
         assert len(entity.state.data.conversation_history) == 0
 
@@ -627,7 +628,7 @@ class TestErrorHandling:
         mock_agent = Mock()
         mock_agent.run = AsyncMock(side_effect=Exception("Agent error"))
 
-        entity = AgentEntity(mock_agent, state_provider=_InMemoryStateProvider(thread_id="conv-1"))
+        entity = AgentEntity(mock_agent, state_provider=_InMemoryStateProvider(session_id="conv-1"))
 
         result = await entity.run({
             "message": "Test message",
@@ -719,17 +720,58 @@ class TestIncomingRequestParsing:
         assert message == "Plain text message"
         assert response_format == "json"
 
-    def test_extract_thread_id_from_query_params(self) -> None:
-        """Test thread identifier extraction from query parameters."""
+    def test_extract_session_id_from_query_params(self) -> None:
+        """Test session identifier extraction from query parameters."""
+        app = self._create_app()
+
+        request = Mock()
+        request.params = {"session_id": "query-session"}
+        req_body: dict[str, Any] = {}
+
+        assert app._resolve_session_id(request, req_body) == "query-session"
+
+    def test_extract_legacy_thread_id_from_query_params(self) -> None:
+        """The deprecated thread_id name is still accepted on incoming requests."""
         app = self._create_app()
 
         request = Mock()
         request.params = {"thread_id": "query-thread"}
         req_body: dict[str, Any] = {}
 
-        thread_id = app._resolve_thread_id(request, req_body)
+        assert app._resolve_session_id(request, req_body) == "query-thread"
 
-        assert thread_id == "query-thread"
+    def test_session_id_wins_over_matching_legacy_thread_id(self) -> None:
+        """Matching values under both names resolve to that value."""
+        app = self._create_app()
+
+        request = Mock()
+        request.params = {"session_id": "same-key", "thread_id": "same-key"}
+
+        assert app._resolve_session_id(request, {}) == "same-key"
+        assert app._resolve_session_id(request, {"session_id": "same-key"}) == "same-key"
+
+    def test_conflicting_session_identifiers_are_rejected(self) -> None:
+        """Any two non-blank values that disagree are rejected, matching the .NET behavior."""
+        app = self._create_app()
+
+        request = Mock()
+        request.params = {"session_id": "query-session", "thread_id": "query-thread"}
+        with pytest.raises(IncomingRequestError, match="Conflicting session identifiers"):
+            app._resolve_session_id(request, {})
+
+        # Conflicts across the body and query string are rejected too.
+        request.params = {"session_id": "query-session"}
+        with pytest.raises(IncomingRequestError, match="Conflicting session identifiers"):
+            app._resolve_session_id(request, {"thread_id": "body-thread"})
+
+    def test_blank_session_identifiers_are_ignored(self) -> None:
+        """Blank values fall through to the next source instead of winning or conflicting."""
+        app = self._create_app()
+
+        request = Mock()
+        request.params = {"thread_id": "query-thread"}
+
+        assert app._resolve_session_id(request, {"session_id": "   "}) == "query-thread"
 
 
 class TestHttpRunRoute:
@@ -784,7 +826,7 @@ class TestHttpRunRoute:
 
         assert response.status_code == 202
         assert response.mimetype == MIMETYPE_TEXT_PLAIN
-        assert response.headers.get(THREAD_ID_HEADER) is not None
+        assert response.headers.get(SESSION_ID_HEADER) is not None
         assert response.get_body().decode("utf-8") == "Agent request accepted"
 
         signal_args = client.signal_entity.call_args[0]
@@ -792,6 +834,7 @@ class TestHttpRunRoute:
 
         assert run_request["message"] == "Plain text via HTTP"
         assert run_request["role"] == "user"
+        assert "session_id" not in run_request
         assert "thread_id" not in run_request
 
     async def test_http_run_accept_header_returns_json(self) -> None:
@@ -814,9 +857,64 @@ class TestHttpRunRoute:
 
         assert response.status_code == 202
         assert response.mimetype == MIMETYPE_APPLICATION_JSON
-        assert response.headers.get(THREAD_ID_HEADER) is None
+        assert response.headers.get(SESSION_ID_HEADER) is None
         body = response.get_body().decode("utf-8")
         assert '"status": "accepted"' in body
+
+        # Responses carry only the canonical session_id name.
+        payload = json.loads(body)
+        assert payload["session_id"]
+        assert "thread_id" not in payload
+
+    async def test_http_run_round_trips_explicit_session_id(self) -> None:
+        """An explicit caller-supplied key flows through the entity, payload, and header unchanged."""
+        mock_agent = Mock()
+        mock_agent.name = "HttpAgentEcho"
+
+        handler = self._get_run_handler(mock_agent)
+
+        request = Mock()
+        request.headers = {WAIT_FOR_RESPONSE_HEADER: "false", "Accept": MIMETYPE_APPLICATION_JSON}
+        # Supplied under the deprecated name to also cover backward compatibility.
+        request.params = {"thread_id": "caller-key-1"}
+        request.route_params = {}
+        request.get_json.side_effect = ValueError("Invalid JSON")
+        request.get_body.return_value = b"Plain text via HTTP"
+
+        client = AsyncMock()
+
+        response = await handler(request, client)
+
+        assert response.status_code == 202
+        payload = json.loads(response.get_body().decode("utf-8"))
+        assert payload["session_id"] == "caller-key-1"
+        assert "thread_id" not in payload
+
+        # The durable entity is keyed by the same caller-supplied value.
+        entity_id = client.signal_entity.call_args[0][0]
+        assert entity_id.key == "caller-key-1"
+
+    async def test_http_run_rejects_conflicting_session_identifiers(self) -> None:
+        """Conflicting session identifiers are rejected with HTTP 400."""
+        mock_agent = Mock()
+        mock_agent.name = "HttpAgentConflict"
+
+        handler = self._get_run_handler(mock_agent)
+
+        request = Mock()
+        request.headers = {WAIT_FOR_RESPONSE_HEADER: "false", "Accept": MIMETYPE_APPLICATION_JSON}
+        request.params = {"session_id": "one", "thread_id": "two"}
+        request.route_params = {}
+        request.get_json.side_effect = ValueError("Invalid JSON")
+        request.get_body.return_value = b"Plain text via HTTP"
+
+        client = AsyncMock()
+
+        response = await handler(request, client)
+
+        assert response.status_code == 400
+        assert "Conflicting session identifiers" in response.get_body().decode("utf-8")
+        client.signal_entity.assert_not_called()
 
     async def test_http_run_rejects_empty_message(self) -> None:
         """Test that the HTTP handler rejects empty messages with a 400 response."""
@@ -838,7 +936,7 @@ class TestHttpRunRoute:
 
         assert response.status_code == 400
         assert response.mimetype == MIMETYPE_TEXT_PLAIN
-        assert response.headers.get(THREAD_ID_HEADER) is not None
+        assert response.headers.get(SESSION_ID_HEADER) is not None
         assert response.get_body().decode("utf-8") == "Message is required"
         client.signal_entity.assert_not_called()
 
@@ -945,6 +1043,10 @@ class TestMCPToolEndpoint:
             )
             client_mock.assert_called_once_with(client_name="client")
 
+            # The advertised schema exposes only the canonical "sessionId" property.
+            advertised = json.loads(mcp_trigger_mock.call_args.kwargs["tool_properties"])
+            assert [prop["propertyName"] for prop in advertised] == ["query", "sessionId"]
+
     def test_setup_mcp_tool_trigger_uses_default_description(self) -> None:
         """Test that _setup_mcp_tool_trigger uses default description when none provided."""
         mock_agent = Mock()
@@ -982,7 +1084,7 @@ class TestMCPToolEndpoint:
         client.read_entity_state.return_value = mock_state
 
         # Create JSON string context
-        context = '{"arguments": {"query": "test query", "threadId": "test-thread"}}'
+        context = '{"arguments": {"query": "test query", "sessionId": "test-session"}}'
 
         with patch.object(app, "_get_response_from_entity") as get_response_mock:
             get_response_mock.return_value = {"status": "success", "response": "Test response"}
@@ -1009,7 +1111,7 @@ class TestMCPToolEndpoint:
         client.read_entity_state.return_value = mock_state
 
         # Create JSON string context
-        context = json.dumps({"arguments": {"query": "test query", "threadId": "test-thread"}})
+        context = json.dumps({"arguments": {"query": "test query", "sessionId": "test-session"}})
 
         with patch.object(app, "_get_response_from_entity") as get_response_mock:
             get_response_mock.return_value = {"status": "success", "response": "Test response"}
@@ -1071,8 +1173,8 @@ class TestMCPToolEndpoint:
             with pytest.raises(RuntimeError, match="Agent execution failed"):
                 await app._handle_mcp_tool_invocation("TestAgent", context, client)
 
-    async def test_handle_mcp_tool_invocation_ignores_agent_name_in_thread_id(self) -> None:
-        """Test that MCP tool invocation uses the agent_name parameter, not the name from thread_id."""
+    async def test_handle_mcp_tool_invocation_ignores_agent_name_in_session_id(self) -> None:
+        """Test that MCP tool invocation uses the agent_name parameter, not the name from the session id."""
         mock_agent = Mock()
         mock_agent.name = "PlantAdvisor"
 
@@ -1087,9 +1189,9 @@ class TestMCPToolEndpoint:
         }
         client.read_entity_state.return_value = mock_state
 
-        # Thread ID contains a different agent name (@StockAdvisor@poc123)
+        # Session ID contains a different agent name (@StockAdvisor@poc123)
         # but we're invoking PlantAdvisor - it should use PlantAdvisor's entity
-        context = json.dumps({"arguments": {"query": "test query", "threadId": "@StockAdvisor@test123"}})
+        context = json.dumps({"arguments": {"query": "test query", "sessionId": "@StockAdvisor@test123"}})
 
         with patch.object(app, "_get_response_from_entity") as get_response_mock:
             get_response_mock.return_value = {"status": "success", "response": "Test response"}
@@ -1105,8 +1207,8 @@ class TestMCPToolEndpoint:
             assert entity_id.name == "dafx-PlantAdvisor"
             assert entity_id.key == "test123"
 
-    async def test_handle_mcp_tool_invocation_uses_plain_thread_id_as_key(self) -> None:
-        """Test that a plain thread_id (not in @name@key format) is used as-is for the key."""
+    async def test_handle_mcp_tool_invocation_uses_plain_session_id_as_key(self) -> None:
+        """Test that a plain session id (not in @name@key format) is used as-is for the key."""
         mock_agent = Mock()
         mock_agent.name = "TestAgent"
 
@@ -1120,8 +1222,8 @@ class TestMCPToolEndpoint:
         }
         client.read_entity_state.return_value = mock_state
 
-        # Plain thread_id without @name@key format
-        context = json.dumps({"arguments": {"query": "test query", "threadId": "simple-thread-123"}})
+        # Plain session id without @name@key format
+        context = json.dumps({"arguments": {"query": "test query", "sessionId": "simple-session-123"}})
 
         with patch.object(app, "_get_response_from_entity") as get_response_mock:
             get_response_mock.return_value = {"status": "success", "response": "Test response"}
@@ -1133,7 +1235,59 @@ class TestMCPToolEndpoint:
             entity_id = call_args[0][0]
 
             assert entity_id.name == "dafx-TestAgent"
-            assert entity_id.key == "simple-thread-123"
+            assert entity_id.key == "simple-session-123"
+
+    async def test_handle_mcp_tool_invocation_accepts_legacy_thread_id(self) -> None:
+        """The deprecated threadId argument is still honored when sessionId is absent."""
+        mock_agent = Mock()
+        mock_agent.name = "TestAgent"
+
+        app = AgentFunctionApp(agents=[mock_agent])
+        client = AsyncMock()
+
+        mock_state = Mock()
+        mock_state.entity_state = {
+            "schemaVersion": "1.0.0",
+            "data": {"conversationHistory": []},
+        }
+        client.read_entity_state.return_value = mock_state
+
+        context = json.dumps({"arguments": {"query": "test query", "threadId": "legacy-key-123"}})
+
+        with patch.object(app, "_get_response_from_entity") as get_response_mock:
+            get_response_mock.return_value = {"status": "success", "response": "Test response"}
+
+            await app._handle_mcp_tool_invocation("TestAgent", context, client)
+
+            entity_id = client.signal_entity.call_args[0][0]
+            assert entity_id.key == "legacy-key-123"
+
+    async def test_handle_mcp_tool_invocation_prefers_session_id(self) -> None:
+        """The canonical sessionId argument wins over the deprecated threadId alias."""
+        mock_agent = Mock()
+        mock_agent.name = "TestAgent"
+
+        app = AgentFunctionApp(agents=[mock_agent])
+        client = AsyncMock()
+
+        mock_state = Mock()
+        mock_state.entity_state = {
+            "schemaVersion": "1.0.0",
+            "data": {"conversationHistory": []},
+        }
+        client.read_entity_state.return_value = mock_state
+
+        context = json.dumps({
+            "arguments": {"query": "test query", "sessionId": "canonical-key", "threadId": "legacy-key"}
+        })
+
+        with patch.object(app, "_get_response_from_entity") as get_response_mock:
+            get_response_mock.return_value = {"status": "success", "response": "Test response"}
+
+            await app._handle_mcp_tool_invocation("TestAgent", context, client)
+
+            entity_id = client.signal_entity.call_args[0][0]
+            assert entity_id.key == "canonical-key"
 
     def test_health_check_includes_mcp_tool_enabled(self) -> None:
         """Test that health check endpoint includes mcp_tool_enabled field."""
@@ -1241,30 +1395,51 @@ class TestAgentFunctionAppErrorPaths:
         assert "other" in result
         assert "value" in result
 
-    def test_create_session_id_with_thread_id(self) -> None:
-        """Test _create_session_id with provided thread_id."""
+    def test_create_session_id_with_session_key(self) -> None:
+        """Test _create_session_id with a provided session key."""
         app = AgentFunctionApp(enable_http_endpoints=False, enable_health_check=False)
 
-        # With thread_id provided
-        session_id = app._create_session_id("TestAgent", "my-thread-123")
-        assert session_id.key == "my-thread-123"
+        # With a session key provided
+        session_id = app._create_session_id("TestAgent", "my-session-123")
+        assert session_id.key == "my-session-123"
 
-        # Without thread_id (None) - should generate random
+        # Without a session key (None) - should generate random
         session_id = app._create_session_id("TestAgent", None)
         assert session_id.key is not None
         assert len(session_id.key) > 0
 
-    def test_resolve_thread_id_from_body(self) -> None:
-        """Test _resolve_thread_id extracts from body."""
+    def test_resolve_session_id_from_body(self) -> None:
+        """Test _resolve_session_id extracts from body."""
         app = AgentFunctionApp(enable_http_endpoints=False, enable_health_check=False)
 
         mock_req = Mock()
         mock_req.params = {}
 
-        # Thread ID in body - field name is "thread_id"
-        req_body = {"thread_id": "body-thread-123"}
-        result = app._resolve_thread_id(mock_req, req_body)
-        assert result == "body-thread-123"
+        assert app._resolve_session_id(mock_req, {"session_id": "body-session-123"}) == "body-session-123"
+        # The deprecated field name is still accepted.
+        assert app._resolve_session_id(mock_req, {"thread_id": "body-thread-123"}) == "body-thread-123"
+
+    async def test_handle_mcp_tool_invocation_blank_session_id_falls_back_to_thread_id(self) -> None:
+        """A blank sessionId must not shadow a valid deprecated threadId."""
+        mock_agent = Mock()
+        mock_agent.name = "TestAgent"
+
+        app = AgentFunctionApp(agents=[mock_agent])
+        client = AsyncMock()
+
+        mock_state = Mock()
+        mock_state.entity_state = {"schemaVersion": "1.0.0", "data": {"conversationHistory": []}}
+        client.read_entity_state.return_value = mock_state
+
+        context = json.dumps({"arguments": {"query": "q", "sessionId": "   ", "threadId": "legacy-key"}})
+
+        with patch.object(app, "_get_response_from_entity") as get_response_mock:
+            get_response_mock.return_value = {"status": "success", "response": "Test response"}
+
+            await app._handle_mcp_tool_invocation("TestAgent", context, client)
+
+            entity_id = client.signal_entity.call_args[0][0]
+            assert entity_id.key == "legacy-key"
 
     def test_select_body_parser_json_content_type(self) -> None:
         """Test _select_body_parser for JSON content type."""

--- a/python/packages/durabletask/agent_framework_durabletask/__init__.py
+++ b/python/packages/durabletask/agent_framework_durabletask/__init__.py
@@ -3,19 +3,23 @@
 """Durable Task integration for Microsoft Agent Framework."""
 
 import importlib.metadata
+import warnings
+from typing import TYPE_CHECKING
 
+from . import _constants
 from ._async_bridge import run_agent_coroutine
 from ._callbacks import AgentCallbackContext, AgentResponseCallbackProtocol
 from ._client import DurableAIAgentClient
 from ._constants import (
     DEFAULT_MAX_POLL_RETRIES,
     DEFAULT_POLL_INTERVAL_SECONDS,
+    LEGACY_THREAD_ID_FIELD,
     MIMETYPE_APPLICATION_JSON,
     MIMETYPE_TEXT_PLAIN,
     REQUEST_RESPONSE_FORMAT_JSON,
     REQUEST_RESPONSE_FORMAT_TEXT,
-    THREAD_ID_FIELD,
-    THREAD_ID_HEADER,
+    SESSION_ID_FIELD,
+    SESSION_ID_HEADER,
     WAIT_FOR_RESPONSE_FIELD,
     WAIT_FOR_RESPONSE_HEADER,
     ApiResponseFields,
@@ -73,14 +77,50 @@ try:
 except importlib.metadata.PackageNotFoundError:
     __version__ = "0.0.0"  # Fallback for development mode
 
+if TYPE_CHECKING:  # pragma: no cover - declarations for the deprecated aliases below
+    THREAD_ID_FIELD: str
+    THREAD_ID_HEADER: str
+
+# Deprecated public names mapped to (preferred name, value). Resolved here rather than delegated
+# to ``_constants`` so that exactly one warning is emitted, attributed to the importing caller.
+_DEPRECATED_ALIASES = {
+    "THREAD_ID_FIELD": ("SESSION_ID_FIELD", _constants.LEGACY_THREAD_ID_FIELD),
+    "THREAD_ID_HEADER": ("SESSION_ID_HEADER", _constants.LEGACY_THREAD_ID_HEADER),
+}
+
+
+def __getattr__(name: str) -> str:
+    """Resolve deprecated re-exports lazily so importing the package stays warning-free."""
+    alias = _DEPRECATED_ALIASES.get(name)
+    if alias is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+    preferred, value = alias
+    warnings.warn(
+        f"{name} is deprecated and will be removed in a future release; use {preferred} instead. "
+        "Responses no longer emit the 'thread_id' field or the 'x-ms-thread-id' header.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return value
+
+
+def __dir__() -> list[str]:
+    """Include the deprecated aliases so they remain discoverable."""
+    return sorted(set(globals()) | set(_DEPRECATED_ALIASES))
+
+
 __all__ = [
     "DEFAULT_MAX_POLL_RETRIES",
     "DEFAULT_POLL_INTERVAL_SECONDS",
     "DURABLE_NAME_PREFIX",
+    "LEGACY_THREAD_ID_FIELD",
     "MIMETYPE_APPLICATION_JSON",
     "MIMETYPE_TEXT_PLAIN",
     "REQUEST_RESPONSE_FORMAT_JSON",
     "REQUEST_RESPONSE_FORMAT_TEXT",
+    "SESSION_ID_FIELD",
+    "SESSION_ID_HEADER",
     "THREAD_ID_FIELD",
     "THREAD_ID_HEADER",
     "WAIT_FOR_RESPONSE_FIELD",

--- a/python/packages/durabletask/agent_framework_durabletask/_callbacks.py
+++ b/python/packages/durabletask/agent_framework_durabletask/_callbacks.py
@@ -6,6 +6,7 @@ This module enables callers of AgentFunctionApp to supply streaming and final-re
 invoked during durable entity execution.
 """
 
+import warnings
 from dataclasses import dataclass
 from typing import Protocol
 
@@ -14,12 +15,29 @@ from agent_framework import AgentResponse, AgentResponseUpdate
 
 @dataclass(frozen=True)
 class AgentCallbackContext:
-    """Context supplied to callback invocations."""
+    """Context supplied to callback invocations.
+
+    Note:
+        The ``thread_id`` field was renamed to ``session_id``. Reading ``context.thread_id`` still
+        works (with a ``DeprecationWarning``) and positional construction is unchanged, but
+        constructing this class with the ``thread_id=`` keyword is no longer supported. The agent
+        framework is the only producer of this type; callbacks are consumers.
+    """
 
     agent_name: str
     correlation_id: str
-    thread_id: str | None = None
+    session_id: str | None = None
     request_message: str | None = None
+
+    @property
+    def thread_id(self) -> str | None:
+        """Deprecated alias for :attr:`session_id`."""
+        warnings.warn(
+            "AgentCallbackContext.thread_id is deprecated; use session_id instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.session_id
 
 
 class AgentResponseCallbackProtocol(Protocol):

--- a/python/packages/durabletask/agent_framework_durabletask/_constants.py
+++ b/python/packages/durabletask/agent_framework_durabletask/_constants.py
@@ -10,7 +10,8 @@ For serialization constants, use the DurableStateFields, ContentTypes, and Entry
 to ensure consistent field naming between to_dict() and from_dict() methods.
 """
 
-from typing import Final
+import warnings
+from typing import TYPE_CHECKING, Final
 
 # Supported request/response formats and MIME types
 REQUEST_RESPONSE_FORMAT_JSON: str = "json"
@@ -19,10 +20,42 @@ MIMETYPE_APPLICATION_JSON: str = "application/json"
 MIMETYPE_TEXT_PLAIN: str = "text/plain"
 
 # Field and header names
-THREAD_ID_FIELD: str = "thread_id"
-THREAD_ID_HEADER: str = "x-ms-thread-id"
+SESSION_ID_FIELD: str = "session_id"
+SESSION_ID_HEADER: str = "x-ms-session-id"
 WAIT_FOR_RESPONSE_FIELD: str = "wait_for_response"
 WAIT_FOR_RESPONSE_HEADER: str = "x-ms-wait-for-response"
+
+# Deprecated request field name. Incoming requests may still use "thread_id", but responses
+# only ever emit SESSION_ID_FIELD / SESSION_ID_HEADER.
+LEGACY_THREAD_ID_FIELD: str = "thread_id"
+LEGACY_THREAD_ID_HEADER: str = "x-ms-thread-id"
+
+if TYPE_CHECKING:  # pragma: no cover - declarations for the deprecated aliases below
+    THREAD_ID_FIELD: str
+    THREAD_ID_HEADER: str
+
+# Deprecated public names mapped to (preferred name, value).
+_DEPRECATED_ALIASES: Final[dict[str, tuple[str, str]]] = {
+    "THREAD_ID_FIELD": ("SESSION_ID_FIELD", LEGACY_THREAD_ID_FIELD),
+    "THREAD_ID_HEADER": ("SESSION_ID_HEADER", LEGACY_THREAD_ID_HEADER),
+}
+
+
+def __getattr__(name: str) -> str:
+    """Resolve deprecated constant names, emitting a DeprecationWarning."""
+    alias = _DEPRECATED_ALIASES.get(name)
+    if alias is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+    preferred, value = alias
+    warnings.warn(
+        f"{name} is deprecated and will be removed in a future release; use {preferred} instead. "
+        "Responses no longer emit the 'thread_id' field or the 'x-ms-thread-id' header.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return value
+
 
 # Polling configuration
 DEFAULT_MAX_POLL_RETRIES: int = 30

--- a/python/packages/durabletask/agent_framework_durabletask/_entities.py
+++ b/python/packages/durabletask/agent_framework_durabletask/_entities.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import inspect
 import logging
+import warnings
 from datetime import datetime, timezone
 from typing import Any, cast
 
@@ -38,7 +39,7 @@ class AgentEntityStateProviderMixin:
     Concrete classes must implement:
     - _get_state_dict(): fetch raw persisted state dict (default should be {})
     - _set_state_dict(): persist raw state dict
-    - _get_thread_id_from_entity(): fetch the thread ID from the underlying context
+    - _get_session_id_from_entity(): fetch the session ID from the underlying context
     """
 
     _state_cache: DurableAgentState | None = None
@@ -49,12 +50,32 @@ class AgentEntityStateProviderMixin:
     def _set_state_dict(self, state: dict[str, Any]) -> None:
         raise NotImplementedError
 
-    def _get_thread_id_from_entity(self) -> str:
+    def _get_session_id_from_entity(self) -> str:
+        # Subclasses written against the previous API may still override the old hook name.
+        legacy_hook = getattr(self, "_get_thread_id_from_entity", None)
+        if legacy_hook is not None:
+            warnings.warn(
+                f"{type(self).__name__}._get_thread_id_from_entity is deprecated; "
+                "rename it to _get_session_id_from_entity.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            return cast(str, legacy_hook())
         raise NotImplementedError
 
     @property
+    def session_id(self) -> str:
+        return self._get_session_id_from_entity()
+
+    @property
     def thread_id(self) -> str:
-        return self._get_thread_id_from_entity()
+        """Deprecated alias for :attr:`session_id`."""
+        warnings.warn(
+            "AgentEntityStateProviderMixin.thread_id is deprecated; use session_id instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.session_id
 
     @property
     def state(self) -> DurableAgentState:
@@ -136,16 +157,16 @@ class AgentEntity:
             run_request = request
 
         message = run_request.message
-        thread_id = self._state_provider.thread_id
+        session_id = self._state_provider.session_id
         correlation_id = run_request.correlation_id
-        if not thread_id:
-            raise ValueError("Entity State Provider must provide a thread_id")
+        if not session_id:
+            raise ValueError("Entity State Provider must provide a session_id")
         options: dict[str, Any] = dict(run_request.options)
         options.setdefault("response_format", run_request.response_format)
         if not run_request.enable_tool_calls:
             options.setdefault("tools", None)
 
-        logger.debug("[AgentEntity.run] Received ThreadId %s Message: %s", thread_id, run_request)
+        logger.debug("[AgentEntity.run] Received SessionId %s Message: %s", session_id, run_request)
 
         state_request = DurableAgentStateRequest.from_run_request(run_request)
         self.state.data.conversation_history.append(state_request)
@@ -164,7 +185,7 @@ class AgentEntity:
             agent_run_response: AgentResponse = await self._invoke_agent(
                 run_kwargs=run_kwargs,
                 correlation_id=correlation_id,
-                thread_id=thread_id,
+                session_id=session_id,
                 request_message=message,
             )
 
@@ -211,7 +232,7 @@ class AgentEntity:
         self,
         run_kwargs: dict[str, Any],
         correlation_id: str,
-        thread_id: str,
+        session_id: str,
         request_message: str,
     ) -> AgentResponse:
         """Execute the agent, preferring streaming when available."""
@@ -219,7 +240,7 @@ class AgentEntity:
         if self.callback is not None:
             callback_context = self._build_callback_context(
                 correlation_id=correlation_id,
-                thread_id=thread_id,
+                session_id=session_id,
                 request_message=request_message,
             )
 
@@ -319,7 +340,7 @@ class AgentEntity:
     def _build_callback_context(
         self,
         correlation_id: str,
-        thread_id: str,
+        session_id: str,
         request_message: str,
     ) -> AgentCallbackContext:
         """Create the callback context provided to consumers."""
@@ -327,7 +348,7 @@ class AgentEntity:
         return AgentCallbackContext(
             agent_name=agent_name,
             correlation_id=correlation_id,
-            thread_id=thread_id,
+            session_id=session_id,
             request_message=request_message,
         )
 
@@ -349,5 +370,5 @@ class DurableTaskEntityStateProvider(DurableEntity, AgentEntityStateProviderMixi
     def _set_state_dict(self, state: dict[str, Any]) -> None:
         self.set_state(state)
 
-    def _get_thread_id_from_entity(self) -> str:
+    def _get_session_id_from_entity(self) -> str:
         return self.entity_context.entity_id.key

--- a/python/packages/durabletask/tests/integration_tests/test_01_dt_single_agent.py
+++ b/python/packages/durabletask/tests/integration_tests/test_01_dt_single_agent.py
@@ -6,8 +6,8 @@ Tests basic agent operations including:
 - Agent registration and retrieval
 - Single agent interactions
 - Conversation continuity across multiple messages
-- Multi-threaded agent usage
-- Empty thread ID handling
+- Concurrent agent usage
+- Empty session ID handling
 """
 
 from typing import Any, Protocol

--- a/python/packages/durabletask/tests/integration_tests/test_02_dt_multi_agent.py
+++ b/python/packages/durabletask/tests/integration_tests/test_02_dt_multi_agent.py
@@ -5,7 +5,7 @@
 Tests operations with multiple specialized agents:
 - Multiple agent registration
 - Agent-specific tool usage
-- Independent thread management per agent
+- Independent session management per agent
 - Concurrent agent operations
 - Agent isolation and tool routing
 """

--- a/python/packages/durabletask/tests/integration_tests/test_03_dt_single_agent_streaming.py
+++ b/python/packages/durabletask/tests/integration_tests/test_03_dt_single_agent_streaming.py
@@ -93,7 +93,7 @@ class TestSampleReliableStreaming:
         Stream responses from Redis using the sample's RedisStreamResponseHandler.
 
         Args:
-            session_key: The conversation/thread ID to stream from
+            session_key: The conversation/session ID to stream from
             cursor: Optional cursor to resume from
             timeout: Maximum time to wait for stream completion
 

--- a/python/packages/durabletask/tests/integration_tests/test_04_dt_single_agent_orchestration_chaining.py
+++ b/python/packages/durabletask/tests/integration_tests/test_04_dt_single_agent_orchestration_chaining.py
@@ -4,9 +4,9 @@
 
 Tests orchestration patterns with sequential agent calls:
 - Orchestration registration and execution
-- Sequential agent calls on same thread
+- Sequential agent calls in the same session
 - Conversation continuity in orchestrations
-- Thread context preservation
+- Session context preservation
 """
 
 import json

--- a/python/packages/durabletask/tests/integration_tests/test_05_dt_multi_agent_orchestration_concurrency.py
+++ b/python/packages/durabletask/tests/integration_tests/test_05_dt_multi_agent_orchestration_concurrency.py
@@ -5,7 +5,7 @@
 Tests concurrent execution patterns:
 - Parallel agent execution
 - Concurrent orchestration tasks
-- Independent thread management in parallel
+- Independent session management in parallel
 - Result aggregation from concurrent calls
 """
 

--- a/python/packages/durabletask/tests/test_durable_entities.py
+++ b/python/packages/durabletask/tests/test_durable_entities.py
@@ -15,6 +15,7 @@ from agent_framework import AgentResponse, AgentResponseUpdate, Content, Message
 from pydantic import BaseModel
 
 from agent_framework_durabletask import (
+    AgentCallbackContext,
     AgentEntity,
     AgentEntityStateProviderMixin,
     DurableAgentState,
@@ -54,9 +55,30 @@ class MockEntityContext:
 class _InMemoryStateProvider(AgentEntityStateProviderMixin):
     """Test-only state provider for AgentEntity."""
 
-    def __init__(self, *, thread_id: str, initial_state: dict[str, Any] | None = None) -> None:
-        self._thread_id = thread_id
+    def __init__(self, *, session_id: str, initial_state: dict[str, Any] | None = None) -> None:
+        self._session_id = session_id
         self._state_dict: dict[str, Any] = initial_state or {}
+
+    def _get_state_dict(self) -> dict[str, Any]:
+        return self._state_dict
+
+    def _set_state_dict(self, state: dict[str, Any]) -> None:
+        self._state_dict = state
+
+    def _get_session_id_from_entity(self) -> str:
+        return self._session_id
+
+
+def _make_entity(agent: Any, callback: Any = None, *, session_id: str = "test-session") -> AgentEntity:
+    return AgentEntity(agent, callback=callback, state_provider=_InMemoryStateProvider(session_id=session_id))
+
+
+class _LegacyHookStateProvider(AgentEntityStateProviderMixin):
+    """State provider written against the pre-rename API, used to verify the compatibility shim."""
+
+    def __init__(self, *, thread_id: str) -> None:
+        self._thread_id = thread_id
+        self._state_dict: dict[str, Any] = {}
 
     def _get_state_dict(self) -> dict[str, Any]:
         return self._state_dict
@@ -68,8 +90,46 @@ class _InMemoryStateProvider(AgentEntityStateProviderMixin):
         return self._thread_id
 
 
-def _make_entity(agent: Any, callback: Any = None, *, thread_id: str = "test-thread") -> AgentEntity:
-    return AgentEntity(agent, callback=callback, state_provider=_InMemoryStateProvider(thread_id=thread_id))
+class TestSessionIdCompatibility:
+    """Deprecated 'thread' names must keep working while emitting DeprecationWarning."""
+
+    def test_session_id_property_returns_value(self) -> None:
+        provider = _InMemoryStateProvider(session_id="abc")
+        assert provider.session_id == "abc"
+
+    def test_thread_id_property_is_deprecated_alias(self) -> None:
+        provider = _InMemoryStateProvider(session_id="abc")
+        with pytest.warns(DeprecationWarning, match="use session_id instead"):
+            assert provider.thread_id == "abc"
+
+    def test_legacy_hook_still_resolves_session_id(self) -> None:
+        provider = _LegacyHookStateProvider(thread_id="legacy-key")
+        with pytest.warns(DeprecationWarning, match="_get_session_id_from_entity"):
+            assert provider.session_id == "legacy-key"
+
+    def test_callback_context_thread_id_is_deprecated_alias(self) -> None:
+        context = AgentCallbackContext(agent_name="a", correlation_id="c", session_id="s")
+        assert context.session_id == "s"
+        with pytest.warns(DeprecationWarning, match="use session_id instead"):
+            assert context.thread_id == "s"
+
+    def test_deprecated_constants_still_importable(self) -> None:
+        import agent_framework_durabletask as dt
+
+        assert dt.SESSION_ID_FIELD == "session_id"
+        assert dt.SESSION_ID_HEADER == "x-ms-session-id"
+        assert dt.LEGACY_THREAD_ID_FIELD == "thread_id"
+
+        with pytest.warns(DeprecationWarning, match="use SESSION_ID_FIELD instead"):
+            assert dt.THREAD_ID_FIELD == "thread_id"
+        with pytest.warns(DeprecationWarning, match="use SESSION_ID_HEADER instead"):
+            assert dt.THREAD_ID_HEADER == "x-ms-thread-id"
+
+    def test_unknown_attribute_still_raises(self) -> None:
+        import agent_framework_durabletask as dt
+
+        with pytest.raises(AttributeError):
+            _ = dt.NOT_A_REAL_NAME
 
 
 def _role_value(chat_message: DurableAgentStateMessage) -> str:
@@ -263,7 +323,7 @@ class TestAgentEntityRunAgent:
         mock_agent.run = mock_run
 
         callback = RecordingCallback()
-        entity = _make_entity(mock_agent, callback=callback, thread_id="session-1")
+        entity = _make_entity(mock_agent, callback=callback, session_id="session-1")
 
         result = await entity.run(
             {
@@ -284,7 +344,7 @@ class TestAgentEntityRunAgent:
             context = recorded_call.args[1]
             assert context.agent_name == "StreamingAgent"
             assert context.correlation_id == "corr-stream-1"
-            assert context.thread_id == "session-1"
+            assert context.session_id == "session-1"
             assert context.request_message == "Tell me something"
 
         final_call = callback.response_mock.await_args
@@ -292,7 +352,7 @@ class TestAgentEntityRunAgent:
         final_response, final_context = final_call.args
         assert final_context.agent_name == "StreamingAgent"
         assert final_context.correlation_id == "corr-stream-1"
-        assert final_context.thread_id == "session-1"
+        assert final_context.session_id == "session-1"
         assert final_context.request_message == "Tell me something"
         assert getattr(final_response, "text", "").strip()
 
@@ -304,7 +364,7 @@ class TestAgentEntityRunAgent:
         mock_agent.run = _create_mock_run(response=agent_response)
 
         callback = RecordingCallback()
-        entity = _make_entity(mock_agent, callback=callback, thread_id="session-2")
+        entity = _make_entity(mock_agent, callback=callback, session_id="session-2")
 
         result = await entity.run(
             {
@@ -324,7 +384,7 @@ class TestAgentEntityRunAgent:
         final_context = final_call.args[1]
         assert final_context.agent_name == "NonStreamingAgent"
         assert final_context.correlation_id == "corr-final-1"
-        assert final_context.thread_id == "session-2"
+        assert final_context.session_id == "session-2"
         assert final_context.request_message == "Hi"
 
     async def test_run_agent_updates_conversation_history(self) -> None:
@@ -369,14 +429,14 @@ class TestAgentEntityRunAgent:
         await entity.run({"message": "Message 3", "correlationId": "corr-entity-3c"})
         assert len(entity.state.data.conversation_history) == 6
 
-    async def test_run_requires_entity_thread_id(self) -> None:
-        """Test that AgentEntity.run rejects missing entity thread identifiers."""
+    async def test_run_requires_entity_session_id(self) -> None:
+        """Test that AgentEntity.run rejects missing entity session identifiers."""
         mock_agent = Mock()
         mock_agent.run = _create_mock_run(response=_agent_response("Response"))
 
-        entity = _make_entity(mock_agent, thread_id="")
+        entity = _make_entity(mock_agent, session_id="")
 
-        with pytest.raises(ValueError, match="thread_id"):
+        with pytest.raises(ValueError, match="session_id"):
             await entity.run({"message": "Message", "correlationId": "corr-entity-5"})
 
     async def test_run_agent_multiple_conversations(self) -> None:

--- a/python/samples/03_single_agent_streaming/README.md
+++ b/python/samples/03_single_agent_streaming/README.md
@@ -89,12 +89,18 @@ The `RedisStreamCallback` class implements `AgentResponseCallbackProtocol` to ca
 class RedisStreamCallback(AgentResponseCallbackProtocol):
     async def on_streaming_response_update(self, update, context):
         session_id = context.session_id
+        # Track the chunk sequence number per session
+        sequence = self._sequence_numbers.setdefault(session_id, 0)
+
         # Write chunk to Redis Stream
         async with await get_stream_handler() as handler:
             await handler.write_chunk(session_id, update.text, sequence)
+            self._sequence_numbers[session_id] += 1
 
     async def on_agent_response(self, response, context):
         session_id = context.session_id
+        sequence = self._sequence_numbers.get(session_id, 0)
+
         # Write end-of-stream marker
         async with await get_stream_handler() as handler:
             await handler.write_completion(session_id, sequence)

--- a/python/samples/03_single_agent_streaming/README.md
+++ b/python/samples/03_single_agent_streaming/README.md
@@ -90,12 +90,12 @@ class RedisStreamCallback(AgentResponseCallbackProtocol):
     async def on_streaming_response_update(self, update, context):
         # Write chunk to Redis Stream
         async with await get_stream_handler() as handler:
-            await handler.write_chunk(thread_id, update.text, sequence)
+            await handler.write_chunk(session_id, update.text, sequence)
 
     async def on_agent_response(self, response, context):
         # Write end-of-stream marker
         async with await get_stream_handler() as handler:
-            await handler.write_completion(thread_id, sequence)
+            await handler.write_completion(session_id, sequence)
 ```
 
 ### Worker Registration
@@ -114,11 +114,11 @@ The client uses fire-and-forget mode to start the agent and streams from Redis:
 
 ```python
 # Start agent run with wait_for_response=False for non-blocking execution
-travel_planner.run(user_message, thread=thread, options={"wait_for_response": False})
+travel_planner.run(user_message, session=session, options={"wait_for_response": False})
 
 # Stream response from Redis while the agent is processing
 async with await get_stream_handler() as stream_handler:
-    async for chunk in stream_handler.read_stream(thread_id):
+    async for chunk in stream_handler.read_stream(session_id):
         if chunk.text:
             print(chunk.text, end="", flush=True)
         elif chunk.is_done:
@@ -134,7 +134,7 @@ Clients can resume streaming from any point after disconnection:
 ```python
 cursor = "1734649123456-0"  # Entry ID from previous stream
 async with await get_stream_handler() as stream_handler:
-    async for chunk in stream_handler.read_stream(thread_id, cursor=cursor):
+    async for chunk in stream_handler.read_stream(session_id, cursor=cursor):
         # Process chunk
 ```
 

--- a/python/samples/03_single_agent_streaming/README.md
+++ b/python/samples/03_single_agent_streaming/README.md
@@ -88,11 +88,13 @@ The `RedisStreamCallback` class implements `AgentResponseCallbackProtocol` to ca
 ```python
 class RedisStreamCallback(AgentResponseCallbackProtocol):
     async def on_streaming_response_update(self, update, context):
+        session_id = context.session_id
         # Write chunk to Redis Stream
         async with await get_stream_handler() as handler:
             await handler.write_chunk(session_id, update.text, sequence)
 
     async def on_agent_response(self, response, context):
+        session_id = context.session_id
         # Write end-of-stream marker
         async with await get_stream_handler() as handler:
             await handler.write_completion(session_id, sequence)

--- a/python/samples/03_single_agent_streaming/client.py
+++ b/python/samples/03_single_agent_streaming/client.py
@@ -89,15 +89,15 @@ def get_client(
     return DurableAIAgentClient(dts_client)
 
 
-async def stream_from_redis(thread_id: str, cursor: str | None = None) -> None:
+async def stream_from_redis(session_id: str, cursor: str | None = None) -> None:
     """Stream agent responses from Redis.
 
     Args:
-        thread_id: The conversation/thread ID to stream from
+        session_id: The conversation/session ID to stream from
         cursor: Optional cursor to resume from. If None, starts from beginning.
     """
-    stream_key = f"agent-stream:{thread_id}"
-    logger.info(f"Streaming response from Redis (thread: {thread_id[:8]}...)")
+    stream_key = f"agent-stream:{session_id}"
+    logger.info(f"Streaming response from Redis (session: {session_id[:8]}...)")
     logger.debug(f"To manually check Redis, run: redis-cli XLEN {stream_key}")
     if cursor:
         logger.info(f"Resuming from cursor: {cursor}")
@@ -106,7 +106,7 @@ async def stream_from_redis(thread_id: str, cursor: str | None = None) -> None:
         logger.info("Stream handler created, starting to read...")
         try:
             chunk_count = 0
-            async for chunk in stream_handler.read_stream(thread_id, cursor):
+            async for chunk in stream_handler.read_stream(session_id, cursor):
                 chunk_count += 1
                 logger.debug(
                     f"Received chunk #{chunk_count}: error={chunk.error}, is_done={chunk.is_done}, text_len={len(chunk.text) if chunk.text else 0}"

--- a/python/samples/03_single_agent_streaming/worker.py
+++ b/python/samples/03_single_agent_streaming/worker.py
@@ -70,7 +70,7 @@ class RedisStreamCallback(AgentResponseCallbackProtocol):
     """
 
     def __init__(self) -> None:
-        self._sequence_numbers: dict[str, int] = {}  # Track sequence per thread
+        self._sequence_numbers: dict[str, int] = {}  # Track sequence per session
 
     async def on_streaming_response_update(
         self,
@@ -81,11 +81,11 @@ class RedisStreamCallback(AgentResponseCallbackProtocol):
 
         Args:
             update: The streaming response update chunk.
-            context: The callback context with thread_id, agent_name, etc.
+            context: The callback context with session_id, agent_name, etc.
         """
-        thread_id = context.thread_id
-        if not thread_id:
-            logger.warning("No thread_id available for streaming update")
+        session_id = context.session_id
+        if not session_id:
+            logger.warning("No session_id available for streaming update")
             return
 
         if not update.text:
@@ -93,24 +93,24 @@ class RedisStreamCallback(AgentResponseCallbackProtocol):
 
         text = update.text
 
-        # Get or initialize sequence number for this thread
-        if thread_id not in self._sequence_numbers:
-            self._sequence_numbers[thread_id] = 0
+        # Get or initialize sequence number for this session
+        if session_id not in self._sequence_numbers:
+            self._sequence_numbers[session_id] = 0
 
-        sequence = self._sequence_numbers[thread_id]
+        sequence = self._sequence_numbers[session_id]
 
         try:
             # Use context manager to ensure Redis client is properly closed
             async with await get_stream_handler() as stream_handler:
                 # Write chunk to Redis Stream using public API
-                await stream_handler.write_chunk(thread_id, text, sequence)
+                await stream_handler.write_chunk(session_id, text, sequence)
 
-                self._sequence_numbers[thread_id] += 1
+                self._sequence_numbers[session_id] += 1
 
                 logger.debug(
                     "[%s][%s] Wrote chunk to Redis: seq=%d, text=%s",
                     context.agent_name,
-                    thread_id[:8],
+                    session_id[:8],
                     sequence,
                     text,
                 )
@@ -124,26 +124,26 @@ class RedisStreamCallback(AgentResponseCallbackProtocol):
             response: The final agent response.
             context: The callback context.
         """
-        thread_id = context.thread_id
-        if not thread_id:
+        session_id = context.session_id
+        if not session_id:
             return
 
-        sequence = self._sequence_numbers.get(thread_id, 0)
+        sequence = self._sequence_numbers.get(session_id, 0)
 
         try:
             # Use context manager to ensure Redis client is properly closed
             async with await get_stream_handler() as stream_handler:
                 # Write end-of-stream marker using public API
-                await stream_handler.write_completion(thread_id, sequence)
+                await stream_handler.write_completion(session_id, sequence)
 
                 logger.info(
                     "[%s][%s] Agent completed, wrote end-of-stream marker",
                     context.agent_name,
-                    thread_id[:8],
+                    session_id[:8],
                 )
 
                 # Clean up sequence tracker
-                self._sequence_numbers.pop(thread_id, None)
+                self._sequence_numbers.pop(session_id, None)
         except Exception as ex:
             logger.error(f"Error writing end-of-stream marker: {ex}", exc_info=True)
 

--- a/python/samples/04_single_agent_orchestration_chaining/client.py
+++ b/python/samples/04_single_agent_orchestration_chaining/client.py
@@ -3,7 +3,7 @@
 """Client application for starting a single agent chaining orchestration.
 
 This client connects to the Durable Task Scheduler and starts an orchestration
-that runs a writer agent twice sequentially on the same thread, demonstrating
+that runs a writer agent twice sequentially in the same session, demonstrating
 how conversation context is maintained across multiple agent invocations.
 
 Prerequisites:

--- a/python/samples/04_single_agent_orchestration_chaining/sample.py
+++ b/python/samples/04_single_agent_orchestration_chaining/sample.py
@@ -3,12 +3,12 @@
 """Single Agent Orchestration Chaining Sample - Durable Task Integration
 This sample demonstrates chaining two invocations of the same agent inside a Durable Task
 orchestration while preserving the conversation state between runs. The orchestration
-runs the writer agent sequentially on a shared thread to refine text iteratively.
+runs the writer agent sequentially in a shared session to refine text iteratively.
 Components used:
 - FoundryChatClient to construct the writer agent
 - DurableTaskSchedulerWorker and DurableAIAgentWorker for agent hosting
 - DurableTaskSchedulerClient and orchestration for sequential agent invocations
-- Thread management to maintain conversation context across invocations
+- Session management to maintain conversation context across invocations
 Prerequisites:
 - Set FOUNDRY_PROJECT_ENDPOINT and FOUNDRY_MODEL
 - Sign in with Azure CLI for AzureCliCredential authentication

--- a/python/samples/04_single_agent_orchestration_chaining/worker.py
+++ b/python/samples/04_single_agent_orchestration_chaining/worker.py
@@ -3,7 +3,7 @@
 """Worker process for hosting a single agent with chaining orchestration using Durable Task.
 
 This worker registers a writer agent and an orchestration function that demonstrates
-chaining behavior by running the agent twice sequentially on the same thread,
+chaining behavior by running the agent twice sequentially in the same session,
 preserving conversation context between invocations.
 
 Prerequisites:
@@ -75,11 +75,11 @@ def get_orchestration():
 def single_agent_chaining_orchestration(
     context: OrchestrationContext, _: str
 ) -> Generator[Task[AgentResponse], AgentResponse, str]:
-    """Orchestration that runs the writer agent twice on the same thread.
+    """Orchestration that runs the writer agent twice in the same session.
 
     This demonstrates chaining behavior where the output of the first agent run
     becomes part of the input for the second run, all while maintaining the
-    conversation context through a shared thread.
+    conversation context through a shared session.
 
     Args:
         context: The orchestration context
@@ -113,7 +113,7 @@ def single_agent_chaining_orchestration(
     )
     logger.info(f"[Orchestration] Initial response: {initial_response.text}")
 
-    # Second run: Refine the initial response on the same thread
+    # Second run: Refine the initial response in the same session
     improved_prompt = f"Improve this further while keeping it under 25 words: {initial_response.text}"
 
     logger.info("[Orchestration] Second agent run: Refining the sentence: %s", improved_prompt)

--- a/python/samples/azure_functions/01_single_agent/README.md
+++ b/python/samples/azure_functions/01_single_agent/README.md
@@ -44,7 +44,7 @@ The default plain-text response looks like the following:
 ```http
 HTTP/1.1 200 OK
 Content-Type: text/plain; charset=utf-8
-x-ms-thread-id: 4f205157170244bfbd80209df383757e
+x-ms-session-id: 4f205157170244bfbd80209df383757e
 
 Why did the cloud break up with the server?
 
@@ -58,7 +58,7 @@ When you specify the `x-ms-wait-for-response` header or include `"wait_for_respo
   "status": "accepted",
   "response": "Agent request accepted",
   "message": "Tell me a short joke about cloud computing.",
-  "thread_id": "<guid>",
+  "session_id": "<guid>",
   "correlation_id": "<guid>"
 }
 ```

--- a/python/samples/azure_functions/01_single_agent/demo.http
+++ b/python/samples/azure_functions/01_single_agent/demo.http
@@ -13,7 +13,7 @@ Content-Type: application/json
 
 {
   "message": "Add a security element to it.",
-  "thread_id": "thread-001"
+  "session_id": "session-001"
 }
 
 ### Ask for a joke (plain text payload)

--- a/python/samples/azure_functions/02_multi_agent/README.md
+++ b/python/samples/azure_functions/02_multi_agent/README.md
@@ -39,7 +39,7 @@ Expected HTTP 202 payload:
   "status": "accepted",
   "response": "Agent request accepted",
   "message": "What is the weather in Seattle?",
-  "thread_id": "<guid>",
+  "session_id": "<guid>",
   "correlation_id": "<guid>"
 }
 ```
@@ -59,7 +59,7 @@ Expected HTTP 202 payload:
   "status": "accepted",
   "response": "Agent request accepted",
   "message": "Calculate a 20% tip on a $50 bill",
-  "thread_id": "<guid>",
+  "session_id": "<guid>",
   "correlation_id": "<guid>"
 }
 ```

--- a/python/samples/azure_functions/02_multi_agent/demo.http
+++ b/python/samples/azure_functions/02_multi_agent/demo.http
@@ -36,7 +36,7 @@ Content-Type: application/json
 
 {
   "message": "What is the weather in Seattle?",
-  "thread_id": "weather-user-001"
+  "session_id": "weather-user-001"
 }
 
 ###
@@ -49,7 +49,7 @@ Content-Type: application/json
 
 {
   "message": "Calculate a 20% tip on a $50 bill",
-  "thread_id": "math-user-001"
+  "session_id": "math-user-001"
 }
 
 ###

--- a/python/samples/azure_functions/03_reliable_streaming/README.md
+++ b/python/samples/azure_functions/03_reliable_streaming/README.md
@@ -94,12 +94,18 @@ The `RedisStreamCallback` class implements `AgentResponseCallbackProtocol` to ca
 class RedisStreamCallback(AgentResponseCallbackProtocol):
     async def on_streaming_response_update(self, update, context):
         session_id = context.session_id
+        # Track the chunk sequence number per session
+        sequence = self._sequence_numbers.setdefault(session_id, 0)
+
         # Write chunk to Redis Stream
         async with await get_stream_handler() as handler:
             await handler.write_chunk(session_id, update.text, sequence)
+            self._sequence_numbers[session_id] += 1
 
     async def on_agent_response(self, response, context):
         session_id = context.session_id
+        sequence = self._sequence_numbers.get(session_id, 0)
+
         # Write end-of-stream marker
         async with await get_stream_handler() as handler:
             await handler.write_completion(session_id, sequence)

--- a/python/samples/azure_functions/03_reliable_streaming/README.md
+++ b/python/samples/azure_functions/03_reliable_streaming/README.md
@@ -95,12 +95,12 @@ class RedisStreamCallback(AgentResponseCallbackProtocol):
     async def on_streaming_response_update(self, update, context):
         # Write chunk to Redis Stream
         async with await get_stream_handler() as handler:
-            await handler.write_chunk(thread_id, update.text, sequence)
+            await handler.write_chunk(session_id, update.text, sequence)
 
     async def on_agent_response(self, response, context):
         # Write end-of-stream marker
         async with await get_stream_handler() as handler:
-            await handler.write_completion(thread_id, sequence)
+            await handler.write_completion(session_id, sequence)
 ```
 
 ### 2. Custom Streaming Endpoint

--- a/python/samples/azure_functions/03_reliable_streaming/README.md
+++ b/python/samples/azure_functions/03_reliable_streaming/README.md
@@ -93,11 +93,13 @@ The `RedisStreamCallback` class implements `AgentResponseCallbackProtocol` to ca
 ```python
 class RedisStreamCallback(AgentResponseCallbackProtocol):
     async def on_streaming_response_update(self, update, context):
+        session_id = context.session_id
         # Write chunk to Redis Stream
         async with await get_stream_handler() as handler:
             await handler.write_chunk(session_id, update.text, sequence)
 
     async def on_agent_response(self, response, context):
+        session_id = context.session_id
         # Write end-of-stream marker
         async with await get_stream_handler() as handler:
             await handler.write_completion(session_id, sequence)

--- a/python/samples/azure_functions/03_reliable_streaming/function_app.py
+++ b/python/samples/azure_functions/03_reliable_streaming/function_app.py
@@ -68,7 +68,7 @@ class RedisStreamCallback(AgentResponseCallbackProtocol):
 
     def __init__(self) -> None:
         self._logger = logging.getLogger("durableagent.samples.redis_streaming")
-        self._sequence_numbers = {}  # Track sequence per thread
+        self._sequence_numbers = {}  # Track sequence per session
 
     async def on_streaming_response_update(
         self,
@@ -79,11 +79,11 @@ class RedisStreamCallback(AgentResponseCallbackProtocol):
 
         Args:
             update: The streaming response update chunk.
-            context: The callback context with thread_id, agent_name, etc.
+            context: The callback context with session_id, agent_name, etc.
         """
-        thread_id = context.thread_id
-        if not thread_id:
-            self._logger.warning("No thread_id available for streaming update")
+        session_id = context.session_id
+        if not session_id:
+            self._logger.warning("No session_id available for streaming update")
             return
 
         if not update.text:
@@ -91,24 +91,24 @@ class RedisStreamCallback(AgentResponseCallbackProtocol):
 
         text = update.text
 
-        # Get or initialize sequence number for this thread
-        if thread_id not in self._sequence_numbers:
-            self._sequence_numbers[thread_id] = 0
+        # Get or initialize sequence number for this session
+        if session_id not in self._sequence_numbers:
+            self._sequence_numbers[session_id] = 0
 
-        sequence = self._sequence_numbers[thread_id]
+        sequence = self._sequence_numbers[session_id]
 
         try:
             # Use context manager to ensure Redis client is properly closed
             async with await get_stream_handler() as stream_handler:
                 # Write chunk to Redis Stream using public API
-                await stream_handler.write_chunk(thread_id, text, sequence)
+                await stream_handler.write_chunk(session_id, text, sequence)
 
-                self._sequence_numbers[thread_id] += 1
+                self._sequence_numbers[session_id] += 1
 
                 self._logger.info(
                     "[%s][%s] Wrote chunk to Redis: seq=%d, text=%s",
                     context.agent_name,
-                    thread_id[:8],
+                    session_id[:8],
                     sequence,
                     text,
                 )
@@ -122,26 +122,26 @@ class RedisStreamCallback(AgentResponseCallbackProtocol):
             response: The final agent response.
             context: The callback context.
         """
-        thread_id = context.thread_id
-        if not thread_id:
+        session_id = context.session_id
+        if not session_id:
             return
 
-        sequence = self._sequence_numbers.get(thread_id, 0)
+        sequence = self._sequence_numbers.get(session_id, 0)
 
         try:
             # Use context manager to ensure Redis client is properly closed
             async with await get_stream_handler() as stream_handler:
                 # Write end-of-stream marker using public API
-                await stream_handler.write_completion(thread_id, sequence)
+                await stream_handler.write_completion(session_id, sequence)
 
                 self._logger.info(
                     "[%s][%s] Agent completed, wrote end-of-stream marker",
                     context.agent_name,
-                    thread_id[:8],
+                    session_id[:8],
                 )
 
                 # Clean up sequence tracker
-                self._sequence_numbers.pop(thread_id, None)
+                self._sequence_numbers.pop(session_id, None)
         except Exception as ex:
             self._logger.error(f"Error writing end-of-stream marker: {ex}", exc_info=True)
 
@@ -206,7 +206,7 @@ async def stream(req: func.HttpRequest) -> func.HttpResponse:
 
     Response Headers:
         Content-Type: text/event-stream or text/plain based on Accept header
-        x-conversation-id: The conversation/thread ID
+        x-conversation-id: The conversation/session ID
 
     SSE Event Fields (when Accept: text/event-stream):
         id: Redis stream entry ID (use as cursor for resumption)


### PR DESCRIPTION
## Why

The Microsoft Agent Framework replaced its "thread" concept with "session" — `AgentThread` became `AgentSession`, and `GetNewThread` became `CreateSession` ([microsoft/agent-framework#3430](https://github.com/microsoft/agent-framework/pull/3430), [#3501](https://github.com/microsoft/agent-framework/pull/3501)). There are no remaining `AgentThread` references in the framework.

The durable extension's core types were migrated along with that change — we already have `DurableAgentSession`, `AgentSessionId`, and `session_id` throughout. What never got updated was the outward-facing vocabulary: our HTTP and MCP contracts, a handful of Python public symbols, and the docs and samples all still said "thread". The result is a confusing seam where the framework talks about sessions, our internals talk about sessions, and our API talks about threads.

This PR closes that gap so the durable extension speaks the same language as the framework it extends.

## What's changing

- **HTTP surface** — `session_id` is now the canonical query parameter and JSON field, and `x-ms-session-id` is the response header.
- **MCP surface** — agent tools advertise a `sessionId` property.
- **Python public API** — new `SESSION_ID_FIELD` / `SESSION_ID_HEADER` constants, `AgentCallbackContext.session_id`, and `AgentEntityStateProviderMixin.session_id`.
- **Docs and samples** — .NET and Python samples, READMEs, and `demo.http` files updated to the new names.
- **Validation hardening** — blank identifiers are now uniformly treated as absent, and conflicting identifiers are rejected with `400` instead of one silently winning. Both languages behave identically here; previously Python and .NET disagreed.

Genuine threading references (`asyncio.to_thread`, `threading.Lock`, "orchestration thread", "thread-static") were deliberately left alone.

## Compatibility

### Still works — incoming requests

Existing callers do not need to change. The deprecated names are still accepted everywhere they were before:

```bash
# Both of these continue to work and are equivalent
curl -X POST "http://localhost:7071/api/agents/Joker/run?thread_id=my-key"   -d '...'
curl -X POST "http://localhost:7071/api/agents/Joker/run?session_id=my-key"  -d '...'
```

MCP clients that still send `threadId` are honored at runtime even though the property is no longer advertised. On the Python side, `THREAD_ID_FIELD` and `THREAD_ID_HEADER` remain importable (they now emit a `DeprecationWarning`), `context.thread_id` still reads, and subclasses that override the old `_get_thread_id_from_entity` hook keep working.

### Breaking — responses and schema

**1. Responses no longer emit the old names.** Anything reading `thread_id` or `x-ms-thread-id` off a response needs updating:

```jsonc
// Before                          // After
{ "status": 200,                   { "status": 200,
  "thread_id": "abc",                "session_id": "abc",
  "response": { ... } }              "response": { ... } }
```

**2. The MCP tool schema no longer advertises `threadId`.** Clients that discover the schema will see `sessionId`.

**3. `AgentCallbackContext(thread_id=...)` keyword construction now raises `TypeError`** (Python). Positional construction and reading `.thread_id` are unaffected. The framework is the only producer of this type; callbacks are consumers, so this should not affect real usage:

```python
# Still fine — reading, and positional construction
session = context.session_id     # preferred
session = context.thread_id      # works, warns

# No longer valid
AgentCallbackContext(agent_name="a", correlation_id="c", thread_id="t")
```

**4. Blank identifiers behave differently.** A blank `thread_id` in the body used to suppress a real value in the query string. Blank values are now ignored, and the real value wins.

## What reviewers should look at

- **Was "no dual-write on output" the right call?** This PR intentionally does *not* emit both names. That's a clean break for response consumers, chosen because the packages are still prerelease and dual-writing an alias forever has its own cost. Worth a sanity check that the timing is right.
- **Conflict handling.** Supplying two different non-blank identifiers now returns `400` rather than picking a winner. The alternative — letting `session_id` quietly take precedence — is defensible, but silently routing a request to a different conversation than the caller named seemed worse than failing loudly. Both languages now agree on this.
- **The Python deprecation shims.** `THREAD_ID_FIELD` / `THREAD_ID_HEADER` resolve through a module-level `__getattr__` so that importing the package stays warning-free while direct access still warns. This is the least-common pattern in the diff and the most worth a second pair of eyes.
- **The MCP runtime fallback.** `threadId` is still read even though it is no longer in the advertised schema. This is deliberate — it covers clients that cached the old schema — but it does mean the fallback is not exercised by schema-driven callers.

## Validation

- .NET: full solution builds clean; 60/60 Azure Functions and 180/180 Durable Task unit tests pass.
- Python: `ruff`, `ruff format`, `pyright` (both packages), and `mypy` (both suites) all clean; full unit test suite passes with no warnings.
- New regression tests cover both directions: that the new names work, and that the deprecated input names still do.

Closes #46
