### PR TITLE
.NET: Add local settings templates to Azure Functions samples

### DIFF
--- a/dotnet/samples/.gitignore
+++ b/dotnet/samples/.gitignore
@@ -1,0 +1,2 @@
+# Azure Functions local settings may contain secrets.
+local.settings.json

--- a/dotnet/samples/Directory.Build.props
+++ b/dotnet/samples/Directory.Build.props
@@ -15,6 +15,13 @@
   </ItemGroup>
 
   <ItemGroup>
+    <None Update="local.settings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToPublishDirectory>Never</CopyToPublishDirectory>
+    </None>
+  </ItemGroup>
+
+  <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)\..\src\Shared\Demos\*.cs" LinkBase="" Visible="false" />
   </ItemGroup>
 

--- a/dotnet/samples/DurableAgents/AzureFunctions/01_SingleAgent/local.settings.json.template
+++ b/dotnet/samples/DurableAgents/AzureFunctions/01_SingleAgent/local.settings.json.template
@@ -1,0 +1,10 @@
+{
+  "IsEncrypted": false,
+  "Values": {
+    "FUNCTIONS_WORKER_RUNTIME": "dotnet-isolated",
+    "AzureWebJobsStorage": "UseDevelopmentStorage=true",
+    "DURABLE_TASK_SCHEDULER_CONNECTION_STRING": "Endpoint=http://localhost:8080;TaskHub=default;Authentication=None",
+    "FOUNDRY_PROJECT_ENDPOINT": "https://your-foundry-resource.services.ai.azure.com/api/projects/your-project",
+    "FOUNDRY_MODEL": "your-deployment-name"
+  }
+}

--- a/dotnet/samples/DurableAgents/AzureFunctions/02_AgentOrchestration_Chaining/local.settings.json.template
+++ b/dotnet/samples/DurableAgents/AzureFunctions/02_AgentOrchestration_Chaining/local.settings.json.template
@@ -1,0 +1,10 @@
+{
+  "IsEncrypted": false,
+  "Values": {
+    "FUNCTIONS_WORKER_RUNTIME": "dotnet-isolated",
+    "AzureWebJobsStorage": "UseDevelopmentStorage=true",
+    "DURABLE_TASK_SCHEDULER_CONNECTION_STRING": "Endpoint=http://localhost:8080;TaskHub=default;Authentication=None",
+    "FOUNDRY_PROJECT_ENDPOINT": "https://your-foundry-resource.services.ai.azure.com/api/projects/your-project",
+    "FOUNDRY_MODEL": "your-deployment-name"
+  }
+}

--- a/dotnet/samples/DurableAgents/AzureFunctions/03_AgentOrchestration_Concurrency/local.settings.json.template
+++ b/dotnet/samples/DurableAgents/AzureFunctions/03_AgentOrchestration_Concurrency/local.settings.json.template
@@ -1,0 +1,10 @@
+{
+  "IsEncrypted": false,
+  "Values": {
+    "FUNCTIONS_WORKER_RUNTIME": "dotnet-isolated",
+    "AzureWebJobsStorage": "UseDevelopmentStorage=true",
+    "DURABLE_TASK_SCHEDULER_CONNECTION_STRING": "Endpoint=http://localhost:8080;TaskHub=default;Authentication=None",
+    "FOUNDRY_PROJECT_ENDPOINT": "https://your-foundry-resource.services.ai.azure.com/api/projects/your-project",
+    "FOUNDRY_MODEL": "your-deployment-name"
+  }
+}

--- a/dotnet/samples/DurableAgents/AzureFunctions/04_AgentOrchestration_Conditionals/local.settings.json.template
+++ b/dotnet/samples/DurableAgents/AzureFunctions/04_AgentOrchestration_Conditionals/local.settings.json.template
@@ -1,0 +1,10 @@
+{
+  "IsEncrypted": false,
+  "Values": {
+    "FUNCTIONS_WORKER_RUNTIME": "dotnet-isolated",
+    "AzureWebJobsStorage": "UseDevelopmentStorage=true",
+    "DURABLE_TASK_SCHEDULER_CONNECTION_STRING": "Endpoint=http://localhost:8080;TaskHub=default;Authentication=None",
+    "FOUNDRY_PROJECT_ENDPOINT": "https://your-foundry-resource.services.ai.azure.com/api/projects/your-project",
+    "FOUNDRY_MODEL": "your-deployment-name"
+  }
+}

--- a/dotnet/samples/DurableAgents/AzureFunctions/05_AgentOrchestration_HITL/local.settings.json.template
+++ b/dotnet/samples/DurableAgents/AzureFunctions/05_AgentOrchestration_HITL/local.settings.json.template
@@ -1,0 +1,10 @@
+{
+  "IsEncrypted": false,
+  "Values": {
+    "FUNCTIONS_WORKER_RUNTIME": "dotnet-isolated",
+    "AzureWebJobsStorage": "UseDevelopmentStorage=true",
+    "DURABLE_TASK_SCHEDULER_CONNECTION_STRING": "Endpoint=http://localhost:8080;TaskHub=default;Authentication=None",
+    "FOUNDRY_PROJECT_ENDPOINT": "https://your-foundry-resource.services.ai.azure.com/api/projects/your-project",
+    "FOUNDRY_MODEL": "your-deployment-name"
+  }
+}

--- a/dotnet/samples/DurableAgents/AzureFunctions/06_LongRunningTools/local.settings.json.template
+++ b/dotnet/samples/DurableAgents/AzureFunctions/06_LongRunningTools/local.settings.json.template
@@ -1,0 +1,10 @@
+{
+  "IsEncrypted": false,
+  "Values": {
+    "FUNCTIONS_WORKER_RUNTIME": "dotnet-isolated",
+    "AzureWebJobsStorage": "UseDevelopmentStorage=true",
+    "DURABLE_TASK_SCHEDULER_CONNECTION_STRING": "Endpoint=http://localhost:8080;TaskHub=default;Authentication=None",
+    "FOUNDRY_PROJECT_ENDPOINT": "https://your-foundry-resource.services.ai.azure.com/api/projects/your-project",
+    "FOUNDRY_MODEL": "your-deployment-name"
+  }
+}

--- a/dotnet/samples/DurableAgents/AzureFunctions/07_AgentAsMcpTool/README.md
+++ b/dotnet/samples/DurableAgents/AzureFunctions/07_AgentAsMcpTool/README.md
@@ -32,7 +32,7 @@ For this sample, you'll also need to install [node.js](https://nodejs.org/en/dow
 
 ## Configuration
 
-Update your `local.settings.json` with your Foundry project configuration:
+Copy `local.settings.json.template` to `local.settings.json`, then update it with your Foundry project configuration:
 
 ```json
 {

--- a/dotnet/samples/DurableAgents/AzureFunctions/07_AgentAsMcpTool/local.settings.json.template
+++ b/dotnet/samples/DurableAgents/AzureFunctions/07_AgentAsMcpTool/local.settings.json.template
@@ -1,0 +1,10 @@
+{
+  "IsEncrypted": false,
+  "Values": {
+    "FUNCTIONS_WORKER_RUNTIME": "dotnet-isolated",
+    "AzureWebJobsStorage": "UseDevelopmentStorage=true",
+    "DURABLE_TASK_SCHEDULER_CONNECTION_STRING": "Endpoint=http://localhost:8080;TaskHub=default;Authentication=None",
+    "FOUNDRY_PROJECT_ENDPOINT": "https://your-foundry-resource.services.ai.azure.com/api/projects/your-project",
+    "FOUNDRY_MODEL": "your-deployment-name"
+  }
+}

--- a/dotnet/samples/DurableAgents/AzureFunctions/08_ReliableStreaming/local.settings.json.template
+++ b/dotnet/samples/DurableAgents/AzureFunctions/08_ReliableStreaming/local.settings.json.template
@@ -1,0 +1,12 @@
+{
+  "IsEncrypted": false,
+  "Values": {
+    "FUNCTIONS_WORKER_RUNTIME": "dotnet-isolated",
+    "AzureWebJobsStorage": "UseDevelopmentStorage=true",
+    "DURABLE_TASK_SCHEDULER_CONNECTION_STRING": "Endpoint=http://localhost:8080;TaskHub=default;Authentication=None",
+    "FOUNDRY_PROJECT_ENDPOINT": "https://your-foundry-resource.services.ai.azure.com/api/projects/your-project",
+    "FOUNDRY_MODEL": "your-deployment-name",
+    "REDIS_CONNECTION_STRING": "localhost:6379",
+    "REDIS_STREAM_TTL_MINUTES": "10"
+  }
+}

--- a/dotnet/samples/DurableAgents/AzureFunctions/README.md
+++ b/dotnet/samples/DurableAgents/AzureFunctions/README.md
@@ -85,7 +85,11 @@ azurite
 
 ### Environment Configuration
 
-Each sample has its own `local.settings.json` file that contains the environment variables for the sample. You'll need to update the `local.settings.json` file with the correct values for your Foundry project.
+Each sample includes a `local.settings.json.template` containing the settings it requires. Copy it to `local.settings.json`, then update the Foundry settings:
+
+```bash
+cp local.settings.json.template local.settings.json
+```
 
 ```json
 {

--- a/dotnet/samples/DurableWorkflows/AzureFunctions/01_SequentialWorkflow/local.settings.json.template
+++ b/dotnet/samples/DurableWorkflows/AzureFunctions/01_SequentialWorkflow/local.settings.json.template
@@ -1,0 +1,8 @@
+{
+  "IsEncrypted": false,
+  "Values": {
+    "FUNCTIONS_WORKER_RUNTIME": "dotnet-isolated",
+    "AzureWebJobsStorage": "UseDevelopmentStorage=true",
+    "DURABLE_TASK_SCHEDULER_CONNECTION_STRING": "Endpoint=http://localhost:8080;TaskHub=default;Authentication=None"
+  }
+}

--- a/dotnet/samples/DurableWorkflows/AzureFunctions/02_ConcurrentWorkflow/local.settings.json.template
+++ b/dotnet/samples/DurableWorkflows/AzureFunctions/02_ConcurrentWorkflow/local.settings.json.template
@@ -1,0 +1,10 @@
+{
+  "IsEncrypted": false,
+  "Values": {
+    "FUNCTIONS_WORKER_RUNTIME": "dotnet-isolated",
+    "AzureWebJobsStorage": "UseDevelopmentStorage=true",
+    "DURABLE_TASK_SCHEDULER_CONNECTION_STRING": "Endpoint=http://localhost:8080;TaskHub=default;Authentication=None",
+    "FOUNDRY_PROJECT_ENDPOINT": "https://your-foundry-resource.services.ai.azure.com/api/projects/your-project",
+    "FOUNDRY_MODEL": "your-deployment-name"
+  }
+}

--- a/dotnet/samples/DurableWorkflows/AzureFunctions/03_WorkflowHITL/03_WorkflowHITL.csproj
+++ b/dotnet/samples/DurableWorkflows/AzureFunctions/03_WorkflowHITL/03_WorkflowHITL.csproj
@@ -14,10 +14,6 @@
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 
-  <ItemGroup>
-    <None Include="local.settings.json" />
-  </ItemGroup>
-
   <!-- Azure Functions packages -->
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Functions.Worker" />

--- a/dotnet/samples/DurableWorkflows/AzureFunctions/03_WorkflowHITL/local.settings.json.template
+++ b/dotnet/samples/DurableWorkflows/AzureFunctions/03_WorkflowHITL/local.settings.json.template
@@ -1,0 +1,8 @@
+{
+  "IsEncrypted": false,
+  "Values": {
+    "FUNCTIONS_WORKER_RUNTIME": "dotnet-isolated",
+    "AzureWebJobsStorage": "UseDevelopmentStorage=true",
+    "DURABLE_TASK_SCHEDULER_CONNECTION_STRING": "Endpoint=http://localhost:8080;TaskHub=default;Authentication=None"
+  }
+}

--- a/dotnet/samples/DurableWorkflows/AzureFunctions/04_WorkflowMcpTool/local.settings.json.template
+++ b/dotnet/samples/DurableWorkflows/AzureFunctions/04_WorkflowMcpTool/local.settings.json.template
@@ -1,0 +1,8 @@
+{
+  "IsEncrypted": false,
+  "Values": {
+    "FUNCTIONS_WORKER_RUNTIME": "dotnet-isolated",
+    "AzureWebJobsStorage": "UseDevelopmentStorage=true",
+    "DURABLE_TASK_SCHEDULER_CONNECTION_STRING": "Endpoint=http://localhost:8080;TaskHub=default;Authentication=None"
+  }
+}

--- a/dotnet/samples/DurableWorkflows/AzureFunctions/05_WorkflowAndAgents/README.md
+++ b/dotnet/samples/DurableWorkflows/AzureFunctions/05_WorkflowAndAgents/README.md
@@ -54,7 +54,7 @@ See the [README.md](../../README.md) file in the parent directory for complete s
 - Durable Task Scheduler setup
 - Storage emulator configuration
 
-This sample also requires Foundry project configuration. Set the following in `local.settings.json`:
+This sample also requires Foundry project configuration. Copy `local.settings.json.template` to `local.settings.json`, then set the following values:
 
 - `FOUNDRY_PROJECT_ENDPOINT`: Your Foundry project endpoint URL
 - `FOUNDRY_MODEL`: Your Foundry model deployment name

--- a/dotnet/samples/DurableWorkflows/AzureFunctions/05_WorkflowAndAgents/local.settings.json.template
+++ b/dotnet/samples/DurableWorkflows/AzureFunctions/05_WorkflowAndAgents/local.settings.json.template
@@ -1,0 +1,10 @@
+{
+  "IsEncrypted": false,
+  "Values": {
+    "FUNCTIONS_WORKER_RUNTIME": "dotnet-isolated",
+    "AzureWebJobsStorage": "UseDevelopmentStorage=true",
+    "DURABLE_TASK_SCHEDULER_CONNECTION_STRING": "Endpoint=http://localhost:8080;TaskHub=default;Authentication=None",
+    "FOUNDRY_PROJECT_ENDPOINT": "https://your-foundry-resource.services.ai.azure.com/api/projects/your-project",
+    "FOUNDRY_MODEL": "your-deployment-name"
+  }
+}

--- a/dotnet/tests/Microsoft.Agents.AI.Hosting.AzureFunctions.IntegrationTests/SampleSettingsTemplateValidation.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Hosting.AzureFunctions.IntegrationTests/SampleSettingsTemplateValidation.cs
@@ -41,9 +41,6 @@ public sealed partial class SampleSettingsTemplateValidation
             .. Directory.GetDirectories(Path.Combine(s_samplesPath, "DurableAgents", "AzureFunctions")),
             .. Directory.GetDirectories(Path.Combine(s_samplesPath, "DurableWorkflows", "AzureFunctions")),
         ];
-
-        Assert.Equal(13, sampleDirectories.Length);
-
         foreach (string sampleDirectory in sampleDirectories)
         {
             string templatePath = Path.Combine(sampleDirectory, TemplateFileName);

--- a/dotnet/tests/Microsoft.Agents.AI.Hosting.AzureFunctions.IntegrationTests/SampleSettingsTemplateValidation.cs
+++ b/dotnet/tests/Microsoft.Agents.AI.Hosting.AzureFunctions.IntegrationTests/SampleSettingsTemplateValidation.cs
@@ -1,0 +1,143 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using System.Xml.Linq;
+
+namespace Microsoft.Agents.AI.Hosting.AzureFunctions.IntegrationTests;
+
+public sealed partial class SampleSettingsTemplateValidation
+{
+    private const string TemplateFileName = "local.settings.json.template";
+
+    // Path.GetFullPath does not collapse ".." segments when the base path carries the Windows
+    // "\\?\" extended-length prefix (e.g. deeply nested worktrees), so walk up via DirectoryInfo.Parent
+    // instead, which operates on the already-resolved path components.
+    private static readonly string s_samplesPath = FindSamplesPath();
+
+    private static string FindSamplesPath()
+    {
+        for (DirectoryInfo? directory = new(AppContext.BaseDirectory); directory is not null; directory = directory.Parent)
+        {
+            string candidate = Path.Combine(directory.FullName, "samples");
+            if (Directory.Exists(Path.Combine(candidate, "DurableAgents", "AzureFunctions")) &&
+                Directory.Exists(Path.Combine(candidate, "DurableWorkflows", "AzureFunctions")))
+            {
+                return candidate;
+            }
+        }
+
+        throw new DirectoryNotFoundException(
+            $"Could not locate the 'dotnet/samples' directory by walking up from '{AppContext.BaseDirectory}'.");
+    }
+
+    [Fact]
+    public void TemplatesMatchSampleRequirements()
+    {
+        AssertLocalSettingsBuildDefaults();
+
+        string[] sampleDirectories =
+        [
+            .. Directory.GetDirectories(Path.Combine(s_samplesPath, "DurableAgents", "AzureFunctions")),
+            .. Directory.GetDirectories(Path.Combine(s_samplesPath, "DurableWorkflows", "AzureFunctions")),
+        ];
+
+        Assert.Equal(13, sampleDirectories.Length);
+
+        foreach (string sampleDirectory in sampleDirectories)
+        {
+            string templatePath = Path.Combine(sampleDirectory, TemplateFileName);
+            Assert.True(File.Exists(templatePath), $"Missing {TemplateFileName} in {sampleDirectory}.");
+            AssertAzureFunctionsProject(sampleDirectory);
+
+            using JsonDocument template = JsonDocument.Parse(File.ReadAllText(templatePath));
+            JsonElement root = template.RootElement;
+            Assert.False(root.GetProperty("IsEncrypted").GetBoolean());
+
+            JsonElement values = root.GetProperty("Values");
+            Assert.Equal(JsonValueKind.Object, values.ValueKind);
+
+            HashSet<string> actualKeys = values.EnumerateObject()
+                .Select(property => property.Name)
+                .ToHashSet(StringComparer.Ordinal);
+
+            HashSet<string> expectedKeys =
+            [
+                "FUNCTIONS_WORKER_RUNTIME",
+                "AzureWebJobsStorage",
+                .. GetEnvironmentVariableNames(sampleDirectory),
+                .. GetHostConnectionSettingNames(sampleDirectory),
+            ];
+
+            Assert.True(
+                actualKeys.SetEquals(expectedKeys),
+                $"{templatePath} settings mismatch. Expected: {string.Join(", ", expectedKeys.Order())}. " +
+                $"Actual: {string.Join(", ", actualKeys.Order())}.");
+            Assert.DoesNotContain("TASKHUB_NAME", actualKeys);
+            Assert.All(values.EnumerateObject(), property => Assert.False(string.IsNullOrWhiteSpace(property.Value.GetString())));
+            Assert.Equal("dotnet-isolated", values.GetProperty("FUNCTIONS_WORKER_RUNTIME").GetString());
+            Assert.Equal("UseDevelopmentStorage=true", values.GetProperty("AzureWebJobsStorage").GetString());
+
+            if (values.TryGetProperty("FOUNDRY_PROJECT_ENDPOINT", out JsonElement endpoint))
+            {
+                Assert.True(
+                    Uri.TryCreate(endpoint.GetString(), UriKind.Absolute, out _),
+                    $"{templatePath} must provide a syntactically valid placeholder endpoint.");
+            }
+        }
+    }
+
+    private static void AssertLocalSettingsBuildDefaults()
+    {
+        XDocument buildTargets = XDocument.Load(Path.Combine(s_samplesPath, "Directory.Build.props"));
+        XElement localSettingsItem = Assert.Single(
+            buildTargets.Descendants("None"),
+            item => string.Equals((string?)item.Attribute("Update"), "local.settings.json", StringComparison.Ordinal));
+
+        Assert.Equal("PreserveNewest", localSettingsItem.Element("CopyToOutputDirectory")?.Value);
+        Assert.Equal("Never", localSettingsItem.Element("CopyToPublishDirectory")?.Value);
+    }
+
+    private static void AssertAzureFunctionsProject(string sampleDirectory)
+    {
+        string projectPath = Assert.Single(Directory.GetFiles(sampleDirectory, "*.csproj"));
+        XDocument project = XDocument.Load(projectPath);
+        Assert.Contains(project.Descendants("AzureFunctionsVersion"), property => property.Value == "v4");
+    }
+
+    private static IEnumerable<string> GetEnvironmentVariableNames(string sampleDirectory)
+    {
+        IEnumerable<string> sourcePaths = Directory
+            .EnumerateFiles(sampleDirectory, "*.cs", SearchOption.AllDirectories)
+            .Where(path => !Path.GetRelativePath(sampleDirectory, path)
+                .Split(Path.DirectorySeparatorChar)
+                .Any(segment => segment is "bin" or "obj"));
+
+        foreach (string sourcePath in sourcePaths)
+        {
+            string source = File.ReadAllText(sourcePath);
+            foreach (Match match in EnvironmentVariablePattern().Matches(source))
+            {
+                yield return match.Groups["name"].Value;
+            }
+        }
+    }
+
+    private static IEnumerable<string> GetHostConnectionSettingNames(string sampleDirectory)
+    {
+        string hostPath = Path.Combine(sampleDirectory, "host.json");
+        using JsonDocument host = JsonDocument.Parse(File.ReadAllText(hostPath));
+
+        JsonElement durableTask = host.RootElement
+            .GetProperty("extensions")
+            .GetProperty("durableTask");
+
+        yield return durableTask
+            .GetProperty("storageProvider")
+            .GetProperty("connectionStringName")
+            .GetString()!;
+    }
+
+    [GeneratedRegex("""Environment\.GetEnvironmentVariable\("(?<name>[A-Za-z0-9_]+)"\)""")]
+    private static partial Regex EnvironmentVariablePattern();
+}


### PR DESCRIPTION
## Summary

- add safe `local.settings.json.template` files to all 13 .NET Azure Functions samples, containing only the settings each sample requires
- ignore local settings once under `dotnet/samples` and configure sample builds to copy them to build output but never publish output
- update sample documentation to instruct users to copy the template and remove the stale project reference to a missing settings file
- add regression coverage that validates template JSON, required keys, placeholder values, and shared MSBuild metadata

Closes #85

## Testing

- `dotnet test tests\Microsoft.Agents.AI.Hosting.AzureFunctions.IntegrationTests\Microsoft.Agents.AI.Hosting.AzureFunctions.IntegrationTests.csproj --no-restore --filter-class Microsoft.Agents.AI.Hosting.AzureFunctions.IntegrationTests.SampleSettingsTemplateValidation --verbosity minimal` — 1 passed
- `dotnet build samples\DurableAgents\AzureFunctions\01_SingleAgent\01_SingleAgent.csproj --no-restore --verbosity minimal` — 0 warnings, 0 errors
- `dotnet build samples\DurableWorkflows\AzureFunctions\01_SequentialWorkflow\01_SequentialWorkflow.csproj --no-restore --verbosity minimal` — 0 warnings, 0 errors
- verified `local.settings.json` is copied to build output and excluded from publish output
- verified `func start --no-build` reaches a listening state for one Foundry sample and one pure-workflow sample using local Azurite and DTS emulators
