### PR TITLE
[.NET] Fix durable agent state serialization for non-JSON tool values

### DIFF
--- a/dotnet/src/Microsoft.Agents.AI.DurableTask/CHANGELOG.md
+++ b/dotnet/src/Microsoft.Agents.AI.DurableTask/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+- Fixed a `JsonTypeInfo metadata ... was not provided` failure when persisting agent state for function calls or results that carry values the state serializer has no metadata for, such as the `AIContent` results returned by MCP tools ([#57](https://github.com/microsoft/agent-framework-durable-extension/pull/57))
 - [BREAKING] Added `IWorkflowClient` overloads that start a registered workflow by name, and made workflow result deserialization case-insensitive so results can be read back when hosted in Azure Functions. External implementations of `IWorkflowClient` must implement the new members, and an untyped `null` first argument is now ambiguous between the `Workflow` and workflow-name overloads ([#48](https://github.com/microsoft/agent-framework-durable-extension/pull/48))
 - [BREAKING] Removed the `AddAIAgents` and `AddWorkflows` bulk registration APIs and changed `AddWorkflow` to return `DurableWorkflowOptions` so multiple workflows can be registered fluently ([#39](https://github.com/microsoft/agent-framework-durable-extension/pull/39))
 - Use "session" instead of "thread" terminology in documentation and API comments ([#47](https://github.com/microsoft/agent-framework-durable-extension/pull/47))

--- a/dotnet/src/Microsoft.Agents.AI.DurableTask/State/DurableAgentStateContent.cs
+++ b/dotnet/src/Microsoft.Agents.AI.DurableTask/State/DurableAgentStateContent.cs
@@ -2,6 +2,7 @@
 
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using System.Text.Json.Serialization.Metadata;
 using Microsoft.Extensions.AI;
 
 namespace Microsoft.Agents.AI.DurableTask.State;
@@ -23,9 +24,22 @@ namespace Microsoft.Agents.AI.DurableTask.State;
 [JsonDerivedType(typeof(DurableAgentStateUnknownContent), "unknown")]
 internal abstract class DurableAgentStateContent
 {
-    private static readonly JsonElement s_nullElement = JsonSerializer.SerializeToElement(
-        value: null,
-        jsonTypeInfo: AIJsonUtilities.DefaultOptions.GetTypeInfo(typeof(object)));
+    /// <summary>
+    /// Type info for <see cref="object"/>, which dispatches on the runtime type of the value being
+    /// serialized.
+    /// </summary>
+    /// <remarks>
+    /// Serializing through <see cref="object"/> rather than the runtime type directly preserves the
+    /// <c>$type</c> discriminator for polymorphic types such as <see cref="AIContent"/>, which keeps the
+    /// persisted JSON self describing. This also matches how chat clients serialize loosely typed tool
+    /// values, so a value read back from durable state produces the same payload as the value that was
+    /// never persisted.
+    /// </remarks>
+    private static readonly JsonTypeInfo s_objectTypeInfo =
+        AIJsonUtilities.DefaultOptions.GetTypeInfo(typeof(object));
+
+    private static readonly JsonElement s_nullElement =
+        JsonSerializer.SerializeToElement(value: null, jsonTypeInfo: s_objectTypeInfo);
 
     /// <summary>
     /// Gets any additional data found during deserialization that does not map to known properties.
@@ -82,9 +96,7 @@ internal abstract class DurableAgentStateContent
         {
             null => s_nullElement,
             JsonElement element => element,
-            _ => JsonSerializer.SerializeToElement(
-                value: value,
-                jsonTypeInfo: AIJsonUtilities.DefaultOptions.GetTypeInfo(value.GetType()))
+            _ => JsonSerializer.SerializeToElement(value: value, jsonTypeInfo: s_objectTypeInfo)
         };
     }
 }

--- a/dotnet/src/Microsoft.Agents.AI.DurableTask/State/DurableAgentStateContent.cs
+++ b/dotnet/src/Microsoft.Agents.AI.DurableTask/State/DurableAgentStateContent.cs
@@ -23,6 +23,10 @@ namespace Microsoft.Agents.AI.DurableTask.State;
 [JsonDerivedType(typeof(DurableAgentStateUnknownContent), "unknown")]
 internal abstract class DurableAgentStateContent
 {
+    private static readonly JsonElement s_nullElement = JsonSerializer.SerializeToElement(
+        value: null,
+        jsonTypeInfo: AIJsonUtilities.DefaultOptions.GetTypeInfo(typeof(object)));
+
     /// <summary>
     /// Gets any additional data found during deserialization that does not map to known properties.
     /// </summary>
@@ -55,6 +59,32 @@ internal abstract class DurableAgentStateContent
             UriContent uriContent => DurableAgentStateUriContent.FromUriContent(uriContent),
             UsageContent usageContent => DurableAgentStateUsageContent.FromUsageContent(usageContent),
             _ => DurableAgentStateUnknownContent.FromUnknownContent(content)
+        };
+    }
+
+    /// <summary>
+    /// Encodes a loosely typed value as a <see cref="JsonElement"/> so that it can be persisted.
+    /// </summary>
+    /// <param name="value">
+    /// The value to encode. Values that are already a <see cref="JsonElement"/> are returned unchanged.
+    /// </param>
+    /// <returns>The encoded value.</returns>
+    /// <remarks>
+    /// <see cref="DurableAgentStateJsonContext"/> is source generated and has no reflection fallback, so
+    /// <see cref="object"/> typed members must be reduced to JSON before the state is written. Otherwise
+    /// serialization throws for any runtime type the context was not generated for, which fails the entity
+    /// operation after the model call has already happened.
+    /// See https://github.com/microsoft/agent-framework-durable-extension/issues/33.
+    /// </remarks>
+    protected static JsonElement ToJsonElement(object? value)
+    {
+        return value switch
+        {
+            null => s_nullElement,
+            JsonElement element => element,
+            _ => JsonSerializer.SerializeToElement(
+                value: value,
+                jsonTypeInfo: AIJsonUtilities.DefaultOptions.GetTypeInfo(value.GetType()))
         };
     }
 }

--- a/dotnet/src/Microsoft.Agents.AI.DurableTask/State/DurableAgentStateFunctionCallContent.cs
+++ b/dotnet/src/Microsoft.Agents.AI.DurableTask/State/DurableAgentStateFunctionCallContent.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
 using System.Collections.Immutable;
+using System.Text.Json;
 using System.Text.Json.Serialization;
 using Microsoft.Extensions.AI;
 
@@ -12,12 +13,19 @@ namespace Microsoft.Agents.AI.DurableTask.State;
 internal sealed class DurableAgentStateFunctionCallContent : DurableAgentStateContent
 {
     /// <summary>
-    /// The function call arguments.
+    /// The function call arguments, each encoded as JSON.
     /// </summary>
+    /// <remarks>
+    /// Arguments produced by a chat client from a model response are already <see cref="JsonElement"/>
+    /// values, but callers can supply <see cref="FunctionCallContent"/> containing arbitrary objects (for
+    /// example when replaying history or resuming an approval). Those are encoded here using
+    /// <see cref="AIJsonUtilities.DefaultOptions"/> so that persisting the state cannot fail on a type the
+    /// state serializer has no metadata for.
+    /// </remarks>
     /// TODO: Consider ensuring that empty dictionaries are omitted from serialization.
     [JsonPropertyName("arguments")]
-    public required IReadOnlyDictionary<string, object?> Arguments { get; init; } =
-        ImmutableDictionary<string, object?>.Empty;
+    public required IReadOnlyDictionary<string, JsonElement> Arguments { get; init; } =
+        ImmutableDictionary<string, JsonElement>.Empty;
 
     /// <summary>
     /// Gets the function call identifier.
@@ -44,9 +52,18 @@ internal sealed class DurableAgentStateFunctionCallContent : DurableAgentStateCo
     /// </returns>
     public static DurableAgentStateFunctionCallContent FromFunctionCallContent(FunctionCallContent content)
     {
+        Dictionary<string, JsonElement> arguments = [];
+        if (content.Arguments is not null)
+        {
+            foreach (KeyValuePair<string, object?> argument in content.Arguments)
+            {
+                arguments[argument.Key] = ToJsonElement(argument.Value);
+            }
+        }
+
         return new DurableAgentStateFunctionCallContent()
         {
-            Arguments = content.Arguments?.ToDictionary() ?? [],
+            Arguments = arguments,
             CallId = content.CallId,
             Name = content.Name
         };
@@ -55,9 +72,12 @@ internal sealed class DurableAgentStateFunctionCallContent : DurableAgentStateCo
     /// <inheritdoc/>
     public override AIContent ToAIContent()
     {
-        return new FunctionCallContent(
-            this.CallId,
-            this.Name,
-            new Dictionary<string, object?>(this.Arguments));
+        Dictionary<string, object?> arguments = new(this.Arguments.Count);
+        foreach (KeyValuePair<string, JsonElement> argument in this.Arguments)
+        {
+            arguments[argument.Key] = argument.Value;
+        }
+
+        return new FunctionCallContent(this.CallId, this.Name, arguments);
     }
 }

--- a/dotnet/src/Microsoft.Agents.AI.DurableTask/State/DurableAgentStateFunctionResultContent.cs
+++ b/dotnet/src/Microsoft.Agents.AI.DurableTask/State/DurableAgentStateFunctionResultContent.cs
@@ -9,11 +9,6 @@ namespace Microsoft.Agents.AI.DurableTask.State;
 /// <summary>
 /// Represents the function result content for a durable agent state response.
 /// </summary>
-/// <remarks>
-/// At most one of <see cref="Result"/>, <see cref="ResultContent"/>, and <see cref="ResultContents"/> is
-/// populated, matching the shape of the value the tool returned. All three are absent when the tool
-/// returned nothing.
-/// </remarks>
 internal sealed class DurableAgentStateFunctionResultContent : DurableAgentStateContent
 {
     /// <summary>
@@ -27,37 +22,18 @@ internal sealed class DurableAgentStateFunctionResultContent : DurableAgentState
     public required string CallId { get; init; }
 
     /// <summary>
-    /// Gets the function result, encoded as JSON.
+    /// Gets the function result, encoded as JSON. Absent when the tool returned nothing.
     /// </summary>
     /// <remarks>
     /// Tools created via <c>AIFunctionFactory</c> already marshal their return values into a
     /// <see cref="JsonElement"/>. Custom <see cref="AIFunction"/> implementations may return arbitrary
-    /// objects, which are serialized here using <see cref="AIJsonUtilities.DefaultOptions"/>.
+    /// objects, and MCP tools return <see cref="AIContent"/> or a collection of it. All of these are
+    /// encoded here using <see cref="AIJsonUtilities.DefaultOptions"/> so that every result shape is
+    /// persisted under this single property.
     /// </remarks>
     [JsonPropertyName("result")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public JsonElement? Result { get; init; }
-
-    /// <summary>
-    /// Gets the function result when the tool returned a single <see cref="AIContent"/> value.
-    /// </summary>
-    /// <remarks>
-    /// MCP tools return <see cref="AIContent"/> from their invocation so that downstream chat clients can
-    /// specialize handling of the tool output (for example, sending image results back to the model as
-    /// multi-modal tool responses). Storing the content in its structured form preserves that behavior
-    /// across durable checkpoints.
-    /// </remarks>
-    [JsonPropertyName("resultContent")]
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public DurableAgentStateContent? ResultContent { get; init; }
-
-    /// <summary>
-    /// Gets the function result when the tool returned a collection of <see cref="AIContent"/> values,
-    /// which MCP tools do when a tool result carries more than one content block.
-    /// </summary>
-    [JsonPropertyName("resultContents")]
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public IReadOnlyList<DurableAgentStateContent>? ResultContents { get; init; }
 
     /// <summary>
     /// Creates a <see cref="DurableAgentStateFunctionResultContent"/> from a <see cref="FunctionResultContent"/>.
@@ -66,60 +42,21 @@ internal sealed class DurableAgentStateFunctionResultContent : DurableAgentState
     /// <returns>A <see cref="DurableAgentStateFunctionResultContent"/> representing the original content.</returns>
     public static DurableAgentStateFunctionResultContent FromFunctionResultContent(FunctionResultContent content)
     {
-        JsonElement? result = null;
-        DurableAgentStateContent? resultContent = null;
-        IReadOnlyList<DurableAgentStateContent>? resultContents = null;
-
-        switch (content.Result)
-        {
-            case null:
-                break;
-
-            case JsonElement element:
-                result = element;
-                break;
-
-            case AIContent aiContent:
-                resultContent = FromAIContent(aiContent);
-                break;
-
-            case IEnumerable<AIContent> aiContents:
-                resultContents = [.. aiContents.Select(FromAIContent)];
-                break;
-
-            default:
-                result = ToJsonElement(content.Result);
-                break;
-        }
-
         return new DurableAgentStateFunctionResultContent()
         {
             CallId = content.CallId,
-            Result = result,
-            ResultContent = resultContent,
-            ResultContents = resultContents
+
+            // A null result is left absent rather than encoded as a JSON null so that it round trips
+            // back to a null FunctionResultContent.Result.
+            Result = content.Result is null ? null : ToJsonElement(content.Result)
         };
     }
 
     /// <inheritdoc/>
     public override AIContent ToAIContent()
     {
-        object? result;
-        if (this.ResultContent is not null)
-        {
-            result = this.ResultContent.ToAIContent();
-        }
-        else if (this.ResultContents is not null)
-        {
-            result = this.ResultContents.Select(content => content.ToAIContent()).ToArray();
-        }
-        else
-        {
-            // Boxing a JsonElement? yields either a boxed JsonElement or null, which matches what
-            // the tool originally returned.
-            result = this.Result;
-        }
-
-        return new FunctionResultContent(this.CallId, result);
+        // Boxing a JsonElement? yields either a boxed JsonElement or null, matching the shape chat
+        // clients expect from a tool whose result was marshalled into JSON.
+        return new FunctionResultContent(this.CallId, this.Result);
     }
 }

--- a/dotnet/src/Microsoft.Agents.AI.DurableTask/State/DurableAgentStateFunctionResultContent.cs
+++ b/dotnet/src/Microsoft.Agents.AI.DurableTask/State/DurableAgentStateFunctionResultContent.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 
+using System.Text.Json;
 using System.Text.Json.Serialization;
 using Microsoft.Extensions.AI;
 
@@ -8,6 +9,11 @@ namespace Microsoft.Agents.AI.DurableTask.State;
 /// <summary>
 /// Represents the function result content for a durable agent state response.
 /// </summary>
+/// <remarks>
+/// At most one of <see cref="Result"/>, <see cref="ResultContent"/>, and <see cref="ResultContents"/> is
+/// populated, matching the shape of the value the tool returned. All three are absent when the tool
+/// returned nothing.
+/// </remarks>
 internal sealed class DurableAgentStateFunctionResultContent : DurableAgentStateContent
 {
     /// <summary>
@@ -21,11 +27,37 @@ internal sealed class DurableAgentStateFunctionResultContent : DurableAgentState
     public required string CallId { get; init; }
 
     /// <summary>
-    /// Gets the function result.
+    /// Gets the function result, encoded as JSON.
     /// </summary>
+    /// <remarks>
+    /// Tools created via <c>AIFunctionFactory</c> already marshal their return values into a
+    /// <see cref="JsonElement"/>. Custom <see cref="AIFunction"/> implementations may return arbitrary
+    /// objects, which are serialized here using <see cref="AIJsonUtilities.DefaultOptions"/>.
+    /// </remarks>
     [JsonPropertyName("result")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public object? Result { get; init; }
+    public JsonElement? Result { get; init; }
+
+    /// <summary>
+    /// Gets the function result when the tool returned a single <see cref="AIContent"/> value.
+    /// </summary>
+    /// <remarks>
+    /// MCP tools return <see cref="AIContent"/> from their invocation so that downstream chat clients can
+    /// specialize handling of the tool output (for example, sending image results back to the model as
+    /// multi-modal tool responses). Storing the content in its structured form preserves that behavior
+    /// across durable checkpoints.
+    /// </remarks>
+    [JsonPropertyName("resultContent")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public DurableAgentStateContent? ResultContent { get; init; }
+
+    /// <summary>
+    /// Gets the function result when the tool returned a collection of <see cref="AIContent"/> values,
+    /// which MCP tools do when a tool result carries more than one content block.
+    /// </summary>
+    [JsonPropertyName("resultContents")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public IReadOnlyList<DurableAgentStateContent>? ResultContents { get; init; }
 
     /// <summary>
     /// Creates a <see cref="DurableAgentStateFunctionResultContent"/> from a <see cref="FunctionResultContent"/>.
@@ -34,16 +66,60 @@ internal sealed class DurableAgentStateFunctionResultContent : DurableAgentState
     /// <returns>A <see cref="DurableAgentStateFunctionResultContent"/> representing the original content.</returns>
     public static DurableAgentStateFunctionResultContent FromFunctionResultContent(FunctionResultContent content)
     {
+        JsonElement? result = null;
+        DurableAgentStateContent? resultContent = null;
+        IReadOnlyList<DurableAgentStateContent>? resultContents = null;
+
+        switch (content.Result)
+        {
+            case null:
+                break;
+
+            case JsonElement element:
+                result = element;
+                break;
+
+            case AIContent aiContent:
+                resultContent = FromAIContent(aiContent);
+                break;
+
+            case IEnumerable<AIContent> aiContents:
+                resultContents = [.. aiContents.Select(FromAIContent)];
+                break;
+
+            default:
+                result = ToJsonElement(content.Result);
+                break;
+        }
+
         return new DurableAgentStateFunctionResultContent()
         {
             CallId = content.CallId,
-            Result = content.Result
+            Result = result,
+            ResultContent = resultContent,
+            ResultContents = resultContents
         };
     }
 
     /// <inheritdoc/>
     public override AIContent ToAIContent()
     {
-        return new FunctionResultContent(this.CallId, this.Result);
+        object? result;
+        if (this.ResultContent is not null)
+        {
+            result = this.ResultContent.ToAIContent();
+        }
+        else if (this.ResultContents is not null)
+        {
+            result = this.ResultContents.Select(content => content.ToAIContent()).ToArray();
+        }
+        else
+        {
+            // Boxing a JsonElement? yields either a boxed JsonElement or null, which matches what
+            // the tool originally returned.
+            result = this.Result;
+        }
+
+        return new FunctionResultContent(this.CallId, result);
     }
 }

--- a/dotnet/tests/Microsoft.Agents.AI.DurableTask.UnitTests/State/DurableAgentStateFunctionCallContentTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.DurableTask.UnitTests/State/DurableAgentStateFunctionCallContentTests.cs
@@ -1,0 +1,114 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System.Text.Json;
+using System.Text.Json.Serialization.Metadata;
+using Microsoft.Agents.AI.DurableTask.State;
+using Microsoft.Extensions.AI;
+
+namespace Microsoft.Agents.AI.DurableTask.Tests.Unit.State;
+
+/// <summary>
+/// Regression tests for function call arguments whose values are not plain JSON.
+/// See https://github.com/microsoft/agent-framework-durable-extension/issues/33.
+/// </summary>
+public sealed class DurableAgentStateFunctionCallContentTests
+{
+    private static readonly JsonTypeInfo s_stateContentTypeInfo =
+        DurableAgentStateJsonContext.Default.GetTypeInfo(typeof(DurableAgentStateContent))!;
+
+    private static FunctionCallContent RoundTrip(FunctionCallContent content)
+    {
+        DurableAgentStateContent durableContent = DurableAgentStateContent.FromAIContent(content);
+        string json = JsonSerializer.Serialize(durableContent, s_stateContentTypeInfo);
+
+        DurableAgentStateContent? deserialized =
+            (DurableAgentStateContent?)JsonSerializer.Deserialize(json, s_stateContentTypeInfo);
+
+        Assert.NotNull(deserialized);
+        return Assert.IsType<FunctionCallContent>(deserialized.ToAIContent());
+    }
+
+    [Fact]
+    public void JsonElementArgumentsRoundTrip()
+    {
+        // Chat clients parse model supplied arguments into JsonElement values.
+        JsonElement city = JsonSerializer.SerializeToElement("Seattle");
+        FunctionCallContent result = RoundTrip(new("call-1", "get_weather", new Dictionary<string, object?>
+        {
+            ["city"] = city
+        }));
+
+        Assert.Equal("call-1", result.CallId);
+        Assert.Equal("get_weather", result.Name);
+        Assert.NotNull(result.Arguments);
+        Assert.Equal("Seattle", Assert.IsType<JsonElement>(result.Arguments["city"]).GetString());
+    }
+
+    [Fact]
+    public void ObjectArgumentRoundTrips()
+    {
+        // Callers can supply function calls containing arbitrary objects, for example when replaying
+        // history or resuming a function approval.
+        FunctionCallContent result = RoundTrip(new("call-2", "get_weather", new Dictionary<string, object?>
+        {
+            ["location"] = new Location("Seattle", "WA")
+        }));
+
+        JsonElement location = Assert.IsType<JsonElement>(result.Arguments!["location"]);
+        Assert.Equal("Seattle", location.GetProperty("city").GetString());
+        Assert.Equal("WA", location.GetProperty("state").GetString());
+    }
+
+    [Fact]
+    public void BclValueArgumentRoundTrips()
+    {
+        // DateOnly is not registered on DurableAgentStateJsonContext, so an object typed argument
+        // holding one used to fail serialization outright.
+        FunctionCallContent result = RoundTrip(new("call-3", "get_forecast", new Dictionary<string, object?>
+        {
+            ["date"] = new DateOnly(2026, 1, 31)
+        }));
+
+        Assert.Equal("2026-01-31", Assert.IsType<JsonElement>(result.Arguments!["date"]).GetString());
+    }
+
+    [Fact]
+    public void NullArgumentRoundTrips()
+    {
+        FunctionCallContent result = RoundTrip(new("call-4", "get_weather", new Dictionary<string, object?>
+        {
+            ["city"] = null
+        }));
+
+        Assert.Equal(JsonValueKind.Null, Assert.IsType<JsonElement>(result.Arguments!["city"]).ValueKind);
+    }
+
+    [Fact]
+    public void NoArgumentsRoundTrip()
+    {
+        FunctionCallContent result = RoundTrip(new("call-5", "get_time", arguments: null));
+
+        Assert.Equal("get_time", result.Name);
+        Assert.Empty(result.Arguments!);
+    }
+
+    [Fact]
+    public void PreviouslyPersistedArgumentsAreStillReadable()
+    {
+        // State written before arguments were normalized stores the raw JSON under "arguments".
+        const string LegacyJson =
+            """{"$type":"functionCall","arguments":{"city":"Seattle","days":3},"callId":"call-6","name":"get_forecast"}""";
+
+        DurableAgentStateContent? deserialized =
+            (DurableAgentStateContent?)JsonSerializer.Deserialize(LegacyJson, s_stateContentTypeInfo);
+
+        Assert.NotNull(deserialized);
+        FunctionCallContent result = Assert.IsType<FunctionCallContent>(deserialized.ToAIContent());
+
+        Assert.Equal("call-6", result.CallId);
+        Assert.Equal("Seattle", Assert.IsType<JsonElement>(result.Arguments!["city"]).GetString());
+        Assert.Equal(3, Assert.IsType<JsonElement>(result.Arguments["days"]).GetInt32());
+    }
+
+    private sealed record Location(string City, string State);
+}

--- a/dotnet/tests/Microsoft.Agents.AI.DurableTask.UnitTests/State/DurableAgentStateFunctionResultContentTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.DurableTask.UnitTests/State/DurableAgentStateFunctionResultContentTests.cs
@@ -1,0 +1,129 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System.Text.Json;
+using System.Text.Json.Serialization.Metadata;
+using Microsoft.Agents.AI.DurableTask.State;
+using Microsoft.Extensions.AI;
+
+namespace Microsoft.Agents.AI.DurableTask.Tests.Unit.State;
+
+/// <summary>
+/// Regression tests for function results that are not plain JSON values, such as the
+/// <see cref="AIContent"/> results produced by MCP tools.
+/// See https://github.com/microsoft/agent-framework-durable-extension/issues/33.
+/// </summary>
+public sealed class DurableAgentStateFunctionResultContentTests
+{
+    private static readonly JsonTypeInfo s_stateContentTypeInfo =
+        DurableAgentStateJsonContext.Default.GetTypeInfo(typeof(DurableAgentStateContent))!;
+
+    private static FunctionResultContent RoundTrip(FunctionResultContent content)
+    {
+        DurableAgentStateContent durableContent = DurableAgentStateContent.FromAIContent(content);
+        string json = JsonSerializer.Serialize(durableContent, s_stateContentTypeInfo);
+
+        DurableAgentStateContent? deserialized =
+            (DurableAgentStateContent?)JsonSerializer.Deserialize(json, s_stateContentTypeInfo);
+
+        Assert.NotNull(deserialized);
+        return Assert.IsType<FunctionResultContent>(deserialized.ToAIContent());
+    }
+
+    [Fact]
+    public void SingleAIContentResultRoundTrips()
+    {
+        // McpClientTool returns a single AIContent when the tool result has exactly one content block.
+        FunctionResultContent result = RoundTrip(new("call-1", new TextContent("hello from mcp")));
+
+        Assert.Equal("call-1", result.CallId);
+        TextContent text = Assert.IsType<TextContent>(result.Result);
+        Assert.Equal("hello from mcp", text.Text);
+    }
+
+    [Fact]
+    public void MultipleAIContentResultsRoundTrip()
+    {
+        // McpClientTool returns AIContent[] when the tool result has multiple content blocks.
+        AIContent[] contents = [new TextContent("first"), new UriContent("https://example.com/img.png", "image/png")];
+        FunctionResultContent result = RoundTrip(new("call-2", contents));
+
+        Assert.Equal("call-2", result.CallId);
+        IEnumerable<AIContent> roundTripped = Assert.IsAssignableFrom<IEnumerable<AIContent>>(result.Result);
+
+        AIContent[] items = [.. roundTripped];
+        Assert.Equal(2, items.Length);
+        Assert.Equal("first", Assert.IsType<TextContent>(items[0]).Text);
+        Assert.Equal(new Uri("https://example.com/img.png"), Assert.IsType<UriContent>(items[1]).Uri);
+    }
+
+    [Fact]
+    public void JsonElementResultRoundTrips()
+    {
+        // Tools created through AIFunctionFactory marshal their return value into a JsonElement.
+        JsonElement element = JsonSerializer.SerializeToElement(new { city = "Seattle", tempF = 72 });
+        FunctionResultContent result = RoundTrip(new("call-3", element));
+
+        JsonElement roundTripped = Assert.IsType<JsonElement>(result.Result);
+        Assert.Equal("Seattle", roundTripped.GetProperty("city").GetString());
+        Assert.Equal(72, roundTripped.GetProperty("tempF").GetInt32());
+    }
+
+    [Fact]
+    public void ObjectResultRoundTrips()
+    {
+        // Custom AIFunction implementations may return arbitrary objects.
+        FunctionResultContent result = RoundTrip(new("call-4", new Forecast("Seattle", 72)));
+
+        JsonElement roundTripped = Assert.IsType<JsonElement>(result.Result);
+        Assert.Equal("Seattle", roundTripped.GetProperty("city").GetString());
+        Assert.Equal(72, roundTripped.GetProperty("tempF").GetInt32());
+    }
+
+    [Fact]
+    public void StringResultRoundTrips()
+    {
+        FunctionResultContent result = RoundTrip(new("call-5", "return value"));
+
+        JsonElement roundTripped = Assert.IsType<JsonElement>(result.Result);
+        Assert.Equal("return value", roundTripped.GetString());
+    }
+
+    [Fact]
+    public void NullResultRoundTrips()
+    {
+        FunctionResultContent result = RoundTrip(new("call-6", result: null));
+
+        Assert.Equal("call-6", result.CallId);
+        Assert.Null(result.Result);
+    }
+
+    [Fact]
+    public void ErrorContentResultRoundTrips()
+    {
+        // MCP tools surface tool failures as an ErrorContent result rather than a JSON payload.
+        FunctionResultContent result = RoundTrip(new("call-8", new ErrorContent("tool exploded") { ErrorCode = "E42" }));
+
+        ErrorContent error = Assert.IsType<ErrorContent>(result.Result);
+        Assert.Equal("tool exploded", error.Message);
+        Assert.Equal("E42", error.ErrorCode);
+    }
+
+    [Fact]
+    public void PreviouslyPersistedResultIsStillReadable()
+    {
+        // State written before AIContent results were supported stores the raw JSON under "result".
+        const string LegacyJson = """{"$type":"functionResult","callId":"call-7","result":{"city":"Seattle"}}""";
+
+        DurableAgentStateContent? deserialized =
+            (DurableAgentStateContent?)JsonSerializer.Deserialize(LegacyJson, s_stateContentTypeInfo);
+
+        Assert.NotNull(deserialized);
+        FunctionResultContent result = Assert.IsType<FunctionResultContent>(deserialized.ToAIContent());
+
+        Assert.Equal("call-7", result.CallId);
+        JsonElement element = Assert.IsType<JsonElement>(result.Result);
+        Assert.Equal("Seattle", element.GetProperty("city").GetString());
+    }
+
+    private sealed record Forecast(string City, int TempF);
+}

--- a/dotnet/tests/Microsoft.Agents.AI.DurableTask.UnitTests/State/DurableAgentStateFunctionResultContentTests.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.DurableTask.UnitTests/State/DurableAgentStateFunctionResultContentTests.cs
@@ -9,7 +9,9 @@ namespace Microsoft.Agents.AI.DurableTask.Tests.Unit.State;
 
 /// <summary>
 /// Regression tests for function results that are not plain JSON values, such as the
-/// <see cref="AIContent"/> results produced by MCP tools.
+/// <see cref="AIContent"/> results produced by MCP tools. Every result shape is persisted under the
+/// single <c>result</c> property, encoded through <see cref="object"/> so that the polymorphic
+/// <c>$type</c> discriminator is retained.
 /// See https://github.com/microsoft/agent-framework-durable-extension/issues/33.
 /// </summary>
 public sealed class DurableAgentStateFunctionResultContentTests
@@ -36,8 +38,10 @@ public sealed class DurableAgentStateFunctionResultContentTests
         FunctionResultContent result = RoundTrip(new("call-1", new TextContent("hello from mcp")));
 
         Assert.Equal("call-1", result.CallId);
-        TextContent text = Assert.IsType<TextContent>(result.Result);
-        Assert.Equal("hello from mcp", text.Text);
+
+        JsonElement roundTripped = Assert.IsType<JsonElement>(result.Result);
+        Assert.Equal("text", roundTripped.GetProperty("$type").GetString());
+        Assert.Equal("hello from mcp", roundTripped.GetProperty("text").GetString());
     }
 
     [Fact]
@@ -48,12 +52,15 @@ public sealed class DurableAgentStateFunctionResultContentTests
         FunctionResultContent result = RoundTrip(new("call-2", contents));
 
         Assert.Equal("call-2", result.CallId);
-        IEnumerable<AIContent> roundTripped = Assert.IsAssignableFrom<IEnumerable<AIContent>>(result.Result);
 
-        AIContent[] items = [.. roundTripped];
+        JsonElement roundTripped = Assert.IsType<JsonElement>(result.Result);
+        Assert.Equal(JsonValueKind.Array, roundTripped.ValueKind);
+
+        JsonElement[] items = [.. roundTripped.EnumerateArray()];
         Assert.Equal(2, items.Length);
-        Assert.Equal("first", Assert.IsType<TextContent>(items[0]).Text);
-        Assert.Equal(new Uri("https://example.com/img.png"), Assert.IsType<UriContent>(items[1]).Uri);
+        Assert.Equal("text", items[0].GetProperty("$type").GetString());
+        Assert.Equal("first", items[0].GetProperty("text").GetString());
+        Assert.Equal("uri", items[1].GetProperty("$type").GetString());
     }
 
     [Fact]
@@ -103,9 +110,10 @@ public sealed class DurableAgentStateFunctionResultContentTests
         // MCP tools surface tool failures as an ErrorContent result rather than a JSON payload.
         FunctionResultContent result = RoundTrip(new("call-8", new ErrorContent("tool exploded") { ErrorCode = "E42" }));
 
-        ErrorContent error = Assert.IsType<ErrorContent>(result.Result);
-        Assert.Equal("tool exploded", error.Message);
-        Assert.Equal("E42", error.ErrorCode);
+        JsonElement roundTripped = Assert.IsType<JsonElement>(result.Result);
+        Assert.Equal("error", roundTripped.GetProperty("$type").GetString());
+        Assert.Equal("tool exploded", roundTripped.GetProperty("message").GetString());
+        Assert.Equal("E42", roundTripped.GetProperty("errorCode").GetString());
     }
 
     [Fact]


### PR DESCRIPTION
Fixes #33.

## Problem

A durable agent configured with MCP tools fails the moment a tool is invoked. The LLM call succeeds, the tool runs, and then persisting the entity state throws:

```
System.NotSupportedException: JsonTypeInfo metadata for type 'Microsoft.Extensions.AI.TextContent'
was not provided by TypeInfoResolver of type 'DurableAgentStateJsonContext'.
... Path: $.Result
```

Because the failure happens inside the entity operation, the operation is retried forever — the caller's HTTP request never returns, and the agent is effectively wedged.

## Root cause

`DurableAgentStateJsonContext` is source generated and deliberately has no reflection fallback, so every `object`-typed member of the state model must be reduced to JSON *before* the state is handed to the serializer. Two members were not.

**1. `DurableAgentStateFunctionResultContent.Result` (the reported bug)**

It stored `FunctionResultContent.Result` as a plain `object?`. Tools built by `AIFunctionFactory` marshal their return value into a `JsonElement`, which is registered in the context — so local tools work. `McpClientTool.InvokeCoreAsync` does not: it returns a `Microsoft.Extensions.AI.AIContent` when the `CallToolResult` has a single content block, an `AIContent[]` when it has several, and only falls back to `JsonSerializer.SerializeToElement` for error/structured/meta cases. Those first two shapes hit the missing-metadata path.

**2. `DurableAgentStateFunctionCallContent.Arguments` (same hole, latent)**

`IReadOnlyDictionary<string, object?>` has exactly the same problem and fails identically with `Path: $.Arguments`. It goes unnoticed today only because model-supplied arguments happen to arrive as `JsonElement`. Any caller-supplied `FunctionCallContent` holding another value fails — including plain BCL types such as `DateOnly` — which is reachable through history replay, human-in-the-loop/approval resumption, and middleware that strong-types arguments before they reach the entity. Fixing it alongside avoids shipping a fix for one half of the same bug.

## Fix

- **`DurableAgentStateContent`** gains a shared `protected static JsonElement ToJsonElement(object?)` helper backed by `AIJsonUtilities.DefaultOptions`, plus a cached element for the `null` case. This is the single place loosely typed values get reduced to JSON. The pattern (resolving `JsonTypeInfo` from `AIJsonUtilities.DefaultOptions`) was already used by `DurableAgentStateUnknownContent`, so AOT compatibility is unchanged.
- **`DurableAgentStateFunctionResultContent.Result`** is narrowed from `object?` to `JsonElement?`, and every result shape — `JsonElement`, arbitrary objects, and the `AIContent` / `AIContent[]` that MCP tools return — is encoded through `ToJsonElement` into that single existing `result` property. Values are serialized via `typeof(object)` rather than their runtime type, which retains the polymorphic `$type` discriminator and keeps the stored JSON self describing. A null result is left absent rather than written as JSON `null`, so it round-trips back to null.
- **`DurableAgentStateFunctionCallContent.Arguments`** becomes `IReadOnlyDictionary<string, JsonElement>`, with values encoded on the way in.

## Serialization format

No property is added or removed. Every function result is persisted under the existing `result` property, so the DTS dashboard keeps working, `schemas/durable-agent-entity-state.json` stays accurate as written, and the shape stays aligned with the Python implementation.

Comparing the stored JSON before and after this change, every shape that already serialized on `main` is byte-identical:

```
JsonElement result     {"$type":"functionResult","callId":"r1","result":{"city":"Seattle","tempF":72}}
string result          {"$type":"functionResult","callId":"r2","result":"just text"}
null result            {"$type":"functionResult","callId":"r3"}
args (JsonElement)     {"$type":"functionCall","arguments":{"city":"Seattle","days":3},...}
args (raw string/int)  {"$type":"functionCall","arguments":{"city":"Seattle","days":3},...}
args (null value)      {"$type":"functionCall","arguments":{"x":null},...}
```

The only shapes whose output changes are the three MCP ones, which previously threw:

```
MCP single AIContent   {"$type":"functionResult","callId":"m1","result":{"$type":"text","text":"hi from mcp"}}
MCP multi AIContent    {"$type":"functionResult","callId":"m2","result":[{"$type":"text",...},{"$type":"uri",...}]}
MCP ErrorContent       {"$type":"functionResult","callId":"m3","result":{"$type":"error","message":"boom",...}}
```

## Compatibility

State written by previous versions deserializes unchanged: `result` was always raw JSON and now lands in a `JsonElement?`, and `arguments` was always a JSON object and now lands in a `Dictionary<string, JsonElement>`. `ToAIContent()` still hands back boxed `JsonElement` values, which is exactly what the model-supplied path produces today, so consumers see no difference.

Rollback is also safe: feeding the new MCP payloads above to the previous version's code deserializes cleanly (`result` was `object?`, so it lands as a `JsonElement`) and re-serializes byte-identically.

One intentional behavior change: an argument whose value was CLR `null` now round-trips as a `JsonElement` of `ValueKind.Null` rather than `null`. This matches what the model path already produces, and `NullArgumentRoundTrips` pins it.

## Testing

14 new round-trip tests across `DurableAgentStateFunctionCallContentTests` and `DurableAgentStateFunctionResultContentTests`, covering single `AIContent`, multiple `AIContent`, MCP `ErrorContent`, arbitrary objects, `JsonElement` passthrough, BCL values, null, and empty results.

Reverting the three source files makes exactly 7 of them fail with the error from the issue, so they genuinely pin the bug rather than the implementation.

Full suite: 207/207 `Microsoft.Agents.AI.DurableTask.UnitTests`, 65/65 `Microsoft.Agents.AI.Hosting.AzureFunctions.UnitTests`, clean solution build with no new warnings.

This was also verified end-to-end using a throwaway Azure Functions sample with a real MCP tool server against live Azure OpenAI: without the fix the host logged the issue's exception verbatim and the HTTP request hung indefinitely; with it the agent answered normally. The scratch sample is not part of this PR. That run predates the format change described below; the change was re-verified at unit level by confirming the stored JSON and the resulting model-facing payloads are unchanged.

## Review feedback

The first revision of this PR stored `AIContent` results in two additional properties, `resultContent` and `resultContents`. Per review, those were collapsed into the single `result` property so the DTS dashboard, the entity state schema, and the Python serialization format all stay accurate without changes.

The fidelity that structured storage would have preserved is narrow, and giving it up is not a regression — that path threw before this fix. `OpenAIChatClient` flattens the result to JSON anyway, so its output is byte-identical either way. `OpenAIResponsesChatClient` does specialize `AIContent` into `input_text` / `input_image` / `input_file` parts, so a multi-modal MCP result is now replayed as JSON instead.

Reviving `AIContent` from the stored JSON was considered and rejected: the polymorphic `$type` discriminator is only emitted when the runtime collection type is `AIContent[]` / `IList<AIContent>`. A tool returning `TextContent[]` serializes without it and would silently revive as a bare `AIContent` with the payload dropped, which is a worse failure mode than storing JSON.
